### PR TITLE
Maked log level configurable by command line argument

### DIFF
--- a/embulk-core/src/main/java/org/embulk/command/Runner.java
+++ b/embulk-core/src/main/java/org/embulk/command/Runner.java
@@ -41,6 +41,9 @@ public class Runner
 
         private String resumeStatePath;
         public String getResumeStatePath() { return resumeStatePath; }
+
+        private String logLevel;
+        public String getLogLevel() { return logLevel; }
     }
 
     private final Options options;
@@ -53,6 +56,12 @@ public class Runner
         ModelManager bootstrapModelManager = new ModelManager(null, new ObjectMapper());
         this.options = bootstrapModelManager.readObject(Options.class, optionJson);
         this.systemConfig = new ConfigLoader(bootstrapModelManager).fromPropertiesYamlLiteral(System.getProperties(), "embulk.");
+
+        String logLevel = this.options.getLogLevel();
+        if (logLevel != null) {
+          this.systemConfig.set("logLevel", logLevel);
+        }
+
         this.service = new EmbulkService(systemConfig);
         this.injector = service.getInjector();
     }

--- a/embulk-core/src/main/java/org/embulk/exec/LoggerProvider.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LoggerProvider.java
@@ -4,17 +4,21 @@ import java.util.Properties;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 import org.apache.log4j.PropertyConfigurator;
+import com.google.inject.Inject;
 import com.google.inject.Provider;
+import org.embulk.config.ConfigSource;
 
 public class LoggerProvider
         implements Provider<ILoggerFactory>
 {
-    public LoggerProvider()
+    @Inject
+    public LoggerProvider(@ForSystemConfig ConfigSource systemConfig)
     {
         // TODO system config
         Properties prop = new Properties();
 
-        prop.setProperty("log4j.rootLogger", "INFO,root");
+        String logLevel = systemConfig.get(String.class, "logLevel","INFO");
+        prop.setProperty("log4j.rootLogger", logLevel+",root");
         prop.setProperty("log4j.appender.root", "org.apache.log4j.ConsoleAppender");
         prop.setProperty("log4j.appender.root.layout", "org.apache.log4j.PatternLayout");
         prop.setProperty("log4j.appender.root.layout.ConversionPattern", "%d [%p]: %t:%c: %m%n");

--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -42,10 +42,16 @@ module Embulk
     op.on('-b', '--bundle BUNDLE_DIR', 'Path to a Gemfile directory') do |path|
       # only for help message. implemented at lib/embulk/command/embulk.rb
     end
+    op.on('-l', '--log-level LEVEL', 'Specify the global log level') do |level|
+      options[:logLevel] = level
+    end
 
     case subcmd.to_sym
     when :bundle
       op.remove  # remove --bundle
+      op.on('-l', '--log-level LEVEL', 'Specify the global log level') do |level|
+        # only for help message.
+      end
       if default_bundle_path
         op.banner = "Usage: bundle [directory=#{default_bundle_path}]"
         args = 0..1
@@ -108,6 +114,9 @@ module Embulk
 
     when :new
       op.remove  # remove --bundle
+      op.on('-l', '--log-level LEVEL', 'Specify the global log level') do |level|
+        # only for help message.
+      end
       op.banner = "Usage: new <category> <name>" + %[
 categories:
     ruby-input                 Ruby record input plugin    (like "mysql")


### PR DESCRIPTION
Embulk always sets "INFO"  to the log level of rootLogger.
This PR makes log level configurable by command line arguments as below.

- java -jar pkg/embulk.jar run example.yml -l &lt;LEVEL&gt;
- java -jar pkg/embulk.jar run example.yml --log-level &lt;LEVEL&gt;
- java -Dembulk.logLevel=&lt;LEVEL&gt; -jar pkg/embulk.jar run example.yml

In addition, users can specify the log level by system property: embulk.logLevel.