### PR TITLE
TimeStamp.fromString should be public

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/Timestamp.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/Timestamp.java
@@ -136,7 +136,7 @@ public class Timestamp
         }
     }
 
-    static Timestamp fromString(String text)
+    public static Timestamp fromString(String text)
     {
         // TODO exception handling
         Matcher m = FROM_STRING_PATTERN.matcher(text);


### PR DESCRIPTION
Plugin needs to access this method to create Timestamp from strings.