### PR TITLE
Introduce Gradle Versions Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.7'
     }
 }
 
@@ -21,6 +22,10 @@ allprojects {
     apply plugin: 'idea'
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
+
+    // determine which dependencies have updates
+    // $ gradle dependencyUpdates
+    apply plugin: 'com.github.ben-manes.versions'
 
     group = 'org.embulk'
     version = '0.2.0'


### PR DESCRIPTION
Since I found aws-java-sdk and other libs are old version, I've checked dependency updates by using [gradle-versions-plugin](https://github.com/ben-manes/gradle-versions-plugIn).
gradle-versions-plugin is a useful Gradle plugin which provides a task to determine which dependencies have updates.

This pull request also contains several dependency upgrades. `gradle test` and `bundle exec rake` have been successfully completed. 
If you don't prefer upgrading them right now, please let me know. I'll revert dependencies upgrade.

### Before

```
$ gradle dependencyUpdates
:copy depend to /Users/k-sera/tmp/embulk/embulk/embulk-cli/build/libs/dependencies
:copy depend to /Users/k-sera/tmp/embulk/embulk/embulk-core/build/libs/dependencies
:copy depend to /Users/k-sera/tmp/embulk/embulk/embulk-standards/build/libs/dependencies
Publication mavenJava not found in project :.
:dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.github.ben-manes:gradle-versions-plugin:0.7
 - javax.inject:javax.inject:1
 - javax.validation:validation-api:1.1.0.Final
 - log4j:log4j:1.2.17
 - org.apache.bval:bval-jsr303:0.5
 - org.yaml:snakeyaml:1.14

The following dependencies have later milestone versions:
 - com.amazonaws:aws-java-sdk [1.5.2 -> 1.9.16]
 - com.fasterxml.jackson.core:jackson-annotations [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.core:jackson-core [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.core:jackson-databind [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.datatype:jackson-datatype-guava [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.datatype:jackson-datatype-joda [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.module:jackson-module-guice [2.4.3 -> 2.5.0]
 - com.google.guava:guava [17.0 -> 18.0]
 - com.google.inject:guice [3.0 -> 4.0-beta5]
 - com.google.inject.extensions:guice-multibindings [3.0 -> 4.0-beta5]
 - com.ibm.icu:icu4j [53.1 -> 54.1.1]
 - com.jfrog.bintray.gradle:gradle-bintray-plugin [1.0 -> 1.1]
 - commons-logging:commons-logging [1.2 -> 99.0-does-not-exist]
 - io.airlift:slice [0.7 -> 0.8]
 - io.netty:netty-buffer [4.0.24.Final -> 5.0.0.Alpha1]
 - joda-time:joda-time [2.3 -> 2.7]
 - junit:junit [4.10 -> 4.12]
 - org.jruby:jruby-complete [1.7.16.1 -> 9.0.0.0.pre1]
 - org.mockito:mockito-core [1.9.5 -> 2.0.3-beta]
 - org.slf4j:slf4j-api [1.7.9 -> 1.7.10]
 - org.slf4j:slf4j-log4j12 [1.7.9 -> 1.7.10]

Generated report file build/dependencyUpdates/report.txt
:embulk-cli:dependencyUpdates

------------------------------------------------------------
:embulk-cli Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - javax.inject:javax.inject:1
 - javax.validation:validation-api:1.1.0.Final
 - log4j:log4j:1.2.17
 - org.apache.bval:bval-jsr303:0.5
 - org.yaml:snakeyaml:1.14

The following dependencies have later milestone versions:
 - com.fasterxml.jackson.core:jackson-annotations [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.core:jackson-core [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.core:jackson-databind [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.datatype:jackson-datatype-guava [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.datatype:jackson-datatype-joda [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.module:jackson-module-guice [2.4.3 -> 2.5.0]
 - com.google.guava:guava [17.0 -> 18.0]
 - com.google.inject:guice [3.0 -> 4.0-beta5]
 - com.google.inject.extensions:guice-multibindings [3.0 -> 4.0-beta5]
 - com.ibm.icu:icu4j [53.1 -> 54.1.1]
 - commons-logging:commons-logging [1.2 -> 99.0-does-not-exist]
 - io.airlift:slice [0.7 -> 0.8]
 - io.netty:netty-buffer [4.0.24.Final -> 5.0.0.Alpha1]
 - joda-time:joda-time [2.3 -> 2.7]
 - junit:junit [4.10 -> 4.12]
 - org.jruby:jruby-complete [1.7.16.1 -> 9.0.0.0.pre1]
 - org.mockito:mockito-core [1.9.5 -> 2.0.3-beta]
 - org.slf4j:slf4j-api [1.7.9 -> 1.7.10]
 - org.slf4j:slf4j-log4j12 [1.7.9 -> 1.7.10]

Generated report file build/dependencyUpdates/report.txt
:embulk-core:dependencyUpdates

------------------------------------------------------------
:embulk-core Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - javax.inject:javax.inject:1
 - javax.validation:validation-api:1.1.0.Final
 - log4j:log4j:1.2.17
 - org.apache.bval:bval-jsr303:0.5
 - org.yaml:snakeyaml:1.14

The following dependencies have later milestone versions:
 - com.fasterxml.jackson.core:jackson-annotations [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.core:jackson-core [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.core:jackson-databind [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.datatype:jackson-datatype-guava [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.datatype:jackson-datatype-joda [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.module:jackson-module-guice [2.4.3 -> 2.5.0]
 - com.google.guava:guava [17.0 -> 18.0]
 - com.google.inject:guice [3.0 -> 4.0-beta5]
 - com.google.inject.extensions:guice-multibindings [3.0 -> 4.0-beta5]
 - com.ibm.icu:icu4j [53.1 -> 54.1.1]
 - commons-logging:commons-logging [1.2 -> 99.0-does-not-exist]
 - io.airlift:slice [0.7 -> 0.8]
 - io.netty:netty-buffer [4.0.24.Final -> 5.0.0.Alpha1]
 - joda-time:joda-time [2.3 -> 2.7]
 - junit:junit [4.10 -> 4.12]
 - org.jruby:jruby-complete [1.7.16.1 -> 9.0.0.0.pre1]
 - org.mockito:mockito-core [1.9.5 -> 2.0.3-beta]
 - org.slf4j:slf4j-api [1.7.9 -> 1.7.10]
 - org.slf4j:slf4j-log4j12 [1.7.9 -> 1.7.10]

Generated report file build/dependencyUpdates/report.txt
:embulk-standards:dependencyUpdates

------------------------------------------------------------
:embulk-standards Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - javax.inject:javax.inject:1
 - javax.validation:validation-api:1.1.0.Final
 - log4j:log4j:1.2.17
 - org.apache.bval:bval-jsr303:0.5
 - org.yaml:snakeyaml:1.14

The following dependencies have later milestone versions:
 - com.amazonaws:aws-java-sdk [1.5.2 -> 1.9.16]
 - com.fasterxml.jackson.core:jackson-annotations [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.core:jackson-core [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.core:jackson-databind [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.datatype:jackson-datatype-guava [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.datatype:jackson-datatype-joda [2.4.3 -> 2.5.0]
 - com.fasterxml.jackson.module:jackson-module-guice [2.4.3 -> 2.5.0]
 - com.google.guava:guava [17.0 -> 18.0]
 - com.google.inject:guice [3.0 -> 4.0-beta5]
 - com.google.inject.extensions:guice-multibindings [3.0 -> 4.0-beta5]
 - com.ibm.icu:icu4j [53.1 -> 54.1.1]
 - commons-logging:commons-logging [1.2 -> 99.0-does-not-exist]
 - io.airlift:slice [0.7 -> 0.8]
 - io.netty:netty-buffer [4.0.24.Final -> 5.0.0.Alpha1]
 - joda-time:joda-time [2.3 -> 2.7]
 - junit:junit [4.10 -> 4.12]
 - org.jruby:jruby-complete [1.7.16.1 -> 9.0.0.0.pre1]
 - org.mockito:mockito-core [1.9.5 -> 2.0.3-beta]
 - org.slf4j:slf4j-api [1.7.9 -> 1.7.10]
 - org.slf4j:slf4j-log4j12 [1.7.9 -> 1.7.10]

Generated report file build/dependencyUpdates/report.txt

BUILD SUCCESSFUL

Total time: 17.778 secs
```

### After

```
$ gradle dependencyUpdates
Download https://jcenter.bintray.com/com/jfrog/bintray/gradle/gradle-bintray-plugin/1.1/gradle-bintray-plugin-1.1.jar
:copy depend to /Users/k-sera/tmp/embulk/embulk/embulk-cli/build/libs/dependencies
:copy depend to /Users/k-sera/tmp/embulk/embulk/embulk-core/build/libs/dependencies
:copy depend to /Users/k-sera/tmp/embulk/embulk/embulk-standards/build/libs/dependencies
Publication mavenJava not found in project :.
:dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.amazonaws:aws-java-sdk:1.9.16
 - com.fasterxml.jackson.core:jackson-annotations:2.5.0
 - com.fasterxml.jackson.core:jackson-core:2.5.0
 - com.fasterxml.jackson.core:jackson-databind:2.5.0
 - com.fasterxml.jackson.datatype:jackson-datatype-guava:2.5.0
 - com.fasterxml.jackson.datatype:jackson-datatype-joda:2.5.0
 - com.fasterxml.jackson.module:jackson-module-guice:2.5.0
 - com.github.ben-manes:gradle-versions-plugin:0.7
 - com.google.guava:guava:18.0
 - com.ibm.icu:icu4j:54.1.1
 - com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1
 - io.airlift:slice:0.8
 - javax.inject:javax.inject:1
 - javax.validation:validation-api:1.1.0.Final
 - joda-time:joda-time:2.7
 - junit:junit:4.12
 - log4j:log4j:1.2.17
 - org.apache.bval:bval-jsr303:0.5
 - org.slf4j:slf4j-api:1.7.10
 - org.slf4j:slf4j-log4j12:1.7.10
 - org.yaml:snakeyaml:1.14

The following dependencies have later milestone versions:
 - com.google.inject:guice [3.0 -> 4.0-beta5]
 - com.google.inject.extensions:guice-multibindings [3.0 -> 4.0-beta5]
 - commons-logging:commons-logging [1.2 -> 99.0-does-not-exist]
 - io.netty:netty-buffer [4.0.24.Final -> 5.0.0.Alpha1]
 - org.jruby:jruby-complete [1.7.18 -> 9.0.0.0.pre1]
 - org.mockito:mockito-core [1.10.19 -> 2.0.3-beta]

Generated report file build/dependencyUpdates/report.txt
:embulk-cli:dependencyUpdates

------------------------------------------------------------
:embulk-cli Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.fasterxml.jackson.core:jackson-annotations:2.5.0
 - com.fasterxml.jackson.core:jackson-core:2.5.0
 - com.fasterxml.jackson.core:jackson-databind:2.5.0
 - com.fasterxml.jackson.datatype:jackson-datatype-guava:2.5.0
 - com.fasterxml.jackson.datatype:jackson-datatype-joda:2.5.0
 - com.fasterxml.jackson.module:jackson-module-guice:2.5.0
 - com.google.guava:guava:18.0
 - com.ibm.icu:icu4j:54.1.1
 - io.airlift:slice:0.8
 - javax.inject:javax.inject:1
 - javax.validation:validation-api:1.1.0.Final
 - joda-time:joda-time:2.7
 - junit:junit:4.12
 - log4j:log4j:1.2.17
 - org.apache.bval:bval-jsr303:0.5
 - org.slf4j:slf4j-api:1.7.10
 - org.slf4j:slf4j-log4j12:1.7.10
 - org.yaml:snakeyaml:1.14

The following dependencies have later milestone versions:
 - com.google.inject:guice [3.0 -> 4.0-beta5]
 - com.google.inject.extensions:guice-multibindings [3.0 -> 4.0-beta5]
 - commons-logging:commons-logging [1.2 -> 99.0-does-not-exist]
 - io.netty:netty-buffer [4.0.24.Final -> 5.0.0.Alpha1]
 - org.jruby:jruby-complete [1.7.18 -> 9.0.0.0.pre1]
 - org.mockito:mockito-core [1.10.19 -> 2.0.3-beta]

Generated report file build/dependencyUpdates/report.txt
:embulk-core:dependencyUpdates

------------------------------------------------------------
:embulk-core Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.fasterxml.jackson.core:jackson-annotations:2.5.0
 - com.fasterxml.jackson.core:jackson-core:2.5.0
 - com.fasterxml.jackson.core:jackson-databind:2.5.0
 - com.fasterxml.jackson.datatype:jackson-datatype-guava:2.5.0
 - com.fasterxml.jackson.datatype:jackson-datatype-joda:2.5.0
 - com.fasterxml.jackson.module:jackson-module-guice:2.5.0
 - com.google.guava:guava:18.0
 - com.ibm.icu:icu4j:54.1.1
 - io.airlift:slice:0.8
 - javax.inject:javax.inject:1
 - javax.validation:validation-api:1.1.0.Final
 - joda-time:joda-time:2.7
 - junit:junit:4.12
 - log4j:log4j:1.2.17
 - org.apache.bval:bval-jsr303:0.5
 - org.slf4j:slf4j-api:1.7.10
 - org.slf4j:slf4j-log4j12:1.7.10
 - org.yaml:snakeyaml:1.14

The following dependencies have later milestone versions:
 - com.google.inject:guice [3.0 -> 4.0-beta5]
 - com.google.inject.extensions:guice-multibindings [3.0 -> 4.0-beta5]
 - commons-logging:commons-logging [1.2 -> 99.0-does-not-exist]
 - io.netty:netty-buffer [4.0.24.Final -> 5.0.0.Alpha1]
 - org.jruby:jruby-complete [1.7.18 -> 9.0.0.0.pre1]
 - org.mockito:mockito-core [1.10.19 -> 2.0.3-beta]

Generated report file build/dependencyUpdates/report.txt
:embulk-standards:dependencyUpdates

------------------------------------------------------------
:embulk-standards Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.amazonaws:aws-java-sdk:1.9.16
 - com.fasterxml.jackson.core:jackson-annotations:2.5.0
 - com.fasterxml.jackson.core:jackson-core:2.5.0
 - com.fasterxml.jackson.core:jackson-databind:2.5.0
 - com.fasterxml.jackson.datatype:jackson-datatype-guava:2.5.0
 - com.fasterxml.jackson.datatype:jackson-datatype-joda:2.5.0
 - com.fasterxml.jackson.module:jackson-module-guice:2.5.0
 - com.google.guava:guava:18.0
 - com.ibm.icu:icu4j:54.1.1
 - io.airlift:slice:0.8
 - javax.inject:javax.inject:1
 - javax.validation:validation-api:1.1.0.Final
 - joda-time:joda-time:2.7
 - junit:junit:4.12
 - log4j:log4j:1.2.17
 - org.apache.bval:bval-jsr303:0.5
 - org.slf4j:slf4j-api:1.7.10
 - org.slf4j:slf4j-log4j12:1.7.10
 - org.yaml:snakeyaml:1.14

The following dependencies have later milestone versions:
 - com.google.inject:guice [3.0 -> 4.0-beta5]
 - com.google.inject.extensions:guice-multibindings [3.0 -> 4.0-beta5]
 - commons-logging:commons-logging [1.2 -> 99.0-does-not-exist]
 - io.netty:netty-buffer [4.0.24.Final -> 5.0.0.Alpha1]
 - org.jruby:jruby-complete [1.7.18 -> 9.0.0.0.pre1]
 - org.mockito:mockito-core [1.10.19 -> 2.0.3-beta]

Generated report file build/dependencyUpdates/report.txt

BUILD SUCCESSFUL

Total time: 11.665 secs
```

