### PR TITLE
added basic support for ruby-based parser plugins

### DIFF
--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -129,7 +129,7 @@ categories:
     ruby-filter                Ruby record filter plugin   (like "add-hostname")
     #ruby-file-input           Ruby file input plugin      (like "ftp")          # not implemented yet [#21]
     #ruby-file-output          Ruby file output plugin     (like "ftp")          # not implemented yet [#22]
-    #ruby-parser               Ruby file parser plugin     (like "csv")          # not implemented yet [#33]
+    ruby-parser                Ruby file parser plugin     (like "csv")          # not implemented yet [#33]
     #ruby-formatter            Ruby file formatter plugin  (like "csv")          # not implemented yet [#34]
     #ruby-decoder              Ruby file decoder plugin    (like "gzip")         # not implemented yet [#31]
     #ruby-encoder              Ruby file encoder plugin    (like "gzip")         # not implemented yet [#32]
@@ -261,7 +261,7 @@ examples:
         when "ruby-filter"      then [:ruby, :filter]
         when "ruby-file-input"  then raise "ruby-file-input is not implemented yet. See #21 on github." #[:ruby, :file_input]
         when "ruby-file-output" then raise "ruby-file-output is not implemented yet. See #22 on github." #[:ruby, :file_output]
-        when "ruby-parser"      then raise "ruby-parser is not implemented yet. See #33 on github." #[:ruby, :parser]
+        when "ruby-parser"      then [:ruby, :parser]
         when "ruby-formatter"   then raise "ruby-formatter is not implemented yet. See #34 on github." #[:ruby, :formatter]
         when "ruby-decoder"     then raise "ruby-decoder is not implemented yet. See #31 on github." #[:ruby, :decoder]
         when "ruby-encoder"     then raise "ruby-decoder is not implemented yet. See #32 on github." #[:ruby, :encoder]

--- a/lib/embulk/data/new/ruby/filter.rb.erb
+++ b/lib/embulk/data/new/ruby/filter.rb.erb
@@ -7,8 +7,8 @@ module Embulk
       def self.transaction(config, in_schema, &control)
         # configuration code:
         task = {
-          "property1" => config.param("property1", :string)
-          "property2" => config.param("property2", :integer, default: 0)
+          "property1" => config.param("property1", :string),
+          "property2" => config.param("property2", :integer, default: 0),
         }
 
         yield(task, out_columns)

--- a/lib/embulk/data/new/ruby/output.rb.erb
+++ b/lib/embulk/data/new/ruby/output.rb.erb
@@ -7,8 +7,8 @@ module Embulk
       def self.transaction(config, schema, count, &control)
         # configuration code:
         task = {
-          "property1" => config.param("property1", :string)
-          "property2" => config.param("property2", :integer, default: 0)
+          "property1" => config.param("property1", :string),
+          "property2" => config.param("property2", :integer, default: 0),
         }
 
         # resumable output:

--- a/lib/embulk/data/new/ruby/parser.rb.erb
+++ b/lib/embulk/data/new/ruby/parser.rb.erb
@@ -1,8 +1,8 @@
 module Embulk
-  module Input
+  module Parser
 
-    class <%= ruby_class_name %> < InputPlugin
-      Plugin.register_input(<%= name.dump %>, self)
+    class <%= ruby_class_name %> < ParserPlugin
+      Plugin.register_parser(<%= name.dump %>, self)
 
       def self.transaction(config, &control)
         # configuration code:
@@ -17,14 +17,7 @@ module Embulk
           Column.new(2, "name", :double),
         ]
 
-        resume(task, columns, 1, &control)
-      end
-
-      def self.resume(task, columns, count, &control)
-        commit_reports = yield(task, columns, count)
-
-        next_config_diff = {}
-        return next_config_diff
+        yield(task, columns)
       end
 
       def init
@@ -33,13 +26,15 @@ module Embulk
         @property2 = task["property2"]
       end
 
-      def run
-        @page_builder.add(["example-value", 1, 0.1])
-        @page_builder.add(["example-value", 2, 0.2])
+      def run(file_input)
+        while file = file_input.next_file
+          file.each do |buffer|
+            # parsering code
+            record = ["col1", 2, 3.0]
+            @page_builder.add(record)
+          end
+        end
         @page_builder.finish
-
-        commit_report = {}
-        return commit_report
       end
     end
 

--- a/lib/embulk/file_input.rb
+++ b/lib/embulk/file_input.rb
@@ -1,0 +1,30 @@
+
+module Embulk
+  require 'embulk/buffer'
+
+  class FileInput
+    def initialize(java_file_input)
+      @java_file_input = java_file_input
+    end
+
+    def next_file
+      if @java_file_input.nextFile
+        return self
+      else
+        return nil
+      end
+    end
+
+    def each(&block)
+      while java_buffer = @java_file_input.poll
+        buffer = Buffer.from_java(java_buffer)
+        java_buffer.release
+        yield buffer
+      end
+    end
+
+    def close
+      @java_file_input.close
+    end
+  end
+end

--- a/lib/embulk/parser_plugin.rb
+++ b/lib/embulk/parser_plugin.rb
@@ -3,7 +3,7 @@ module Embulk
   require 'embulk/data_source'
   require 'embulk/schema'
   require 'embulk/page_builder'
-  #require 'embulk/file_input'  TODO not implemented
+  require 'embulk/file_input'
 
   class ParserPlugin
     def self.transaction(config, &control)
@@ -49,7 +49,7 @@ module Embulk
         def run(java_task_source, java_schema, java_file_input, java_output)
           task_source = DataSource.from_java(java_task_source)
           schema = Schema.from_java(java_schema)
-          file_input = FileInput.from_java(java_file_input)
+          file_input = FileInput.new(java_file_input)
           page_builder = PageBuilder.new(schema, java_output)
           begin
             @ruby_class.new(task_source, schema, page_builder).run(file_input)

--- a/lib/embulk/plugin.rb
+++ b/lib/embulk/plugin.rb
@@ -36,10 +36,9 @@ module Embulk
       register_plugin(:filter, type, klass, FilterPlugin)
     end
 
-    ## TODO FileInput is not implemented yet.
-    #def register_parser(type, klass)
-    #  register_plugin(:parser, type, klass, ParserPlugin)
-    #end
+    def register_parser(type, klass)
+      register_plugin(:parser, type, klass, ParserPlugin)
+    end
 
     ## TODO FileOutput is not implemented yet.
     #def register_formatter(type, klass)


### PR DESCRIPTION
For #33. This pull-request adds basic support for ruby-based parser plugins.
It doesn't have convenient utilities such as LineDecoder. We need something similar to TextGuessPlugin or LineGuessPlugin.