### PR TITLE
Fix timestamp format '%s'

### DIFF
--- a/lib/embulk/java/time_helper.rb
+++ b/lib/embulk/java/time_helper.rb
@@ -30,7 +30,7 @@ module Embulk
         end
 
         if seconds = hash[:seconds]
-          return seconds * 1_000_000
+          return seconds * 1_000
 
         else
           year = hash[:year]


### PR DESCRIPTION
Please review this patch. 

Detail
https://gist.github.com/hiroyuki-sato/61e5da934ccf41a258ca

Epoch time : 1424770450 is '2015-02-24 18:34:10 +0900'
But, preview result is show 47119-03-07 17:26:40 UTC.


