### PR TITLE
vertical output for preview

### DIFF
--- a/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
@@ -29,7 +29,6 @@ abstract class PreviewPrinter
         this.header = header;
         this.model = model;
         this.samples = new ArrayList<Object[]>(SAMPLES);
-        samples.add(header);
     }
 
     public void add(Object... values) throws IOException

--- a/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
@@ -1,0 +1,97 @@
+package org.embulk.command;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Locale;
+import java.io.PrintStream;
+import java.io.Flushable;
+import java.io.IOException;
+import java.text.NumberFormat;
+import org.embulk.spi.time.Timestamp;
+import org.embulk.config.ModelManager;
+
+abstract class PreviewPrinter
+{
+    protected static final int SAMPLES = 10;
+
+    protected PrintStream out;
+
+    protected String[] header;
+
+    protected List<Object[]> samples;
+
+    protected NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.ENGLISH);
+    protected ModelManager model;
+
+    public PreviewPrinter(PrintStream out, ModelManager model, String... header)
+    {
+        this.out = out;
+        this.header = header;
+        this.model = model;
+        this.samples = new ArrayList<Object[]>(SAMPLES);
+        samples.add(header);
+    }
+
+    public void add(Object... values) throws IOException
+    {
+        int min = header.length < values.length ? header.length : values.length;
+        Object[] cols = new Object[header.length];
+        for(int i=0; i < min; i++) {
+            if(values[i] == null) {
+                cols[i] = "";
+            } else {
+                cols[i] = valueToString(values[i]);
+            }
+        }
+        for(int i=min; i < header.length; i++) {
+            cols[i] = "";
+        }
+
+        samples.add(cols);
+        if(samples.size() < SAMPLES) {
+            return;
+        }
+    }
+
+    protected String valueToString(Object obj)
+    {
+        if (obj instanceof String) {
+            return (String) obj;
+        } else if (obj instanceof Number) {
+            if (obj instanceof Integer) {
+                return numberFormat.format(((Integer) obj).longValue());
+            }
+            if (obj instanceof Long) {
+                return numberFormat.format(((Long) obj).longValue());
+            }
+            return obj.toString();
+        } else if (obj instanceof Timestamp) {
+            return obj.toString();
+        } else {
+            return model.writeObject(obj);
+        }
+    }
+
+    abstract protected void flushSamples();
+
+    protected int maxLengthInColumn(int i)
+    {
+        int max = 0;
+        for(Object[] cols : samples) {
+            String s = (String) cols[i];
+            int len = (s == null) ? 0 : s.length();
+            if(max < len) {
+                max = len;
+            }
+        }
+        return max;
+    }
+
+    public void finish() throws IOException
+    {
+        if(!samples.isEmpty()) {
+            flushSamples();
+        }
+    }
+}
+

--- a/embulk-core/src/main/java/org/embulk/command/Runner.java
+++ b/embulk-core/src/main/java/org/embulk/command/Runner.java
@@ -77,7 +77,10 @@ public class Runner
             guess(args[0]);
             break;
         case "preview":
-            preview(args[0]);
+            preview(args[0], false);
+            break;
+        case "previewrow":
+            preview(args[0], true);
             break;
         default:
             throw new RuntimeException("Unsupported command: "+command);
@@ -212,7 +215,7 @@ public class Runner
         return yml;
     }
 
-    public void preview(String partialConfigPath)
+    public void preview(String partialConfigPath, boolean rowstyle)
     {
         ConfigSource config = loadYamlConfig(partialConfigPath);
         ExecSession exec = newExecSession(config);
@@ -226,28 +229,13 @@ public class Runner
             header[i] = result.getSchema().getColumnName(i) + ":" + result.getSchema().getColumnType(i);
         }
 
