### PR TITLE
guess executor gets list of guess plugin names from system config

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/ForGuess.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ForGuess.java
@@ -1,0 +1,16 @@
+package org.embulk.exec;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForGuess
+{
+}

--- a/embulk-core/src/main/java/org/embulk/exec/LoggerProvider.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LoggerProvider.java
@@ -6,32 +6,19 @@ import org.slf4j.LoggerFactory;
 import org.apache.log4j.PropertyConfigurator;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import org.embulk.config.Task;
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigSource;
 
 public class LoggerProvider
         implements Provider<ILoggerFactory>
 {
-    private interface LoggerProviderSystemTask
-            extends Task
-    {
-        @Config("log_level")
-        @ConfigDefault("\"info\"")
-        public String getLogLevel();
-    }
-
     @Inject
     public LoggerProvider(@ForSystemConfig ConfigSource systemConfig)
     {
         // TODO system config
         Properties prop = new Properties();
 
-        LoggerProviderSystemTask systemTask = systemConfig.loadConfig(LoggerProviderSystemTask.class);
-
         final String level;
-        String logLevel = systemTask.getLogLevel();
+        String logLevel = systemConfig.get(String.class, "log_level", "info");  // here can't use loadConfig because ModelManager uses LoggerProvider
         switch (logLevel) {
         case "fatal": level = "FATAL"; break;
         case "error": level = "ERROR"; break;

--- a/embulk-core/src/main/java/org/embulk/exec/LoggerProvider.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LoggerProvider.java
@@ -6,19 +6,32 @@ import org.slf4j.LoggerFactory;
 import org.apache.log4j.PropertyConfigurator;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import org.embulk.config.Task;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigSource;
 
 public class LoggerProvider
         implements Provider<ILoggerFactory>
 {
+    private interface LoggerProviderSystemTask
+            extends Task
+    {
+        @Config("log_level")
+        @ConfigDefault("\"info\"")
+        public String getLogLevel();
+    }
+
     @Inject
     public LoggerProvider(@ForSystemConfig ConfigSource systemConfig)
     {
         // TODO system config
         Properties prop = new Properties();
 
+        LoggerProviderSystemTask systemTask = systemConfig.loadConfig(LoggerProviderSystemTask.class);
+
         final String level;
-        String logLevel = systemConfig.get(String.class, "logLevel", "info");
+        String logLevel = systemTask.getLogLevel();
         switch (logLevel) {
         case "fatal": level = "FATAL"; break;
         case "error": level = "ERROR"; break;

--- a/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
@@ -4,13 +4,17 @@ import com.google.common.base.Preconditions;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
+import com.google.inject.multibindings.Multibinder;
 import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
 import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.DecoderPlugin;
 import org.embulk.spi.EncoderPlugin;
+import org.embulk.exec.GuessExecutor;
+import org.embulk.plugin.PluginType;
 import static org.embulk.plugin.InjectedPluginSource.registerPluginTo;
+import static org.embulk.exec.GuessExecutor.registerDefaultGuessPluginTo;
 
 public class StandardPluginModule
         implements Module
@@ -39,5 +43,11 @@ public class StandardPluginModule
 
         // file encoder plugins
         registerPluginTo(binder, EncoderPlugin.class, "gzip", GzipFileEncoderPlugin.class);
+
+        // default guess plugins
+        registerDefaultGuessPluginTo(binder, new PluginType("gzip"));
+        registerDefaultGuessPluginTo(binder, new PluginType("charset"));
+        registerDefaultGuessPluginTo(binder, new PluginType("newline"));
+        registerDefaultGuessPluginTo(binder, new PluginType("csv"));
     }
 }

--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -118,6 +118,9 @@ module Embulk
       op.on('-C', '--classpath PATH', "Add java classpath separated by #{classpath_separator} (CLASSPATH)") do |classpath|
         classpaths.concat classpath.split(classpath_separator)
       end
+      op.on('-g', '--guess NAMES', "Comma-separated list of guess plugin names") do |names|
+        (options[:guessPlugins] ||= []).concat names.split(",")
+      end
       args = 1..1
 
     when :new


### PR DESCRIPTION
For #35.
`guess` subcommand accepts `-g, --guess NAMES` option to use installed guess plugins.
