### PR TITLE
Minor fixed plugin templates

### DIFF
--- a/lib/embulk/data/new/java/build.gradle.erb
+++ b/lib/embulk/data/new/java/build.gradle.erb
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %[<%= display_name %> <%= display_category %> plugin for Embulk]
   spec.description   = %[<%= display_name %> <%= display_category %> plugin is an Embulk plugin <%= description %>]
   spec.email         = [<%= email.dump %>]
-  spec.license       = ["MIT"]
+  spec.licenses      = ["MIT"]
   # TODO: spec.homepage      = <%= "https://github.com/#{email[/([^@]*)/]}/#{project_name}".dump %>
 
   spec.files         = `git ls-files`.split("\n") + Dir["classpath/*.jar"]

--- a/lib/embulk/data/new/java/file_input.java.erb
+++ b/lib/embulk/data/new/java/file_input.java.erb
@@ -59,5 +59,6 @@ public class <%= java_class_name %>
         PluginTask task = taskSource.loadTask(PluginTask.class);
 
         // TODO
+        throw new UnsupportedOperationException("The 'open' method needs to be implemented");
     }
 }

--- a/lib/embulk/data/new/java/file_output.java.erb
+++ b/lib/embulk/data/new/java/file_output.java.erb
@@ -61,5 +61,6 @@ public class <%= java_class_name %>
         PluginTask task = taskSource.loadTask(PluginTask.class);
 
         // TODO
+        throw new UnsupportedOperationException("The 'open' method needs to be implemented");
     }
 }

--- a/lib/embulk/data/new/java/input.java.erb
+++ b/lib/embulk/data/new/java/input.java.erb
@@ -64,5 +64,6 @@ public class <%= java_class_name %>
         PluginTask task = taskSource.loadTask(PluginTask.class);
 
         // TODO
+        throw new UnsupportedOperationException("The 'run' method needs to be implemented");
     }
 }

--- a/lib/embulk/data/new/java/output.java.erb
+++ b/lib/embulk/data/new/java/output.java.erb
@@ -60,5 +60,6 @@ public class <%= java_class_name %>
         PluginTask task = taskSource.loadTask(PluginTask.class);
 
         // TODO
+        throw new UnsupportedOperationException("The 'open' method needs to be implemented");
     }
 }

--- a/lib/embulk/data/new/ruby/gemspec.erb
+++ b/lib/embulk/data/new/ruby/gemspec.erb
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "<%= display_name %> <%= display_category %> plugin for Embulk"
   spec.description   = "<%= display_name %> <%= display_category %> plugin is an Embulk plugin <%= description %>"
   spec.email         = [<%= email.dump %>]
-  spec.license       = ["MIT"]
+  spec.licenses      = ["MIT"]
   # TODO: spec.homepage      = "https://github.com/<%= email[/([^@]*)/] %>/<%= project_name %>"
 
   spec.files         = `git ls-files`.split("\n") + Dir["classpath/*.jar"]


### PR DESCRIPTION
* fixed license declarations within the templates of java/build.gradle and gemspec.
* changed the method bodies within the templates of Java plugin classes. By the changing, the generated Java plugin classes can be compiled. 