### PR TITLE
Fix NPE message issue because Buffer.release() is called twice

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/PageReader.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageReader.java
@@ -18,14 +18,21 @@ public class PageReader
     private int readCount = 0;
     private int position;
     private final byte[] nullBitSet;
+    private boolean releasePage;
 
     private static final Page SENTINEL = Page.wrap(Buffer.wrap(new byte[4]));  // buffer().release() does nothing
 
     public PageReader(Schema schema)
     {
+        this(schema, true);
+    }
+
+    public PageReader(Schema schema, boolean releasePage)
+    {
         this.schema = schema;
         this.columnOffsets = PageFormat.columnOffsets(schema);
         this.nullBitSet = new byte[PageFormat.nullBitSetSize(schema)];
+        this.releasePage = releasePage;
     }
 
     public static int getRecordCount(Page page)
@@ -37,7 +44,9 @@ public class PageReader
 
     public void setPage(Page page)
     {
-        this.page.buffer().release();
+        if (releasePage) {
+            this.page.buffer().release();
+        }
         this.page = SENTINEL;
 
         Buffer pageBuffer = page.buffer();
@@ -151,7 +160,9 @@ public class PageReader
     @Override
     public void close()
     {
-        page.buffer().release();
+        if (releasePage) {
+            page.buffer().release();
+        }
         page = SENTINEL;
     }
 

--- a/embulk-core/src/test/java/org/embulk/spi/MockBuffer.java
+++ b/embulk-core/src/test/java/org/embulk/spi/MockBuffer.java
@@ -1,0 +1,19 @@
+package org.embulk.spi;
+
+public class MockBuffer extends Buffer {
+    private int releasedCount;
+
+    protected MockBuffer(byte[] wrap, int offset, int capacity) {
+        super(wrap, offset, capacity);
+    }
+    
+    public int getReleasedCount() {
+        return releasedCount;
+    }
+
+    @Override
+    public void release() {
+        super.release();
+        releasedCount++;
+    }
+}

--- a/embulk-core/src/test/java/org/embulk/spi/MockBufferAllocator.java
+++ b/embulk-core/src/test/java/org/embulk/spi/MockBufferAllocator.java
@@ -1,0 +1,24 @@
+package org.embulk.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MockBufferAllocator implements BufferAllocator {
+    List<MockBuffer> allocatedBuffers = new ArrayList<MockBuffer>();
+
+    @Override
+    public Buffer allocate() {
+        return allocate(1024);
+    }
+
+    @Override
+    public Buffer allocate(int minimumCapacity) {
+        MockBuffer buffer = new MockBuffer(new byte[minimumCapacity], 0, minimumCapacity);
+        allocatedBuffers.add(buffer);
+        return buffer;
+    }
+
+    public List<MockBuffer> getAllocatedBuffers() {
+        return allocatedBuffers;
+    }
+}

--- a/embulk-core/src/test/java/org/embulk/spi/TestPageReader.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestPageReader.java
@@ -1,0 +1,64 @@
+package org.embulk.spi;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.embulk.spi.type.Types;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestPageReader {
+    Column column;
+    Schema schema;
+    MockBufferAllocator bufferAllocator;
+    MockBuffer fooBuffer;
+    MockBuffer barBuffer;
+    List<Page> pages;
+
+    @Before
+    public void setUp() throws Exception {
+        column = new Column(0, "name", Types.STRING);
+        schema = PageTestUtils.newSchema(column);
+        bufferAllocator = new MockBufferAllocator();
+        pages = PageTestUtils.buildPage(bufferAllocator, schema, "foo", "bar");
+        fooBuffer = bufferAllocator.getAllocatedBuffers().get(0);
+        barBuffer = bufferAllocator.getAllocatedBuffers().get(1);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        column = null;
+        schema = null;
+        bufferAllocator = null;
+        fooBuffer = null;
+        barBuffer = null;
+        pages = null;
+    }
+
+    @Test
+    public void testPageReaderDefaultReleasePageBuffer() {
+        PageReader reader = new PageReader(schema);
+        for (Page page : pages) {
+            reader.setPage(page);
+        }
+        reader.close();
+
+        assertEquals("Verify foo is not released", 1, fooBuffer.getReleasedCount());
+        assertEquals("Verify bar is not released", 1, barBuffer.getReleasedCount());
+    }
+
+    @Test
+    public void testPageReaderDontReleasePage() {
+        PageReader reader = new PageReader(schema, false);
+        for (Page page : pages) {
+            reader.setPage(page);
+        }
+        reader.close();
+
+        assertEquals("Verify foo is released", 0, fooBuffer.getReleasedCount());
+        assertEquals("Verify bar is released", 0, barBuffer.getReleasedCount());
+    }
+
+}

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
@@ -72,7 +72,7 @@ public class CsvFormatterPlugin
         }
 
         return new PageOutput() {
-            private final PageReader pageReader = new PageReader(schema);
+            private final PageReader pageReader = new PageReader(schema, false);
 
             public void add(Page page)
             {
@@ -131,6 +131,7 @@ public class CsvFormatterPlugin
 
                     encoder.addNewLine();
                 }
+                page.release();
             }
 
             public void finish()

