### PR TITLE
set default task as :build to new Rakefile template

### DIFF
--- a/lib/embulk/data/new/ruby/Rakefile
+++ b/lib/embulk/data/new/ruby/Rakefile
@@ -1,1 +1,3 @@
 require "bundler/gem_tasks"
+
+task default: :build


### PR DESCRIPTION
Default template README.md said 'run "rake" to build', but Rakefile have no default task.
And `rake` will raise an error like below.
```
rake aborted!
Don't know how to build task 'default'
```

// or, should I change README.md?