### PR TITLE
Embulk::JavaPlugin.classloader fixed java.net.URL on Windows

### DIFF
--- a/lib/embulk/java_plugin.rb
+++ b/lib/embulk/java_plugin.rb
@@ -5,7 +5,7 @@ module Embulk
   class JavaPlugin
     def self.classloader(dir)
       jars = Dir["#{dir}/**/*.jar"]
-      urls = jars.map {|jar| java.io.File.new(File.expand_path(jar)).toURL }
+      urls = jars.map {|jar| java.io.File.new(File.expand_path(jar)).toURI.toURL }
       classloader = Java::PluginClassLoader.new(JRuby.runtime, urls)
     end
 

--- a/lib/embulk/java_plugin.rb
+++ b/lib/embulk/java_plugin.rb
@@ -5,7 +5,7 @@ module Embulk
   class JavaPlugin
     def self.classloader(dir)
       jars = Dir["#{dir}/**/*.jar"]
-      urls = jars.map {|jar| java.net.URL.new "file://#{File.expand_path(jar)}" }
+      urls = jars.map {|jar| java.io.File.new(File.expand_path(jar)).toURL }
       classloader = Java::PluginClassLoader.new(JRuby.runtime, urls)
     end
 


### PR DESCRIPTION
This pull-request fixes ClassNotFoundException on Windows when embulk loads a java-based plugin.