--- a/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
@@ -55,7 +55,7 @@ public class StdoutOutputPlugin
         final PluginTask task = taskSource.loadTask(PluginTask.class);
 
         return new TransactionalPageOutput() {
-            private final PageReader reader = new PageReader(schema);
+            private final PageReader reader = new PageReader(schema, false);
             private final PagePrinter printer = new PagePrinter(schema, task);
 
             public void add(Page page)


### PR DESCRIPTION
This problem is that StdoutOutputPlugin shows NullPointerException when big data is shown because PooledBufferAllocator$NettyByteBuffer.release() has a debug code to check release() is called twice.

This problem occurs in TransactionalPageOutput.add() in StdoutOutputPlugin.open(). The code has like the following code:

```
  public void add(Page page) {
    reader.setPage(page);
    while (reader.nextRecord()) {
      ...
    }
    page.release();
  }
```

It means that page.release() is called after reading records(e.g. page1) and then reader.setPage(page) is called when add() is called for another new Page instance(e.g. page2). reader.setPage(page) calls Page.release() for the previous page instance(page1) and then NullPointerException is printed by PooledBufferAllocator$NettyByteBufBuffer.release() because release() for page1 is called twice.

My fix is like the following chnages:

- Added a new parameter, releasePage, to the constructor of PageReader to set a flag to call Page.release() in setPage()/close() or not.
- Added the parameter to StdoutOutputPlugin and CsvFormatterPlugin to avoid calling Page.release(). CsvFormatterPlugin didn't call Page.release(). So, I added the call at the end of  TransactionalPageOutput.add() method.

Note:
- I checked StdoutOutputPlugin,NullOutputPlugin, and CsvFormatterPlugin. And personally, I thought it is good to call page.release() in add() method for memory usage although it only affects a little memory. (Or, there is other fix ways like removing page.release() from StdoutOutputPlugin.open().) So, it is ok for me to reject my current change.
- CsvFormatterPlugin may not need to change in this fix. The code doesn't call PageReader.close(). So, I think either page.release() or PageReader.close() should be called even though the change is only relates a little memory footprint.


Testcase:
I think it is required to make two or more Page instances with stdout output plugin.

```
$ embulk example try1
$ cd try1/csv/
$ gunzip sample_01.csv.gz
```

Create a big csv file. For example, run like the following script to generate about 500k csv file.

```
#!/bin/bash
# Generate bigger csv file from a file.
file=sample_01.csv
a=0
max=2500

cat $file
while :
do
    a=`expr $a + 1`
    cat $file|grep -v "comment"
    if [ $a -ge $max ]; then
        break
    fi
done
```

Save it as test.sh and run it under try1/csv directory.

```
$ sh test.sh > sample_500k.csv
```

Then create config.yml and run embulk.

```
$ cd ../..
$ embulk guess try1/example.yml -o config.yml
$ embulk run config.yml > test.log
```

I think you can see like the following NullPointerException several times.

```
java.lang.NullPointerException
	at org.embulk.exec.PooledBufferAllocator$NettyByteBufBuffer.release(PooledBufferAllocator.java:54)
	at org.embulk.spi.Page.release(Page.java:38)
	at org.embulk.standards.StdoutOutputPlugin$1.add(StdoutOutputPlugin.java:67)
	at org.embulk.spi.PageBuilder.doFlush(PageBuilder.java:197)
	at org.embulk.spi.PageBuilder.flush(PageBuilder.java:203)
	at org.embulk.spi.PageBuilder.addRecord(PageBuilder.java:182)
	at org.embulk.standards.CsvParserPlugin.run(CsvParserPlugin.java:198)
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:145)
	at org.embulk.exec.LocalExecutor$6.call(LocalExecutor.java:630)
	at org.embulk.exec.LocalExecutor$6.call(LocalExecutor.java:616)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
```

Please comment if you have any questions.

Thanks.
