### PR TITLE
Add skip_header_lines option to CSV parser plugin

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -98,7 +98,11 @@ public class CsvParserPlugin
             if (task.getSkipHeaderLines() > 0) {
                 throw new ConfigException("'header_line' option is invalid if 'skip_header_lines' is set.");
             }
-            task.setSkipHeaderLines(1);
+            if (task.getHeaderLine().get()) {
+                task.setSkipHeaderLines(1);
+            } else {
+                task.setSkipHeaderLines(0);
+            }
         }
 
         control.run(task.dump(), task.getSchemaConfig().toSchema());

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -50,6 +50,7 @@ public class CsvParserPlugin
         public Optional<Boolean> getHeaderLine();
 
         @Config("skip_header_lines")
+        @ConfigDefault("0")
         public int getSkipHeaderLines();
         public void setSkipHeaderLines(int n);
 

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -115,9 +115,14 @@ public class CsvTokenizer
         }
     }
 
+    public boolean hasNextColumn()
+    {
+        return recordState == RecordState.NOT_END;
+    }
+
     public String nextColumn()
     {
-        Preconditions.checkState(recordState == RecordState.NOT_END, "doesn't have enough columns");  // TODO exception class
+        Preconditions.checkState(hasNextColumn(), "doesn't have enough columns");  // TODO exception class
 
         // reset last state
         wasQuotedColumn = false;

--- a/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
@@ -31,7 +31,7 @@ public class TestCsvParserPlugin
         CsvParserPlugin.PluginTask task = config.loadConfig(CsvParserPlugin.PluginTask.class);
         assertEquals(Charset.forName("utf-8"), task.getCharset());
         assertEquals(Newline.CRLF, task.getNewline());
-        assertEquals(false, task.getHeaderLine());
+        assertEquals(false, task.getHeaderLine().or(false));
         assertEquals(',', task.getDelimiterChar());
         assertEquals('\"', task.getQuoteChar());
     }
@@ -62,7 +62,7 @@ public class TestCsvParserPlugin
         CsvParserPlugin.PluginTask task = config.loadConfig(CsvParserPlugin.PluginTask.class);
         assertEquals(Charset.forName("utf-16"), task.getCharset());
         assertEquals(Newline.LF, task.getNewline());
-        assertEquals(true, task.getHeaderLine());
+        assertEquals(true, task.getHeaderLine().or(false));
         assertEquals('\t', task.getDelimiterChar());
         assertEquals('\\', task.getQuoteChar());
     }

--- a/lib/embulk/guess/csv.rb
+++ b/lib/embulk/guess/csv.rb
@@ -24,6 +24,8 @@ module Embulk
         "\\N",  # MySQL LOAD, Hive STORED AS TEXTFILE
       ]
 
+      MAX_SKIP_LINES = 10
+
       def guess_lines(config, sample_lines)
         delim = guess_delimiter(sample_lines)
         unless delim
@@ -32,7 +34,7 @@ module Embulk
         end
 
         parser_config = config["parser"] || {}
-        parser_guessed = {"type" => "csv", "delimiter" => delim}
+        parser_guessed = DataSource.new.merge({"type" => "csv", "delimiter" => delim})
 
         quote = guess_quote(sample_lines, delim)
         parser_guessed["quote"] = quote ? quote : ''
@@ -44,7 +46,10 @@ module Embulk
         parser_guessed["null_string"] = null_string if null_string
         # don't even set null_string to avoid confusion of null and 'null' in YAML format
 
-        sample_records = sample_lines.map {|line| line.split(delim) }  # TODO use CsvTokenizer
+        sample_records = split_lines(parser_guessed, sample_lines, delim)
+        skip_header_lines = guess_skip_header_lines(sample_records)
+        sample_records = sample_records[skip_header_lines..-1]
+
         first_types = SchemaGuess.types_from_array_records(sample_records[0, 1])
         other_types = SchemaGuess.types_from_array_records(sample_records[1..-1])
 
