### PR TITLE
Fix FileOutputOutputStream memory leak.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/util/FileOutputOutputStream.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/FileOutputOutputStream.java
@@ -62,6 +62,7 @@ public class FileOutputOutputStream
         if (pos > 0) {
             buffer.limit(pos);
             out.add(buffer);
+            buffer.release();
             buffer = Buffer.EMPTY;
             pos = 0;
             return true;


### PR DESCRIPTION
FileOutputOutputStream does not release allocated buffer. This causes OutOfMemoryError with following logs.

This PR fixes it.
```
$ java -Xmx1024m -Dio.netty.leakDetectionLevel=advanced -jar embulk.jar run local-copy.yml 
...
2015-02-18 11:20:30,160 [INFO]: main:org.embulk.exec.LocalExecutor: {done:  0 / 1, running: 0}
2015-02-18 11:20:30,191 [INFO]: embulk-executor-0:org.embulk.standards.LocalFileOutputPlugin: Writing local file 'xxx.csv'
2015-02-18 11:20:30,599 [ERROR]: embulk-executor-0:io.netty.util.ResourceLeakDetector: LEAK: ByteBuf.release() was not called before it's garbage-collected.
Recent access records: 0
Created at:
	io.netty.util.ResourceLeakDetector.open(ResourceLeakDetector.java:163)
	io.netty.buffer.AbstractByteBufAllocator.toLeakAwareBuffer(AbstractByteBufAllocator.java:42)
	io.netty.buffer.PooledByteBufAllocator.newHeapBuffer(PooledByteBufAllocator.java:228)
	io.netty.buffer.AbstractByteBufAllocator.heapBuffer(AbstractByteBufAllocator.java:136)
	io.netty.buffer.AbstractByteBufAllocator.heapBuffer(AbstractByteBufAllocator.java:122)
	io.netty.buffer.AbstractByteBufAllocator.buffer(AbstractByteBufAllocator.java:77)
	org.embulk.exec.PooledBufferAllocator.allocate(PooledBufferAllocator.java:22)
	org.embulk.spi.util.FileOutputOutputStream.flush(FileOutputOutputStream.java:76)
	org.embulk.spi.util.FileOutputOutputStream.write(FileOutputOutputStream.java:48)
	sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221)
	sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:282)
	sun.nio.cs.StreamEncoder.write(StreamEncoder.java:125)
	sun.nio.cs.StreamEncoder.write(StreamEncoder.java:135)
	java.io.OutputStreamWriter.write(OutputStreamWriter.java:220)
	java.io.Writer.write(Writer.java:157)
	java.io.Writer.append(Writer.java:227)
	org.embulk.spi.util.LineEncoder.addText(LineEncoder.java:75)
	org.embulk.standards.CsvFormatterPlugin$1$1.stringColumn(CsvFormatterPlugin.java:111)
	org.embulk.spi.Column.visit(Column.java:57)
	org.embulk.spi.Schema.visitColumns(Schema.java:48)
	org.embulk.standards.CsvFormatterPlugin$1.add(CsvFormatterPlugin.java:81)
	org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.add(FileOutputRunner.java:172)
	org.embulk.spi.PageBuilder.doFlush(PageBuilder.java:197)
	org.embulk.spi.PageBuilder.flush(PageBuilder.java:203)
	org.embulk.spi.PageBuilder.addRecord(PageBuilder.java:182)
	org.embulk.standards.CsvParserPlugin.run(CsvParserPlugin.java:198)
	org.embulk.spi.FileInputRunner.run(FileInputRunner.java:129)
	org.embulk.exec.LocalExecutor$6.call(LocalExecutor.java:623)
	org.embulk.exec.LocalExecutor$6.call(LocalExecutor.java:610)
	java.util.concurrent.FutureTask.run(FutureTask.java:262)
	java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	java.lang.Thread.run(Thread.java:744)
...
Error: Your application used more memory than the safety cap of 1024M.
Specify -J-Xmx####m to increase it (#### = cap size in MB).
Specify -w for full OutOfMemoryError stack trace
```