### PR TITLE
Fixed FileInputInputStream.skip() to avoid returning -1

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/util/FileInputInputStream.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/FileInputInputStream.java
@@ -80,7 +80,8 @@ public class FileInputInputStream
     @Override
     public long skip(long len)
     {
-        return read(null, 0, (int) Math.min(len, Integer.MAX_VALUE));
+        int skipped = read(null, 0, (int) Math.min(len, Integer.MAX_VALUE));
+        return skipped > 0 ? skipped : 0;
     }
 
     private boolean nextBuffer()

--- a/embulk-core/src/test/java/org/embulk/spi/TestFileInputInputStream.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestFileInputInputStream.java
@@ -64,4 +64,26 @@ public class TestFileInputInputStream
         assertEquals(expected.length, pos);
         assertArrayEquals(expected, actual);
     }
+
+    @Test
+    public void testSkipReturnsZeroForNoData() {
+        FileInputInputStream in = new FileInputInputStream(new MockFileInput());
+        assertEquals("Verify skip() returns 0 when there is no data.", 0L, in.skip(1));
+    }
+
+    private static class MockFileInput implements FileInput {
+        @Override
+        public boolean nextFile() {
+            return false;
+        }
+
+        @Override
+        public Buffer poll() {
+            return null;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
 }


### PR DESCRIPTION
org.embulk.spi.util.FileInputInputStream.skip() returns -1 when there is
no data in the stream. skip() calls read() method and use the returned
value without validation. skip() should return 0 or more positive value
when read() returns -1.