@@ -53,12 +58,16 @@ module Embulk
           return {}
         end
 
-        unless parser_config.has_key?("header_line")
-          parser_guessed["header_line"] = (first_types != other_types && !first_types.any? {|t| t != "string" })
+        header_line = (first_types != other_types && !first_types.any? {|t| t != "string" })
+
+        if header_line
+          parser_guessed["skip_header_lines"] = skip_header_lines + 1
+        else
+          parser_guessed["skip_header_lines"] = skip_header_lines
         end
 
         unless parser_config.has_key?("columns")
-          if parser_guessed["header_line"] || parser_config["header_line"]
+          if header_line
             column_names = sample_records.first
           else
             column_names = (0..other_types.size).to_a.map {|i| "c#{i}" }
@@ -80,6 +89,32 @@ module Embulk
       end
 
       private
+
+      def split_lines(parser_config, sample_lines, delim)
+        parser_task = parser_config.merge({"columns" => []}).load_config(org.embulk.standards.CsvParserPlugin::PluginTask)
+        data = sample_lines.map {|x| x.force_encoding('UTF-8') }.join(parser_task.getNewline.getString.encode('UTF-8'))
+        sample = Buffer.from_ruby_string(data)
+        decoder = Java::LineDecoder.new(Java::ListFileInput.new([[sample.to_java]]), parser_task)
+        tokenizer = org.embulk.standards.CsvTokenizer.new(decoder, parser_task)
+        rows = []
+        while tokenizer.nextFile
+          while tokenizer.nextRecord
+            columns = []
+            while true
+              begin
+                columns << tokenizer.nextColumn
+              rescue java.lang.IllegalStateException  # TODO exception class
+                rows << columns
+                break
+              end
+            end
+          end
+        end
+        return rows
+      rescue
+        # TODO warning if fallback to this ad-hoc implementation
+        sample_lines.map {|line| line.split(delim) }
+      end
 
       def guess_delimiter(sample_lines)
         delim_weights = DELIMITER_CANDIDATES.map do |d|
@@ -152,6 +187,17 @@ module Embulk
         end.select {|str,count| count > 0 }.sort_by {|str,count| -count }
         found = guessed.first
         return found ? found[0] : nil
+      end
+
+      def guess_skip_header_lines(sample_records)
+        counts = sample_records.map {|records| records.size }
+        (1..MAX_SKIP_LINES).each do |i|
+          check_row_count = counts[i-1]
+          if counts[i..-1].all? {|c| c <= check_row_count }
+            return i - 1
+          end
+        end
+        return 0
       end
 
       def array_sum(array)

--- a/lib/embulk/guess/csv.rb
+++ b/lib/embulk/guess/csv.rb
@@ -25,6 +25,7 @@ module Embulk
       ]
 
       MAX_SKIP_LINES = 10
+      NO_SKIP_DETECT_LINES = 10
 
       def guess_lines(config, sample_lines)
         delim = guess_delimiter(sample_lines)
@@ -191,9 +192,9 @@ module Embulk
 
       def guess_skip_header_lines(sample_records)
         counts = sample_records.map {|records| records.size }
-        (1..MAX_SKIP_LINES).each do |i|
+        (1..[MAX_SKIP_LINES, counts.length - 1].min).each do |i|
           check_row_count = counts[i-1]
-          if counts[i..-1].all? {|c| c <= check_row_count }
+          if counts[i, NO_SKIP_DETECT_LINES].all? {|c| c == check_row_count }
             return i - 1
           end
         end

--- a/lib/embulk/guess_plugin.rb
+++ b/lib/embulk/guess_plugin.rb
@@ -115,6 +115,7 @@ module Embulk
         while line = decoder.poll
           sample_lines << line
         end
+        sample_lines.pop unless sample_lines.empty?  # last line can be partial
       end
 
       return guess_lines(config, sample_lines);


### PR DESCRIPTION
New `skip_header_lines` (int, optional) replaces `header_line` parameter. `header_line` parameter is obsoleted but kept for backward compatibility.