### PR TITLE
Limit the size of a quoted value

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -275,7 +275,7 @@ public class CsvTokenizer
 
                     } else {
                         if ((linePos - valueStartPos) + quotedValue.length() > maxQuotedSizeLimit) {
-                            throw new QuotedSizeExceededException("The size of the quoted value exceeds the limit size ("+maxQuotedSizeLimit+")");
+                            throw new QuotedSizeLimitExceededException("The size of the quoted value exceeds the limit size ("+maxQuotedSizeLimit+")");
                         }
                         // keep QUOTED_VALUE state
                     }
@@ -355,10 +355,10 @@ public class CsvTokenizer
         return c == escape;
     }
 
-    static class QuotedSizeExceededException
+    static class QuotedSizeLimitExceededException
             extends RuntimeException
     {
-        QuotedSizeExceededException(String message)
+        QuotedSizeLimitExceededException(String message)
         {
             super(message);
         }

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -27,7 +27,7 @@ public class CsvTokenizer
     private final char escape;
     private final String newline;
     private final boolean trimIfNotQuoted;
-    private final long maxQuotedSizeLimit;  // TODO not used yet
+    private final long maxQuotedSizeLimit;
     private final LineDecoder input;
 
     private RecordState recordState = RecordState.END;  // initial state is end of a record. nextRecord() must be called first
@@ -274,6 +274,9 @@ public class CsvTokenizer
                         }
 
                     } else {
+                        if ((linePos - valueStartPos) + quotedValue.length() > maxQuotedSizeLimit) {
+                            throw new QuotedSizeExceededException("The size of the quoted value exceeds the limit size ("+maxQuotedSizeLimit+")");
+                        }
                         // keep QUOTED_VALUE state
                     }
                     break;
@@ -350,5 +353,14 @@ public class CsvTokenizer
     private boolean isEscape(char c)
     {
         return c == escape;
+    }
+
+    static class QuotedSizeExceededException
+            extends RuntimeException
+    {
+        QuotedSizeExceededException(String message)
+        {
+            super(message);
+        }
     }
 }


### PR DESCRIPTION
max_quoted_size_limit allows users to limit the size of a quoted value.
Issue #108