### PR TITLE
Don't load newline and charset plugins by default

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
@@ -46,8 +46,7 @@ public class StandardPluginModule
 
         // default guess plugins
         registerDefaultGuessPluginTo(binder, new PluginType("gzip"));
-        registerDefaultGuessPluginTo(binder, new PluginType("charset"));
-        registerDefaultGuessPluginTo(binder, new PluginType("newline"));
         registerDefaultGuessPluginTo(binder, new PluginType("csv"));
+        // charset and newline guess plugins are loaded and invoked by CsvGuessPlugin
     }
 }

--- a/lib/embulk/guess_plugin.rb
+++ b/lib/embulk/guess_plugin.rb
@@ -45,6 +45,12 @@ module Embulk
 
   class TextGuessPlugin < GuessPlugin
     def guess(config, sample)
+      if config.fetch('parser', {}).fetch('charset', nil).nil?
+        require 'embulk/guess/charset'
+        charset_guess = Guess::CharsetGuessPlugin.new
+        return charset_guess.guess(config, sample)
+      end
+
       # TODO pure-ruby LineDecoder implementation?
       begin
         parser_task = config.param("parser", :hash, default: {}).load_config(Java::LineDecoder::DecoderTask)
@@ -79,6 +85,18 @@ module Embulk
 
   class LineGuessPlugin < GuessPlugin
     def guess(config, sample)
+      if config.fetch('parser', {}).fetch('charset', nil).nil?
+        require 'embulk/guess/charset'
+        charset_guess = Guess::CharsetGuessPlugin.new
+        return charset_guess.guess(config, sample)
+      end
+
+      if config.fetch('parser', {}).fetch('newline', nil).nil?
+        require 'embulk/guess/newline'
+        newline_guess = Guess::NewlineGuessPlugin.new
+        return newline_guess.guess(config, sample)
+      end
+
       # TODO pure-ruby LineDecoder implementation?
       begin
         parser_task = config.param("parser", :hash, default: {}).load_config(Java::LineDecoder::DecoderTask)


### PR DESCRIPTION
* TextGuessPlugin invokes charset guess plugin automatically.
* LineGuessPlugin invokes charset and newline guess plugins automatically
* charset and newline guess plugins are not loaded by default