### PR TITLE
Fix a problem of embulk.bat (in Windows environment)

### DIFF
--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -2,7 +2,7 @@
 : <<BAT
 @echo off
 
-java -jar %0 %*
+java -jar %~f0 %*
 
 exit /B
 BAT


### PR DESCRIPTION
When a command is "embulk.bat", "%0" is "embulk.bat".
But when a command is "embulk" (an extension can be omitted), "%0" is "embulk", and the error "Error: Unable to access jarfile embulk" will be raised.

I think "%0" should be changed to "%~f0", which means the absolute path (containing an extension) of the bat file.
(http://pf-j.sakura.ne.jp/program/dos/doscmd/str_percent.htm)

Please check it.