### PR TITLE
Task 'classpath' should clean a destination directory first to avoid a version conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ dependencies {
 //
 // classpath task
 //
-task classpath(dependsOn: ['build', ':embulk-cli:classpath']) << { }
+task classpath(dependsOn: ['clean', 'build', ':embulk-cli:classpath']) << { }
 clean { delete 'classpath' }
 
 //


### PR DESCRIPTION
After executing `./gradlew classpath` commands with several versions, I found the different versions of `embulk-core-0.x.x.jar` and `embulk-standards-0.x.x.jar` existed and `bin/embulk` command didn't work expectedly.

![classpath dir](http://gyazo.com/d22e0b32fc5cc6b13467e91fc26649c2.png)

So I think `./gradlew classpath` command should clean the directory first.