-        TablePrinter printer = new TablePrinter(System.out, header) {
-            private NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.ENGLISH);
-
-            protected String valueToString(Object obj)
-            {
-                if (obj instanceof String) {
-                    return (String) obj;
-                } else if (obj instanceof Number) {
-                    if (obj instanceof Integer) {
-                        return numberFormat.format(((Integer) obj).longValue());
-                    }
-                    if (obj instanceof Long) {
-                        return numberFormat.format(((Long) obj).longValue());
-                    }
-                    return obj.toString();
-                } else if (obj instanceof Timestamp) {
-                    return obj.toString();
-                } else {
-                    return model.writeObject(obj);
-                }
-            }
-        };
+        PreviewPrinter printer;
+        if (rowstyle) {
+            printer = new TablePrinter(System.out, model, header);
+        }
+        else {
+            printer = new VerticalPrinter(System.out, model, header);
+        }
 
         try {
             for (Object[] record : records) {

--- a/embulk-core/src/main/java/org/embulk/command/Runner.java
+++ b/embulk-core/src/main/java/org/embulk/command/Runner.java
@@ -44,6 +44,9 @@ public class Runner
 
         private String logLevel;
         public String getLogLevel() { return logLevel; }
+
+        private String outputStyle;
+        public String getOutputStyle() { return outputStyle; }
     }
 
     private final Options options;
@@ -77,10 +80,7 @@ public class Runner
             guess(args[0]);
             break;
         case "preview":
-            preview(args[0], false);
-            break;
-        case "previewrow":
-            preview(args[0], true);
+            preview(args[0]);
             break;
         default:
             throw new RuntimeException("Unsupported command: "+command);
@@ -215,7 +215,7 @@ public class Runner
         return yml;
     }
 
-    public void preview(String partialConfigPath, boolean rowstyle)
+    public void preview(String partialConfigPath)
     {
         ConfigSource config = loadYamlConfig(partialConfigPath);
         ExecSession exec = newExecSession(config);
@@ -230,11 +230,11 @@ public class Runner
         }
 
         PreviewPrinter printer;
-        if (rowstyle) {
-            printer = new TablePrinter(System.out, model, header);
+        if ("vertical".equalsIgnoreCase(options.getOutputStyle())) {
+            printer = new VerticalPrinter(System.out, model, header);
         }
         else {
-            printer = new VerticalPrinter(System.out, model, header);
+            printer = new TablePrinter(System.out, model, header);
         }
 
         try {

--- a/embulk-core/src/main/java/org/embulk/command/TablePrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/TablePrinter.java
@@ -6,59 +6,20 @@ import java.util.Locale;
 import java.io.PrintStream;
 import java.io.Flushable;
 import java.io.IOException;
+import org.embulk.config.ModelManager;
 
-class TablePrinter
+class TablePrinter extends PreviewPrinter
 {
-    private static final int SAMPLES = 10;
 
-    private PrintStream out;
-
-    private String[] header;
-
-    private List<Object[]> samples;
     private String format;
     private String border;
 
-    public TablePrinter(PrintStream out, String... header)
+    public TablePrinter(PrintStream out, ModelManager model, String... header)
     {
-        this.out = out;
-        this.header = header;
-        this.samples = new ArrayList<Object[]>(SAMPLES);
-        samples.add(header);
+        super(out, model, header);
     }
 
-    public void add(Object... values) throws IOException
-    {
-        int min = header.length < values.length ? header.length : values.length;
-        Object[] cols = new Object[header.length];
-        for(int i=0; i < min; i++) {
-            if(values[i] == null) {
-                cols[i] = "";
-            } else {
-                cols[i] = valueToString(values[i]);
-            }
-        }
-        for(int i=min; i < header.length; i++) {
-            cols[i] = "";
-        }
-
-        if(samples == null) {
-            out.format(format, cols);
-            return;
-        }
-
-        samples.add(cols);
-        if(samples.size() < SAMPLES) {
-            return;
-        }
-    }
-
-    protected String valueToString(Object obj)
-    {
-        return obj.toString();
-    }
-
-    private void flushSamples()
+    protected void flushSamples()
     {
         StringBuilder borderBuilder = new StringBuilder();
 
@@ -92,28 +53,10 @@ class TablePrinter
             }
         }
 
+        out.println(border);
+
         this.samples = null;
     }
 
-    private int maxLengthInColumn(int i)
-    {
-        int max = 0;
-        for(Object[] cols : samples) {
-            String s = (String) cols[i];
-            int len = (s == null) ? 0 : s.length();
-            if(max < len) {
-                max = len;
-            }
-        }
-        return max;
-    }
-
-    public void finish() throws IOException
-    {
-        if(!samples.isEmpty()) {
-            flushSamples();
-        }
-        out.println(border);
-    }
 }
 

