### PR TITLE
csv guess plugin guesses null_string and escape options

### DIFF
--- a/lib/embulk/command/embulk_example.rb
+++ b/lib/embulk/command/embulk_example.rb
@@ -13,8 +13,8 @@ module Embulk
 id,account,time,purchase,comment
 1,32864,2015-01-27 19:23:49,20150127,embulk
 2,14824,2015-01-27 19:01:23,20150127,embulk jruby
-3,27559,2015-01-28 02:20:02,20150128,embulk core
-4,11270,2015-01-29 11:54:36,20150129,"Embulk ""csv"" parser plugin"
+3,27559,2015-01-28 02:20:02,20150128,"Embulk ""csv"" parser plugin"
+4,11270,2015-01-29 11:54:36,20150129,NULL
 EOF
     end
 


### PR DESCRIPTION
This changes add support for guessing `escape` and `null_string` options to `csv` guess plugin.
The algorithms are:

* null_string
  * count number of `(line-begin | delimiter) candidate (line-end | delimiter)`
  * For example, if it finds `,NULL,`, it increments point of `NULL`. It uses the string with the highest point.
  * If not found, use default (which means nothing will be null).
* escape
  * count number of `candidate (delimiter | quote)`
  * For example, if it finds `\"`, it increments point of `\`. It uses the string with the highest point.
  * If not found, use "" (empty string).
