### PR TITLE
CsvTokenizer

### DIFF
--- a/quickload-standards/src/main/java/org/quickload/standards/CsvParserPlugin.java
+++ b/quickload-standards/src/main/java/org/quickload/standards/CsvParserPlugin.java
@@ -27,7 +27,8 @@ import org.quickload.time.TimestampParserTask;
 import java.util.Map;
 
 public class CsvParserPlugin
-        extends BasicParserPlugin {
+        extends BasicParserPlugin
+{
     @Override
     public TaskSource getBasicParserTask(ExecTask exec, ConfigSource config)
     {
@@ -64,9 +65,9 @@ public class CsvParserPlugin
         try (PageBuilder builder = new PageBuilder(pageAllocator, schema, pageOutput)) {
             while (fileBufferInput.nextFile()) {
                 boolean skipHeaderLine = task.getHeaderLine();
-                while (tokenizer.hasNextRecord()) {
+                while (tokenizer.nextRecord()) {
                     if (skipHeaderLine) {
-                        tokenizer.skipLine();
+                        tokenizer.skipCurrentLine();
                         skipHeaderLine = false;
                         continue;
                     }
@@ -133,11 +134,8 @@ public class CsvParserPlugin
                                 }
                             }
                         });
-
-                        tokenizer.nextRecord();
                     } catch (Exception e) {
-                        exec.notice().skippedLine(tokenizer.getCurrentUntokenizedLine());
-                        tokenizer.skipLine();
+                        exec.notice().skippedLine(tokenizer.skipCurrentLine());
                     }
                 }
             }
@@ -151,7 +149,7 @@ public class CsvParserPlugin
             return v;
         }
 
-        if (tokenizer.isQuotedColumn()) {
+        if (tokenizer.wasQuotedColumn()) {
             return "";
         }
 


### PR DESCRIPTION
- Implemented recovery from multiline quoted broken values
- Separated DEFAULT_PARSED state to BEGIN and VALUE to remove extra parseStarted flag handling
- Renamed LAST_TRIMMED to LAST_TRIM_OR_VALUE to make the meaning clear
- Separated isEscape handling in QUOTED from isQuote handling to not wrongly assume escape is a end of quoted value
- Moved linePos management from nextColumn to nextChar method to remove extra columnStartPos and columnEndPos menber fields
- Initialize StringBuffer (renamed to quotedValue) only with QUOTED state to remove unnecessary copy overhead
- Moved empty line handling to nextLine method to simplify the state machine
- nextRecord method returns boolean and removed hasNextRecord method to remove extra null check of line field
- skipCurrentLine method returns skipped line to remove lineBuffer member field
