### PR TITLE
Java plugin loader

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PluginClassLoader.java
@@ -48,7 +48,7 @@ public class PluginClassLoader
             }
 
             try {
-                return resolveClass(findClass(name), resolve);
+                return resolveClass(getParent().loadClass(name), resolve);
             } catch (ClassNotFoundException ignored) {
             }
 

--- a/embulk-core/src/main/java/org/embulk/spi/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PluginClassLoader.java
@@ -1,0 +1,80 @@
+package org.embulk.spi;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
+import com.google.common.collect.ImmutableList;
+import org.jruby.Ruby;
+
+public class PluginClassLoader
+        extends URLClassLoader
+{
+    private static final String[] PARENT_FIRST_PACKAGES = new String[] {
+        "org.embulk.",
+        "io.airlift.slice.",
+        "com.fasterxml.jackson.",
+        "com.google.inject.",
+        "org.jruby.",
+        "javax.inject.",
+        "java.",
+    };
+
+    public PluginClassLoader(Ruby pluginJRubyRuntime, List<URL> urls)
+    {
+        this(urls, pluginJRubyRuntime.getJRubyClassLoader());
+    }
+
+    public PluginClassLoader(List<URL> urls, ClassLoader parent)
+    {
+        super(urls.toArray(new URL[urls.size()]), parent);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve)
+            throws ClassNotFoundException
+    {
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> loadedClass = findLoadedClass(name);
+            if (loadedClass != null) {
+                return resolveClass(loadedClass, resolve);
+            }
+
+            boolean parentFirst = isInParentFirstPackage(name);
+            if (!parentFirst) {
+                try {
+                    return resolveClass(findClass(name), resolve);
+                } catch (ClassNotFoundException ignored) {
+                }
+            }
+
+            try {
+                return resolveClass(findClass(name), resolve);
+            } catch (ClassNotFoundException ignored) {
+            }
+
+            if (parentFirst) {
+                return resolveClass(findClass(name), resolve);
+            }
+
+            throw new ClassNotFoundException(name);
+        }
+    }
+
+    private Class<?> resolveClass(Class<?> clazz, boolean resolve)
+    {
+        if (resolve) {
+            resolveClass(clazz);
+        }
+        return clazz;
+    }
+
+    private boolean isInParentFirstPackage(String name)
+    {
+        for (String pkg : PARENT_FIRST_PACKAGES) {
+            if (name.startsWith(pkg)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/lib/embulk/buffer.rb
+++ b/lib/embulk/buffer.rb
@@ -2,14 +2,14 @@
 module Embulk
   class Buffer < String
     if Embulk.java?
-      def self.from_java_object(java_buffer)
+      def self.from_java(java_buffer)
         byte_list = org.jruby.util.ByteList.new(java_buffer.array(), java_buffer.offset(), java_buffer.limit(), false)
         buffer = new
         buffer.replace(org.jruby.RubyString.new(JRuby.runtime, self, byte_list).dup)  # TODO simplify
         buffer
       end
 
-      def java_object
+      def to_java
         Java::Buffer.wrap(to_java_bytes)
       end
     end

--- a/lib/embulk/column.rb
+++ b/lib/embulk/column.rb
@@ -6,26 +6,26 @@ module Embulk
     end
 
     if Embulk.java?
-      def self.from_java_object(java_column)
+      def self.from_java(java_column)
         Column.new(
           java_column.getIndex,
           java_column.getName,
-          Type.from_java_object(java_column.getType))
+          Type.from_java(java_column.getType))
       end
 
-      def java_object
-        Java::Column.new(index, name, Type.to_java_object(type))
+      def to_java
+        Java::Column.new(index, name, Type.new_java_type(type))
       end
     end
   end
 
   module Type
     if Embulk.java?
-      def self.from_java_object(java_type)
+      def self.from_java(java_type)
         java_type.getName.to_sym
       end
 
-      def self.to_java_object(ruby_type)
+      def self.new_java_type(ruby_type)
         case ruby_type
         when :boolean
           Java::Types::BOOLEAN

--- a/lib/embulk/data_source.rb
+++ b/lib/embulk/data_source.rb
@@ -39,7 +39,7 @@ module Embulk
     end
 
     if Embulk.java?
-      def self.from_java_object(java_data_source_impl)
+      def self.from_java(java_data_source_impl)
         json = java_data_source_impl.toString
         new.merge!(JSON.parse(json))
       end
@@ -48,7 +48,7 @@ module Embulk
         new.merge!(hash)
       end
 
-      def java_object
+      def to_java
         json = to_json
         Java::Injected::ModelManager.readObject(Java::DataSourceImpl.java_class, json.to_java)
       end

--- a/lib/embulk/decoder_plugin.rb
+++ b/lib/embulk/decoder_plugin.rb
@@ -1,0 +1,27 @@
+module Embulk
+
+  require 'embulk/data_source'
+
+  class DecoderPlugin
+    def self.transaction(config, &control)
+      raise NotImplementedError, "DecoderPlugin.transaction(config, &control) must be implemented"
+    end
+
+    # TODO
+
+    if Embulk.java?
+      # TODO new_java
+
+      def self.from_java(java_class)
+        JavaPlugin.ruby_adapter_class(java_class, DecoderPlugin, RubyAdapter)
+      end
+
+      module RubyAdapter
+        module ClassMethods
+        end
+        # TODO
+      end
+    end
+  end
+
+end

--- a/lib/embulk/encoder_plugin.rb
+++ b/lib/embulk/encoder_plugin.rb
@@ -1,0 +1,27 @@
+module Embulk
+
+  require 'embulk/data_source'
+
+  class EncoderPlugin
+    def self.transaction(config, &control)
+      raise NotImplementedError, "EncoderPlugin.transaction(config, &control) must be implemented"
+    end
+
+    # TODO
+
+    if Embulk.java?
+      # TODO new_java
+
+      def self.from_java(java_class)
+        JavaPlugin.ruby_adapter_class(java_class, EncoderPlugin, RubyAdapter)
+      end
+
+      module RubyAdapter
+        module ClassMethods
+        end
+        # TODO
+      end
+    end
+  end
+
+end

--- a/lib/embulk/file_input_plugin.rb
+++ b/lib/embulk/file_input_plugin.rb
@@ -1,0 +1,27 @@
+module Embulk
+
+  class FileInputPlugin
+    # TODO transaction, resume, cleanup
+    # TODO run
+
+    if Embulk.java?
+      # TODO to_java
+
+      def self.from_java(java_class)
+        JavaPlugin.ruby_adapter_class(java_class, FileInputPlugin, RubyAdapter)
+      end
+
+      module RubyAdapter
+        module ClassMethods
+          def new_java
+            Java::FileInputRunner.new(Java.injector.getInstance(java_class))
+          end
+          # TODO transaction, resume, cleanup
+        end
+
+        # TODO run
+      end
+    end
+  end
+
+end

--- a/lib/embulk/file_output_plugin.rb
+++ b/lib/embulk/file_output_plugin.rb
@@ -1,0 +1,27 @@
+module Embulk
+
+  class FileOutputPlugin
+    # TODO transaction, resume, cleanup
+    # TODO add, finish, close, abort, commit
+
+    if Embulk.java?
+      # TODO to_java
+
+      def self.from_java(java_class)
+        JavaPlugin.ruby_adapter_class(java_class, FileOutputPlugin, RubyAdapter)
+      end
+
+      module RubyAdapter
+        module ClassMethods
+          def new_java
+            Java::FileOutputRunner.new(Java.injector.getInstance(java_class))
+          end
+          # TODO transaction, resume, cleanup
+        end
+
+        # TODO add, finish, close, abort, commit
+      end
+    end
+  end
+
+end

--- a/lib/embulk/filter_plugin.rb
+++ b/lib/embulk/filter_plugin.rb
@@ -1,5 +1,10 @@
 module Embulk
 
+  require 'embulk/data_source'
+  require 'embulk/schema'
+  require 'embulk/page'
+  require 'embulk/page_builder'
+
   class FilterPlugin
     def self.transaction(config, in_schema, &control)
       yield(config)
@@ -26,7 +31,7 @@ module Embulk
     end
 
     if Embulk.java?
-      def self.to_java
+      def self.new_java
         JavaAdapter.new(self)
       end
 
@@ -77,9 +82,19 @@ module Embulk
           def close
             @ruby_object.close
           ensure
-              @page_builder.close
+            @page_builder.close
           end
         end
+      end
+
+      def self.from_java(java_class)
+        JavaPlugin.ruby_adapter_class(java_class, FilterPlugin, RubyAdapter)
+      end
+
+      module RubyAdapter
+        module ClassMethods
+        end
+        # TODO
       end
     end
   end

--- a/lib/embulk/filter_plugin.rb
+++ b/lib/embulk/filter_plugin.rb
@@ -26,7 +26,7 @@ module Embulk
     end
 
     if Embulk.java?
-      def self.java_object
+      def self.to_java
         JavaAdapter.new(self)
       end
 
@@ -38,20 +38,20 @@ module Embulk
         end
 
         def transaction(java_config, java_in_schema, java_control)
-          config = DataSource.from_java_object(java_config)
-          in_schema = Schema.from_java_object(java_in_schema)
+          config = DataSource.from_java(java_config)
+          in_schema = Schema.from_java(java_in_schema)
           @ruby_class.transaction(config, in_schema) do |task_source_hash, out_columns|
-            java_task_source = DataSource.from_ruby_hash(task_source_hash).java_object
-            java_out_schemas = Schema.new(out_columns).java_object
+            java_task_source = DataSource.from_ruby_hash(task_source_hash).to_java
+            java_out_schemas = Schema.new(out_columns).to_java
             java_control.run(java_task_source, java_out_schemas)
           end
           nil
         end
 
         def open(java_task_source, java_in_schema, java_out_schema, java_output)
-          task_source = DataSource.from_java_object(java_task_source)
-          in_schema = Schema.from_java_object(java_in_schema)
-          out_schema = Schema.from_java_object(java_out_schema)
+          task_source = DataSource.from_java(java_task_source)
+          in_schema = Schema.from_java(java_in_schema)
+          out_schema = Schema.from_java(java_out_schema)
           page_builder = PageBuilder.new(out_schema, java_output)
           ruby_object = @ruby_class.new(task_source, in_schema, out_schema, page_builder)
           return OutputAdapter.new(ruby_object, in_schema, page_builder)

--- a/lib/embulk/formatter_plugin.rb
+++ b/lib/embulk/formatter_plugin.rb
@@ -1,0 +1,101 @@
+module Embulk
+
+  require 'embulk/data_source'
+  require 'embulk/schema'
+  require 'embulk/page'
+  #require 'embulk/file_output'  TODO not implemented
+
+  class FormatterPlugin
+    def self.transaction(config, schema, &control)
+      yield(config)
+      return {}
+    end
+
+    def initialize(task, schema, file_output)
+      @task = task
+      @schema = schema
+      @file_output
+    end
+
+    attr_reader :task, :schema, :file_output
+
+    def add(page)
+      raise NotImplementedError, "FormatterPlugin#add(page) must be implemented"
+    end
+
+    def finish
+    end
+
+    def close
+    end
+
+    if Embulk.java?
+      def self.new_java
+        JavaAdapter.new(self)
+      end
+
+      class JavaAdapter
+        include Java::FormatterPlugin
+
+        def initialize(ruby_class)
+          @ruby_class = ruby_class
+        end
+
+        def transaction(java_config, java_schema, java_control)
+          config = DataSource.from_java(java_config)
+          schema = Schema.from_java(java_schema)
+          @ruby_class.transaction(config, schema) do |task_source_hash|
+            java_task_source = DataSource.from_ruby_hash(task_source_hash).to_java
+            java_control.run(java_task_source)
+          end
+          nil
+        end
+
+        def open(java_task_source, java_schema, java_file_output)
+          task_source = DataSource.from_java(java_task_source)
+          schema = Schema.from_java(java_schema)
+          file_output = FileOutput.from_java(java_file_output)
+          ruby_object = @ruby_class.new(task_source, schema, file_output)
+          return OutputAdapter.new(ruby_object, schema, file_output)
+        end
+
+        class OutputAdapter
+          include Java::TransactionalPageOutput
+
+          def initialize(ruby_object, schema, file_output)
+            @ruby_object = ruby_object
+            @schema = schema
+            @file_output = file_output
+          end
+
+          def add(java_page)
+            # TODO reuse page reader
+            @ruby_object.add Page.new(java_page, @schema)
+          end
+
+          def finish
+            @ruby_object.finish
+          end
+
+          def close
+            @ruby_object.close
+          ensure
+            @file_output.close
+          end
+        end
+      end
+
+      def self.from_java(java_class)
+        JavaPlugin.ruby_adapter_class(java_class, FormatterPlugin, RubyAdapter)
+      end
+
+      module RubyAdapter
+        module ClassMethods
+          # TODO transaction, resume, cleanup
+        end
+        # TODO add, finish, close
+      end
+    end
+  end
+
+end

--- a/lib/embulk/guess_plugin.rb
+++ b/lib/embulk/guess_plugin.rb
@@ -6,11 +6,11 @@ module Embulk
     end
 
     if Embulk.java?
-      def self.java_object
+      def self.to_java
         JavaAdapter.new(new)
       end
 
-      def self.from_java_object(java_guess)
+      def self.from_java(java_guess)
         RubyAdapter.new(java_guess)
       end
 
@@ -20,13 +20,13 @@ module Embulk
         end
 
         def guess(config, sample)
-          java_config = config.java_object
-          java_sample = sample.java_object
+          java_config = config.to_java
+          java_sample = sample.to_java
           java_next_config = @java_guess.guess(java_config, java_sample)
-          return DataSource.from_java_object(java_next_config)
+          return DataSource.from_java(java_next_config)
         end
 
-        def java_object
+        def to_java
           @java_guess
         end
       end
@@ -39,10 +39,10 @@ module Embulk
         end
 
         def guess(java_config, java_sample)
-          config = DataSource.from_java_object(java_config)
-          sample = Buffer.from_java_object(java_sample)
+          config = DataSource.from_java(java_config)
+          sample = Buffer.from_java(java_sample)
           next_config_hash = @ruby_guess.guess(config, sample)
-          return DataSource.from_ruby_hash(next_config_hash).java_object
+          return DataSource.from_ruby_hash(next_config_hash).to_java
         end
       end
     end
@@ -60,7 +60,7 @@ module Embulk
         return DataSource.new
       end
 
-      decoder = Java::LineDecoder.new(Java::ListFileInput.new([[sample.java_object]]), task)
+      decoder = Java::LineDecoder.new(Java::ListFileInput.new([[sample.to_java]]), task)
       sample_text = ''
       while decoder.nextFile
         first = true
@@ -94,7 +94,7 @@ module Embulk
         return DataSource.new
       end
 
-      decoder = Java::LineDecoder.new(Java::ListFileInput.new([[sample.java_object]]), task)
+      decoder = Java::LineDecoder.new(Java::ListFileInput.new([[sample.to_java]]), task)
       sample_lines = []
       while decoder.nextFile
         while line = decoder.poll

--- a/lib/embulk/input_plugin.rb
+++ b/lib/embulk/input_plugin.rb
@@ -91,11 +91,7 @@ module Embulk
       end
 
       def self.from_java(java_class)
-        if java_class < org.embulk.spi.FileInputPlugin
-          FileInputPlugin.from_java(java_class)
-        else
-          JavaPlugin.ruby_adapter_class(java_class, InputPlugin, RubyAdapter)
-        end
+        JavaPlugin.ruby_adapter_class(java_class, InputPlugin, RubyAdapter)
       end
 
       module RubyAdapter

--- a/lib/embulk/input_plugin.rb
+++ b/lib/embulk/input_plugin.rb
@@ -29,7 +29,7 @@ module Embulk
     end
 
     if Embulk.java?
-      def self.to_java
+      def self.new_java
         JavaAdapter.new(self)
       end
 
@@ -88,6 +88,20 @@ module Embulk
             page_builder.close
           end
         end
+      end
+
+      def self.from_java(java_class)
+        if java_class < org.embulk.spi.FileInputPlugin
+          FileInputPlugin.from_java(java_class)
+        else
+          JavaPlugin.ruby_adapter_class(java_class, InputPlugin, RubyAdapter)
+        end
+      end
+
+      module RubyAdapter
+        module ClassMethods
+        end
+        # TODO
       end
     end
   end

--- a/lib/embulk/input_plugin.rb
+++ b/lib/embulk/input_plugin.rb
@@ -29,7 +29,7 @@ module Embulk
     end
 
     if Embulk.java?
-      def self.java_object
+      def self.to_java
         JavaAdapter.new(self)
       end
 
@@ -41,49 +41,49 @@ module Embulk
         end
 
         def transaction(java_config, java_control)
-          config = DataSource.from_java_object(java_config)
+          config = DataSource.from_java(java_config)
           next_config_hash = @ruby_class.transaction(config) do |task_source_hash,columns,processor_count|
-            java_task_source = DataSource.from_ruby_hash(task_source_hash).java_object
-            java_schema = Schema.new(columns).java_object
+            java_task_source = DataSource.from_ruby_hash(task_source_hash).to_java
+            java_schema = Schema.new(columns).to_java
             java_commit_reports = java_control.run(java_task_source, java_schema, processor_count)
             java_commit_reports.map {|java_commit_report|
-              DataSource.from_java_object(java_commit_report)
+              DataSource.from_java(java_commit_report)
             }
           end
           # TODO check return type of #transaction
-          return DataSource.from_ruby_hash(next_config_hash).java_object
+          return DataSource.from_ruby_hash(next_config_hash).to_java
         end
 
         def resume(java_task_source, java_schema, processor_count, java_control)
-          task_source = DataSource.from_java_object(java_task_source)
-          schema = Schema.from_java_object(java_schema)
+          task_source = DataSource.from_java(java_task_source)
+          schema = Schema.from_java(java_schema)
           next_config_hash = @ruby_class.resume(task_source, schema, processor_count) do |task_source_hash,columns,processor_count|
-            java_task_source = DataSource.from_ruby_hash(task_source_hash).java_object
-            java_schema = Schema.new(columns).java_object
+            java_task_source = DataSource.from_ruby_hash(task_source_hash).to_java
+            java_schema = Schema.new(columns).to_java
             java_commit_reports = java_control.run(java_task_source, java_schema, processor_count)
             java_commit_reports.map {|java_commit_report|
-              DataSource.from_java_object(java_commit_report)
+              DataSource.from_java(java_commit_report)
             }
           end
           # TODO check return type of #resume
-          return DataSource.from_ruby_hash(next_config_hash).java_object
+          return DataSource.from_ruby_hash(next_config_hash).to_java
         end
 
         def cleanup(java_task_source, java_schema, processor_count, java_commit_reports)
-          task_source = DataSource.from_java_object(java_task_source)
-          schema = Schema.from_java_object(java_schema)
-          commit_reports = java_commit_reports.map {|c| DataSource.from_java_object(c) }
+          task_source = DataSource.from_java(java_task_source)
+          schema = Schema.from_java(java_schema)
+          commit_reports = java_commit_reports.map {|c| DataSource.from_java(c) }
           @ruby_class.cleanup(task_source, schema, processor_count, commit_reports)
           return nil
         end
 
         def run(java_task_source, java_schema, processor_index, java_output)
-          task_source = DataSource.from_java_object(java_task_source)
-          schema = Schema.from_java_object(java_schema)
+          task_source = DataSource.from_java(java_task_source)
+          schema = Schema.from_java(java_schema)
           page_builder = PageBuilder.new(schema, java_output)
           begin
             commit_report_hash = @ruby_class.new(task_source, schema, processor_index, page_builder).run
-            return DataSource.from_ruby_hash(commit_report_hash).java_object
+            return DataSource.from_ruby_hash(commit_report_hash).to_java
           ensure
             page_builder.close
           end

--- a/lib/embulk/java/bootstrap.rb
+++ b/lib/embulk/java/bootstrap.rb
@@ -8,5 +8,10 @@ module Embulk
       #   ModelManager
       #   BufferAllocator
     end
+
+    def self.injector
+      # TODO use org.embulk.spi.Exec.getInjector
+      Injector
+    end
   end
 end

--- a/lib/embulk/java/imports.rb
+++ b/lib/embulk/java/imports.rb
@@ -22,6 +22,7 @@ module Embulk::Java
   java_import 'org.embulk.spi.Column'
   java_import 'org.embulk.spi.type.Type'
   java_import 'org.embulk.spi.type.Types'
+  java_import 'org.embulk.spi.PluginClassLoader'
 
   # TODO
 end

--- a/lib/embulk/java/imports.rb
+++ b/lib/embulk/java/imports.rb
@@ -13,6 +13,10 @@ module Embulk::Java
   java_import 'org.embulk.spi.OutputPlugin'
   java_import 'org.embulk.spi.FilterPlugin'
   java_import 'org.embulk.spi.InputPlugin'
+  java_import 'org.embulk.spi.ParserPlugin'
+  java_import 'org.embulk.spi.FormatterPlugin'
+  java_import 'org.embulk.spi.EncoderPlugin'
+  java_import 'org.embulk.spi.DecoderPlugin'
   java_import 'org.embulk.spi.TransactionalPageOutput'
   java_import 'org.embulk.spi.PageReader'
   java_import 'org.embulk.spi.PageBuilder'
@@ -23,6 +27,8 @@ module Embulk::Java
   java_import 'org.embulk.spi.type.Type'
   java_import 'org.embulk.spi.type.Types'
   java_import 'org.embulk.spi.PluginClassLoader'
+  java_import 'org.embulk.spi.FileInputRunner'
+  java_import 'org.embulk.spi.FileOutputRunner'
 
   # TODO
 end

--- a/lib/embulk/java_plugin.rb
+++ b/lib/embulk/java_plugin.rb
@@ -1,0 +1,36 @@
+module Embulk
+
+  require 'embulk/plugin'
+
+  class JavaPlugin
+    def self.classloader(dir)
+      jars = Dir["#{dir}/**/*.jar"]
+      urls = jars.map {|jar| "file://#{File.expand_path(jar)}" }
+      classloader = Java::PluginClassLoader.new(JRuby.runtime, urls)
+    end
+
+    def self.register_guess(name, jar_dir, class_fqdn)
+      java_class = classloader(jar_dir).findClass(class_fqdn)
+      Plugin.register_java_guess(name, java_class)
+    end
+
+    def self.ruby_adapter_class(java_class_, ruby_base_class, ruby_module)
+      Class.new(ruby_base_class) do
+        define_singleton_method(:java_class) do
+          java_class_
+        end
+
+        define_singleton_method(:new_java) do
+          Java.injector.getInstance(java_class_)
+        end
+
+        define_method(:java_object) do
+          @java_object ||= self.class.new_java
+        end
+
+        include ruby_module
+        extend ruby_module::ClassMethods
+      end
+    end
+  end
+end

--- a/lib/embulk/java_plugin.rb
+++ b/lib/embulk/java_plugin.rb
@@ -5,31 +5,74 @@ module Embulk
   class JavaPlugin
     def self.classloader(dir)
       jars = Dir["#{dir}/**/*.jar"]
-      urls = jars.map {|jar| "file://#{File.expand_path(jar)}" }
+      urls = jars.map {|jar| java.net.URL.new "file://#{File.expand_path(jar)}" }
       classloader = Java::PluginClassLoader.new(JRuby.runtime, urls)
     end
 
-    def self.register_guess(name, jar_dir, class_fqdn)
-      java_class = classloader(jar_dir).findClass(class_fqdn)
+    def self.register_input(name, class_fqdn, jar_dir)
+      java_class = classloader(jar_dir).loadClass(class_fqdn)  # TODO handle class not found error
+      Plugin.register_java_input(name, java_class)
+    end
+
+    def self.register_output(name, class_fqdn, jar_dir)
+      java_class = classloader(jar_dir).loadClass(class_fqdn)
+      Plugin.register_java_output(name, java_class)
+    end
+
+    def self.register_filter(name, class_fqdn, jar_dir)
+      java_class = classloader(jar_dir).loadClass(class_fqdn)
+      Plugin.register_java_filter(name, java_class)
+    end
+
+    def self.register_parser(name, class_fqdn, jar_dir)
+      java_class = classloader(jar_dir).loadClass(class_fqdn)
+      Plugin.register_java_parser(name, java_class)
+    end
+
+    def self.register_formatter(name, class_fqdn, jar_dir)
+      java_class = classloader(jar_dir).loadClass(class_fqdn)
+      Plugin.register_java_formatter(name, java_class)
+    end
+
+    def self.register_decoder(name, class_fqdn, jar_dir)
+      java_class = classloader(jar_dir).loadClass(class_fqdn)
+      Plugin.register_java_decoder(name, java_class)
+    end
+
+    def self.register_encoder(name, class_fqdn, jar_dir)
+      java_class = classloader(jar_dir).loadClass(class_fqdn)
+      Plugin.register_java_encoder(name, java_class)
+    end
+
+    def self.register_guess(name, class_fqdn, jar_dir)
+      java_class = classloader(jar_dir).loadClass(class_fqdn)
       Plugin.register_java_guess(name, java_class)
     end
 
-    def self.ruby_adapter_class(java_class_, ruby_base_class, ruby_module)
+    def self.ruby_adapter_class(java_class, ruby_base_class, ruby_module)
       Class.new(ruby_base_class) do
-        define_singleton_method(:java_class) do
-          java_class_
-        end
-
-        define_singleton_method(:new_java) do
-          Java.injector.getInstance(java_class_)
-        end
-
-        define_method(:java_object) do
-          @java_object ||= self.class.new_java
-        end
+        const_set(:JAVA_CLASS, java_class)
 
         include ruby_module
         extend ruby_module::ClassMethods
+
+        unless method_defined?(:java_object)
+          def java_object
+            @java_object ||= self.class.new_java
+          end
+        end
+
+        unless (class<<self;self;end).method_defined?(:java_class)
+          def self.java_class
+            self::JAVA_CLASS
+          end
+        end
+
+        unless (class<<self;self;end).method_defined?(:new_java)
+          def self.new_java
+            Java.injector.getInstance(java_class)
+          end
+        end
       end
     end
   end

--- a/lib/embulk/output_plugin.rb
+++ b/lib/embulk/output_plugin.rb
@@ -44,7 +44,7 @@ module Embulk
     end
 
     if Embulk.java?
-      def self.to_java
+      def self.new_java
         JavaAdapter.new(self)
       end
 
@@ -107,6 +107,7 @@ module Embulk
           end
 
           def add(java_page)
+            # TODO reuse page reader
             @ruby_object.add Page.new(java_page, @schema)
           end
 
@@ -127,6 +128,21 @@ module Embulk
             return DataSource.from_ruby_hash(commit_report_hash).to_java
           end
         end
+      end
+
+      def self.from_java(java_class)
+        if java_class < org.embulk.spi.FileInputPlugin
+          FileOutputPlugin.from_java(java_class)
+        else
+          JavaPlugin.ruby_adapter_class(java_class, OutputPlugin, RubyAdapter)
+        end
+      end
+
+      module RubyAdapter
+        module ClassMethods
+          # TODO transaction, resume, cleanup
+        end
+        # TODO add, finish, close, abort, commit
       end
     end
   end

--- a/lib/embulk/output_plugin.rb
+++ b/lib/embulk/output_plugin.rb
@@ -44,7 +44,7 @@ module Embulk
     end
 
     if Embulk.java?
-      def self.java_object
+      def self.to_java
         JavaAdapter.new(self)
       end
 
@@ -56,44 +56,44 @@ module Embulk
         end
 
         def transaction(java_config, java_schema, processor_count, java_control)
-          config = DataSource.from_java_object(java_config)
-          schema = Schema.from_java_object(java_schema)
+          config = DataSource.from_java(java_config)
+          schema = Schema.from_java(java_schema)
           next_config_hash = @ruby_class.transaction(config, schema, processor_count) do |task_source_hash|
-            java_task_source = DataSource.from_ruby_hash(task_source_hash).java_object
+            java_task_source = DataSource.from_ruby_hash(task_source_hash).to_java
             java_commit_reports = java_control.run(java_task_source)
             java_commit_reports.map {|java_commit_report|
-              DataSource.from_java_object(java_commit_report)
+              DataSource.from_java(java_commit_report)
             }
           end
           # TODO check return type of #transaction
-          return DataSource.from_ruby_hash(next_config_hash).java_object
+          return DataSource.from_ruby_hash(next_config_hash).to_java
         end
 
         def resume(java_task_source, java_schema, processor_count, java_control)
-          task_source = DataSource.from_java_object(java_task_source)
-          schema = Schema.from_java_object(java_schema)
+          task_source = DataSource.from_java(java_task_source)
+          schema = Schema.from_java(java_schema)
           next_config_hash = @ruby_class.resume(task_source, schema, processor_count) do |task_source_hash,columns,processor_count|
-            java_task_source = DataSource.from_ruby_hash(task_source_hash).java_object
+            java_task_source = DataSource.from_ruby_hash(task_source_hash).to_java
             java_commit_reports = java_control.run(java_task_source)
             java_commit_reports.map {|java_commit_report|
-              DataSource.from_java_object(java_commit_report)
+              DataSource.from_java(java_commit_report)
             }
           end
           # TODO check return type of #resume
-          return DataSource.from_ruby_hash(next_config_hash).java_object
+          return DataSource.from_ruby_hash(next_config_hash).to_java
         end
 
         def cleanup(java_task_source, java_schema, processor_count, java_commit_reports)
-          task_source = DataSource.from_java_object(java_task_source)
-          schema = Schema.from_java_object(java_schema)
-          commit_reports = java_commit_reports.map {|c| DataSource.from_java_object(c) }
+          task_source = DataSource.from_java(java_task_source)
+          schema = Schema.from_java(java_schema)
+          commit_reports = java_commit_reports.map {|c| DataSource.from_java(c) }
           @ruby_class.cleanup(task_source, schema, processor_count, commit_reports)
           return nil
         end
 
         def open(java_task_source, java_schema, processor_index)
-          task_source = DataSource.from_java_object(java_task_source)
-          schema = Schema.from_java_object(java_schema)
+          task_source = DataSource.from_java(java_task_source)
+          schema = Schema.from_java(java_schema)
           ruby_object = @ruby_class.new(task_source, schema, processor_index)
           return OutputAdapter.new(ruby_object, schema)
         end
@@ -124,7 +124,7 @@ module Embulk
 
           def commit
             commit_report_hash = @ruby_object.commit
-            return DataSource.from_ruby_hash(commit_report_hash).java_object
+            return DataSource.from_ruby_hash(commit_report_hash).to_java
           end
         end
       end

--- a/lib/embulk/output_plugin.rb
+++ b/lib/embulk/output_plugin.rb
@@ -131,11 +131,7 @@ module Embulk
       end
 
       def self.from_java(java_class)
-        if java_class < org.embulk.spi.FileInputPlugin
-          FileOutputPlugin.from_java(java_class)
-        else
-          JavaPlugin.ruby_adapter_class(java_class, OutputPlugin, RubyAdapter)
-        end
+        JavaPlugin.ruby_adapter_class(java_class, OutputPlugin, RubyAdapter)
       end
 
       module RubyAdapter

--- a/lib/embulk/page.rb
+++ b/lib/embulk/page.rb
@@ -15,7 +15,7 @@ module Embulk
 
     def each
       schema = @schema
-      reader = Java::PageReader.new(schema.java_object)
+      reader = Java::PageReader.new(schema.to_java)
       begin
         reader.setPage(@java_page)
         while reader.nextRecord

--- a/lib/embulk/page_builder.rb
+++ b/lib/embulk/page_builder.rb
@@ -2,7 +2,7 @@ module Embulk
 
   class PageBuilder
     def initialize(schema, java_page_output)
-      @page_builder = Java::PageBuilder.new(Java::Injected::BufferAllocator, schema.java_object, java_page_output)
+      @page_builder = Java::PageBuilder.new(Java::Injected::BufferAllocator, schema.to_java, java_page_output)
       @schema = schema
     end
 

--- a/lib/embulk/parser_plugin.rb
+++ b/lib/embulk/parser_plugin.rb
@@ -1,0 +1,72 @@
+module Embulk
+
+  require 'embulk/data_source'
+  require 'embulk/schema'
+  require 'embulk/page_builder'
+  #require 'embulk/file_input'  TODO not implemented
+
+  class ParserPlugin
+    def self.transaction(config, &control)
+      raise NotImplementedError, "ParserPlugin.transaction(config, &control) must be implemented"
+    end
+
+    def initialize(task, schema, page_builder)
+      @task = task
+      @schema = schema
+      @page_builder = page_builder
+    end
+
+    def run(file_input)
+      raise NotImplementedError, "ParserPlugin#run(file_input) must be implemented"
+    end
+
+    if Embulk.java?
+      def self.new_java
+        JavaAdapter.new(self)
+      end
+
+      class JavaAdapter
+        include Java::ParserPlugin
+
+        def initialize(ruby_class)
+          @ruby_class = ruby_class
+        end
+
+        def transaction(java_config, java_control)
+          config = DataSource.from_java(java_config)
+          @ruby_class.transaction(config) do |task_source_hash,columns|
+            java_task_source = DataSource.from_ruby_hash(task_source_hash).to_java
+            java_schema = Schema.new(columns).to_java
+            java_control.run(java_task_source, java_schema)
+          end
+          nil
+        end
+
+        def run(java_task_source, java_schema, java_file_input, java_output)
+          task_source = DataSource.from_java(java_task_source)
+          schema = Schema.from_java(java_schema)
+          file_input = FileInput.from_java(java_file_input)
+          page_builder = PageBuilder.new(schema, java_output)
+          begin
+            @ruby_class.new(task_source, schema, page_builder).run(file_input)
+            nil
+          ensure
+            page_builder.close
+            # FileInput is closed by FileInputRunner
+          end
+        end
+      end
+
+      def self.from_java(java_class)
+        JavaPlugin.ruby_adapter_class(java_class, ParserPlugin, RubyAdapter)
+      end
+
+      module RubyAdapter
+        module ClassMethods
+        end
+        # TODO
+      end
+    end
+  end
+
+end

--- a/lib/embulk/plugin.rb
+++ b/lib/embulk/plugin.rb
@@ -4,8 +4,10 @@ module Embulk
   require 'embulk/error'
   require 'embulk/plugin_registry'
   require 'embulk/input_plugin'
-  require 'embulk/filter_plugin'
+  require 'embulk/file_input_plugin'
   require 'embulk/output_plugin'
+  require 'embulk/file_output_plugin'
+  require 'embulk/filter_plugin'
   require 'embulk/parser_plugin'
   require 'embulk/formatter_plugin'
   require 'embulk/decoder_plugin'
@@ -30,6 +32,10 @@ module Embulk
                       "Output plugin #{klass} must extend OutputPlugin")
     end
 
+    def register_filter(type, klass)
+      register_plugin(:filter, type, klass, FilterPlugin)
+    end
+
     ## TODO FileInput is not implemented yet.
     #def register_parser(type, klass)
     #  register_plugin(:parser, type, klass, ParserPlugin)
@@ -50,93 +56,94 @@ module Embulk
     #  register_plugin(:encoder, type, klass, EncoderPlugin)
     #end
 
-    def register_filter(type, klass)
-      register_plugin(:filter, type, klass, FilterPlugin)
-    end
-
     def register_guess(type, klass)
       register_plugin(:guess, type, klass, GuessPlugin,
                      "Guess plugin #{klass} must extend GuessPlugin, LineGuessPlugin, or TextGuessPlugin class")
     end
 
-    def get_input(type)
-      # TODO not implemented yet
-      lookup(:guess, type)
-    end
+    # TODO InputPlugin::RubyAdapter is not written by anyone yet
+    #def get_input(type)
+    #  lookup(:input, type)
+    #end
 
-    def get_output(type)
-      # TODO not implemented yet
-      lookup(:guess, type)
-    end
+    # TODO OutputPlugin::RubyAdapter is not written by anyone yet
+    #def get_output(type)
+    #  lookup(:output, type)
+    #end
 
-    def get_parser(type)
-      # TODO not implemented yet
-      lookup(:guess, type)
-    end
+    # TODO FilterPlugin::RubyAdapter is not written by anyone yet
+    #def get_filter(type)
+    #  lookup(:filter, type)
+    #end
 
-    def get_formatter(type)
-      # TODO not implemented yet
-      lookup(:guess, type)
-    end
+    # TODO FilterPlugin::RubyAdapter is not written by anyone yet
+    #def get_parser(type)
+    #  # TODO not implemented yet
+    #  lookup(:parser, type)
+    #end
 
-    def get_decoder(type)
-      # TODO not implemented yet
-      lookup(:guess, type)
-    end
+    # TODO FormatterPlugin::RubyAdapter is not written by anyone yet
+    #def get_formatter(type)
+    #  # TODO not implemented yet
+    #  lookup(:formatter, type)
+    #end
 
-    def get_encoder(type)
-      # TODO not implemented yet
-      lookup(:guess, type)
-    end
+    # TODO DecoderPlugin::RubyAdapter is not written by anyone yet
+    #def get_decoder(type)
+    #  # TODO not implemented yet
+    #  lookup(:decoder, type)
+    #end
 
-    def get_filter(type)
-      # TODO not implemented yet
-      lookup(:guess, type)
-    end
+    # TODO EncoderPlugin::RubyAdapter is not written by anyone yet
+    #def get_encoder(type)
+    #  # TODO not implemented yet
+    #  lookup(:encoder, type)
+    #end
 
     def get_guess(type)
-      # TODO not implemented yet
       lookup(:guess, type)
     end
 
     def register_java_input(type, klass)
-      register_java_plugin(:input, type, klass, InputPlugin,
-                           org.embulk.spi.InputPlugin)
+      register_java_plugin(:input, type, klass,
+                           "org.embulk.spi.InputPlugin" => InputPlugin,
+                           "org.embulk.spi.FileInputPlugin" => FileInputPlugin)
     end
 
     def register_java_output(type, klass)
-      register_java_plugin(:output, type, klass, OutputPlugin,
-                           org.embulk.spi.OutputPlugin)
-    end
-
-    def register_java_parser(type, klass)
-      register_java_plugin(:parser, type, klass, ParserPlugin,
-                           org.embulk.spi.ParserPlugin)
-    end
-
-    def register_java_formatter(type, klass)
-      register_java_plugin(:formatter, type, klass, FormatterPlugin,
-                           org.embulk.spi.FormatterPlugin)
-    end
-
-    def register_java_decoder(type, klass)
-      register_java_plugin(:decoder, type, klass, DecoderPlugin,
-                           org.embulk.spi.DecoderPlugin)
-    end
-
-    def register_java_encoder(type, klass)
-      register_java_plugin(:encoder, type, klass, EncoderPlugin,
-                           org.embulk.spi.EncoderPlugin)
+      register_java_plugin(:output, type, klass,
+                           "org.embulk.spi.OutputPlugin" => OutputPlugin,
+                           "org.embulk.spi.FileOutputPlugin" => FileOutputPlugin)
     end
 
     def register_java_filter(type, klass)
-      register_java_plugin(:filter, type, klass, FilterPlugin,
-                           org.embulk.spi.FilterPlugin)
+      register_java_plugin(:filter, type, klass,
+                           "org.embulk.spi.FilterPlugin" => FilterPlugin)
+    end
+
+    def register_java_parser(type, klass)
+      register_java_plugin(:parser, type, klass,
+                           "org.embulk.spi.ParserPlugin" => ParserPlugin)
+    end
+
+    def register_java_formatter(type, klass)
+      register_java_plugin(:formatter, type, klass,
+                           "org.embulk.spi.FormatterPlugin" => FormatterPlugin)
+    end
+
+    def register_java_decoder(type, klass)
+      register_java_plugin(:decoder, type, klass,
+                           "org.embulk.spi.DecoderPlugin" => DecoderPlugin)
+    end
+
+    def register_java_encoder(type, klass)
+      register_java_plugin(:encoder, type, klass,
+                           "org.embulk.spi.EncoderPlugin" => EncoderPlugin)
     end
 
     def register_java_guess(type, klass)
-      register_java_plugin(:guess, type, klass, GuessPlugin,
-                           org.embulk.spi.GuessPlugin)
+      register_java_plugin(:guess, type, klass,
+                           "org.embulk.spi.GuessPlugin" => GuessPlugin)
     end
 
     def new_java_input(type)
@@ -145,6 +152,10 @@ module Embulk
 
     def new_java_output(type)
       lookup(:output, type).new_java
+    end
+
+    def new_java_filter(type)
+      lookup(:filter, type).new_java
     end
 
     def new_java_parser(type)
@@ -161,10 +172,6 @@ module Embulk
 
     def new_java_encoder(type)
       lookup(:encoder, type).new_java
-    end
-
-    def new_java_filter(type)
-      lookup(:filter, type).new_java
     end
 
     def new_java_guess(type)
@@ -189,12 +196,16 @@ module Embulk
       @registries[category].register(type, klass)
     end
 
-    def register_java_plugin(category, type, klass, ruby_base_class, iface, message=nil)
-      unless klass < iface
-        message ||= "Java plugin #{klass} must implement #{iface}"
+    def register_java_plugin(category, type, klass, iface_map, message=nil)
+      found = iface_map.find do |iface_name,ruby_base_class|
+        iface = JRuby.runtime.getJRubyClassLoader.load_class(iface_name)
+        iface.isAssignableFrom(klass)
+      end
+      unless found
+        message ||= "Java plugin #{klass} must implement #{iface_map.keys.join(' or ')}"
         raise message
       end
-      adapted = ruby_base_class.from_java(klass)
+      adapted = found.last.from_java(klass)
       @registries[category].register(type, adapted)
     end
   end
@@ -206,14 +217,14 @@ module Embulk
       extend Forwardable
 
       def_delegators 'INSTANCE',
-        :register_input, :get_input, :new_java_input,
-        :register_output, :get_output, :new_java_output,
-        :register_parser, :get_parser, :new_java_parser,
-        :register_formatter, :get_formatter, :new_java_formatter,
-        :register_decoder, :get_decoder, :new_java_decoder,
-        :register_encoder, :get_encoder, :new_java_encoder,
-        :register_filter, :get_filter, :new_java_filter,
-        :register_guess, :get_guess, :new_java_guess
+        :register_input, :get_input, :register_java_input, :new_java_input,
+        :register_output, :get_output, :register_java_output, :new_java_output,
+        :register_filter, :get_filter, :register_java_filter, :new_java_filter,
+        :register_parser, :get_parser, :register_java_parser, :new_java_parser,
+        :register_formatter, :get_formatter, :register_java_formatter, :new_java_formatter,
+        :register_decoder, :get_decoder, :register_java_decoder, :new_java_decoder,
+        :register_encoder, :get_encoder, :register_java_encoder, :new_java_encoder,
+        :register_guess, :get_guess, :register_java_guess, :new_java_guess
     end
   end
 end

--- a/lib/embulk/plugin.rb
+++ b/lib/embulk/plugin.rb
@@ -95,35 +95,35 @@ module Embulk
     end
 
     def new_java_input(type)
-      lookup(:input, type).java_object
+      lookup(:input, type).to_java
     end
 
     def new_java_output(type)
-      lookup(:output, type).java_object
+      lookup(:output, type).to_java
     end
 
     def new_java_parser(type)
-      lookup(:parser, type).java_object
+      lookup(:parser, type).to_java
     end
 
     def new_java_formatter(type)
-      lookup(:formatter, type).java_object
+      lookup(:formatter, type).to_java
     end
 
     def new_java_decoder(type)
-      lookup(:decoder, type).java_object
+      lookup(:decoder, type).to_java
     end
 
     def new_java_encoder(type)
-      lookup(:encoder, type).java_object
+      lookup(:encoder, type).to_java
     end
 
     def new_java_filter(type)
-      lookup(:filter, type).java_object
+      lookup(:filter, type).to_java
     end
 
     def new_java_guess(type)
-      lookup(:guess, type).java_object
+      lookup(:guess, type).to_java
     end
 
     private

--- a/lib/embulk/plugin.rb
+++ b/lib/embulk/plugin.rb
@@ -11,6 +11,7 @@ module Embulk
   require 'embulk/decoder_plugin'
   require 'embulk/encoder_plugin'
   require 'embulk/guess_plugin'
+  require 'embulk/java_plugin' if Embulk.java?
 
   class PluginManager
     def initialize
@@ -29,12 +30,12 @@ module Embulk
                       "Output plugin #{klass} must extend OutputPlugin")
     end
 
