### PR TITLE
Adds the missing findbugs dependency to the build.gradle. Fixes the buil...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,8 @@ subprojects {
                 'io.airlift:slice:0.7',
                 'joda-time:joda-time:2.3',
                 'io.netty:netty-buffer:4.0.24.Final',
-                'com.ibm.icu:icu4j:53.1'
+                'com.ibm.icu:icu4j:53.1',
+                'com.google.code.findbugs:annotations:3.0.0'
 
         testCompile 'junit:junit:4.10',
                     'org.mockito:mockito-core:1.9.5'


### PR DESCRIPTION
Looks like findbugs dependency was missing in the build.gradle, thus the build by gradle failed.

**The build log without this change**
```
[~/Development/embulk]% ./gradlew build
:copy depend to /Users/thagikura/Development/embulk/embulk-cli/build/libs/dependencies
:copy depend to /Users/thagikura/Development/embulk/embulk-core/build/libs/dependencies
:copy depend to /Users/thagikura/Development/embulk/embulk-standards/build/libs/dependencies
Publication mavenJava not found in project :.
:embulk-core:compileJava
/Users/thagikura/Development/embulk/embulk-core/src/main/java/org/embulk/spi/Buffer.java:5: error: package edu.umd.cs.findbugs.annotations does not exist
import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
                                      ^
/Users/thagikura/Development/embulk/embulk-core/src/main/java/org/embulk/spi/type/AbstractType.java:3: error: package edu.umd.cs.findbugs.annotations does not exist
import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
                                      ^
/Users/thagikura/Development/embulk/embulk-core/src/main/java/org/embulk/spi/Buffer.java:53: error: cannot find symbol
    @SuppressFBWarnings(value = "EI_EXPOSE_REP")
     ^
  symbol:   class SuppressFBWarnings
  location: class Buffer
/Users/thagikura/Development/embulk/embulk-core/src/main/java/org/embulk/spi/type/AbstractType.java:37: error: cannot find symbol
    @SuppressFBWarnings(value = "EQ_UNUSUAL")
     ^
  symbol:   class SuppressFBWarnings
  location: class AbstractType
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
4 errors
:embulk-core:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':embulk-core:compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 15.009 secs
```

**The build log with this change**
```
[~/Development/embulk]% ./gradlew build
:copy depend to /Users/thagikura/Development/embulk/embulk-cli/build/libs/dependencies
:copy depend to /Users/thagikura/Development/embulk/embulk-core/build/libs/dependencies
:copy depend to /Users/thagikura/Development/embulk/embulk-standards/build/libs/dependencies
Publication mavenJava not found in project :.
:embulk-core:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
:embulk-core:processResources
:embulk-core:classes
:embulk-core:jar
:embulk-standards:compileJava
:embulk-standards:processResources
:embulk-standards:classes
:embulk-standards:jar
:embulk-cli:compileJava
:embulk-cli:processResources UP-TO-DATE
:embulk-cli:classes
:embulk-cli:jar
:embulk-core:javadoc
:embulk-standards:javadoc
:embulk-cli:javadoc
:embulk-cli:javadocJar
:embulk-cli:sourcesJar
:embulk-cli:assemble
:embulk-core:compileTestJava
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
:embulk-core:processTestResources UP-TO-DATE
:embulk-core:testClasses
:embulk-cli:compileTestJava UP-TO-DATE
:embulk-cli:processTestResources UP-TO-DATE
:embulk-cli:testClasses UP-TO-DATE
:embulk-cli:test UP-TO-DATE
:embulk-cli:check UP-TO-DATE
:embulk-cli:build
:embulk-core:javadocJar
:embulk-core:sourcesJar
:embulk-core:assemble
:embulk-core:test
:embulk-core:check
:embulk-core:build
:embulk-standards:javadocJar
:embulk-standards:sourcesJar
:embulk-standards:assemble
:embulk-standards:compileTestJava
:embulk-standards:processTestResources UP-TO-DATE
:embulk-standards:testClasses
:embulk-standards:test
:embulk-standards:check
:embulk-standards:build

BUILD SUCCESSFUL
```