--- a/embulk-core/src/main/java/org/embulk/command/TablePrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/TablePrinter.java
@@ -17,6 +17,7 @@ class TablePrinter extends PreviewPrinter
     public TablePrinter(PrintStream out, ModelManager model, String... header)
     {
         super(out, model, header);
+        samples.add(header);
     }
 
     protected void flushSamples()

--- a/embulk-core/src/main/java/org/embulk/command/VerticalPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/VerticalPrinter.java
@@ -18,14 +18,25 @@ class VerticalPrinter extends PreviewPrinter
 
     protected void flushSamples()
     {
-        for( int i = 1 ; i < samples.size() ; i++ ) {
-            out.format("******************* %d **********************\n",i);
+        int maxHeaderLen = maxHeaderLength() + 1;
+        for( int i = 0 ; i < samples.size() ; i++ ) {
+            out.format("******************* %d **********************\n",i+1);
             Object[] sample = samples.get(i);
             for( int j = 0 ; j < header.length ; j++ ) {
-                out.format("%s: %s\n",valueToString(header[j]),valueToString(sample[j]));
+                out.format("%" + maxHeaderLen +"s: %s\n",header[j],valueToString(sample[j]));
             }
             out.println("");
         }
+    }
+
+    protected int maxHeaderLength()
+    {
+        int maxlength = 0;
+        for( int i = 0 ; i < header.length ; i++ ) {
+            int len = header[i].length();
+            if (len > maxlength) maxlength = len;
+        }
+        return maxlength;
     }
 
 }

--- a/embulk-core/src/main/java/org/embulk/command/VerticalPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/VerticalPrinter.java
@@ -1,0 +1,32 @@
+package org.embulk.command;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Locale;
+import java.io.PrintStream;
+import java.io.Flushable;
+import java.io.IOException;
+import org.embulk.config.ModelManager;
+
+class VerticalPrinter extends PreviewPrinter
+{
+
+    public VerticalPrinter(PrintStream out, ModelManager model, String... header)
+    {
+        super(out, model, header);
+    }
+
+    protected void flushSamples()
+    {
+        for( int i = 1 ; i < samples.size() ; i++ ) {
+            out.format("******************* %d **********************\n",i);
+            Object[] sample = samples.get(i);
+            for( int j = 0 ; j < header.length ; j++ ) {
+                out.format("%s: %s\n",valueToString(header[j]),valueToString(sample[j]));
+            }
+            out.println("");
+        }
+    }
+
+}
+

--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -102,6 +102,9 @@ module Embulk
       op.on('-C', '--classpath PATH', "Add java classpath separated by #{classpath_separator} (CLASSPATH)") do |classpath|
         classpaths.concat classpath.split(classpath_separator)
       end
+      op.on('-S', '--output-style SYTLE', 'Preview output style (table or vertical)') do |style|
+        options[:outputStyle] = style
+      end
       args = 1..1
 
     when :guess


### PR DESCRIPTION
This PR is added vertical output for preview
(like the MySQL ¥G)

Is this OK?

example output:
```
$ java -jar ./embulk-0.4.6.jar preview --output-style vertical config.yml
******************* 1 **********************
            id:long: 1
       account:long: 32,864
     time:timestamp: 2015-01-27 19:23:49 UTC
 purchase:timestamp: 2015-01-27 00:00:00 UTC
     comment:string: embulk
 
******************* 2 **********************
            id:long: 2
       account:long: 14,824
     time:timestamp: 2015-01-27 19:01:23 UTC
 purchase:timestamp: 2015-01-27 00:00:00 UTC
     comment:string: embulk jruby
 
******************* 3 **********************
            id:long: 3
       account:long: 27,559
     time:timestamp: 2015-01-28 02:20:02 UTC
 purchase:timestamp: 2015-01-28 00:00:00 UTC
     comment:string: Embulk "csv" parser plugin
```