-    ## TODO ParserPlugin JRuby API is not written by anyone yet
+    ## TODO FileInput is not implemented yet.
     #def register_parser(type, klass)
     #  register_plugin(:parser, type, klass, ParserPlugin)
     #end
 
-    ## TODO FormatterPlugin JRuby API is not written by anyone yet
+    ## TODO FileOutput is not implemented yet.
     #def register_formatter(type, klass)
     #  register_plugin(:formatter, type, klass, FormatterPlugin)
     #end

--- a/lib/embulk/schema.rb
+++ b/lib/embulk/schema.rb
@@ -82,12 +82,12 @@ module Embulk
     end
 
     if Embulk.java?
-      def self.from_java_object(java_schema)
-        new java_schema.getColumns.map {|column| Column.from_java_object(column) }
+      def self.from_java(java_schema)
+        new java_schema.getColumns.map {|column| Column.from_java(column) }
       end
 
-      def java_object
-        columns = self.map {|column| column.java_object }
+      def to_java
+        columns = self.map {|column| column.to_java }
         Java::Schema.new(columns)
       end
     end


### PR DESCRIPTION
Implemented Java plugin loader [#28].
Here is the first example plugin using this plugin loader: https://github.com/embulk/embulk-plugin-s3

How it works: (example case: loading S3FileInputPlugin):

1. `plugin.JRubyPluginSource` calls `Plugin.new_java_input`
2. it looks up for `embulk/input_s3.rb` file as an usual ruby-based plugins
3. it ([input_s3.rb](https://github.com/embulk/embulk-plugin-s3/blob/master/lib/embulk/input_s3.rb)) calls `JavaPlugin.register_input`
4. it creates `spi.PluginClassLoader` with jar file list
5. `spi.PluginClassLoader` is designed to load class from the specified jar file list first. If one doesn't exist, it loads class from the parent classloader (=JRubyClassLoader)
6. `JavaPlugin.register_input` loads `S3FileInputPlugin` from the new classloader and calls `Plugin.register_java_input`
7. it calls `FileInputPlugin.from_java`
8. it calls `JavaPlugin.ruby_adapter_class` to wrap `S3FileInputPlugin` in a new class
9. `FileInputPlugin.from_java` defines `new_java` method to the newly created class
10. finally, `Plugin.new_java_input` (=step 1) returns the result of `new_java` method
11. the `new_java` method creates S3FileInputPlugin instance using Injector and wraps it in `spi.FileInputRunner`

