### PR TITLE
Embulk.run: fix timestamp format.

### DIFF
--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -34,7 +34,7 @@ module Embulk
     op = OptionParser.new
     op.version = Embulk::VERSION
 
-    puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S,%3N %z")}: Embulk v#{Embulk::VERSION}"
+    puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%3N %z")}: Embulk v#{Embulk::VERSION}"
 
     load_paths = []
     classpaths = []


### PR DESCRIPTION
In many countries, this PR is invalid. :dizzy_face:
http://en.wikipedia.org/wiki/Decimal_mark#mediaviewer/File:DecimalSeparator.svg
