### PR TITLE
Fix 'rake aborted' when removing embulk-x.x.x.jar

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ exit 127
 EOF
   data = header.force_encoding('ASCII-8BIT') + executable_data
   path = "embulk-#{Embulk::VERSION}.jar"
-  rm path
+  rm_f path
   File.open(path, 'wb', 0755) {|f| f.write data }
   puts "Created #{path}"
 end


### PR DESCRIPTION
I executed "rake" command but ran into "rake aborted" because the rake task uses "rm" command even if "embulk.x.x.x.jar" file doesn't exist.

```
embulk 0.1.0 built to pkg/embulk-0.1.0.gem.
rm embulk-0.1.0.jar
rake aborted!
Errno::ENOENT: No such file or directory - embulk-0.1.0.jar
```
