### PR TITLE
Add description field to @Config annotation

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/Config.java
+++ b/embulk-core/src/main/java/org/embulk/config/Config.java
@@ -12,4 +12,9 @@ import java.lang.annotation.Target;
 public @interface Config
 {
     String value();
+
+    /**
+     * Description of this configuration parameter
+     */
+    String description() default "";
 }

--- a/embulk-core/src/main/java/org/embulk/config/Config.java
+++ b/embulk-core/src/main/java/org/embulk/config/Config.java
@@ -16,5 +16,5 @@ public @interface Config
     /**
      * Description of this configuration parameter
      */
-    String description() default "";
+    String desc() default "";
 }


### PR DESCRIPTION
It would be good if we can add descriptions to `@Config` parameters: 
```
@Config("param", description="parameter description")
```
In future, we can automatically generate documentation of plugin configurations by extracting these annotations.