### PR TITLE
Add delimiter config in CsvFormatter.

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
@@ -31,6 +31,10 @@ public class CsvFormatterPlugin
         @Config("header_line")
         @ConfigDefault("true")
         public boolean getHeaderLine();
+
+        @Config("delimiter")
+        @ConfigDefault("\",\"")
+        public String getDelimiterChar();
     }
 
     @Override
@@ -124,7 +128,7 @@ public class CsvFormatterPlugin
                         private void addDelimiter(Column column)
                         {
                             if (column.getIndex() != 0) {
-                                encoder.addText(",");
+                                encoder.addText(task.getDelimiterChar());
                             }
                         }
                     });

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
@@ -66,13 +66,14 @@ public class CsvFormatterPlugin
         final LineEncoder encoder = new LineEncoder(output, task);
         final Map<Integer, TimestampFormatter> timestampFormatters =
                 newTimestampFormatters(task, schema);
+        final String delimiter = task.getDelimiterChar();
 
         // create a file
         encoder.nextFile();
 
         // write header
         if (task.getHeaderLine()) {
-            writeHeader(schema, encoder);
+            writeHeader(schema, encoder, delimiter);
         }
 
         return new PageOutput() {
@@ -128,7 +129,7 @@ public class CsvFormatterPlugin
                         private void addDelimiter(Column column)
                         {
                             if (column.getIndex() != 0) {
-                                encoder.addText(task.getDelimiterChar());
+                                encoder.addText(delimiter);
                             }
                         }
                     });
@@ -149,11 +150,11 @@ public class CsvFormatterPlugin
         };
     }
 
-    private void writeHeader(Schema schema, LineEncoder encoder)
+    private void writeHeader(Schema schema, LineEncoder encoder, String delimiter)
     {
         for (Column column : schema.getColumns()) {
             if (column.getIndex() != 0) {
-                encoder.addText(",");
+                encoder.addText(delimiter);
             }
             encoder.addText(column.getName());
         }


### PR DESCRIPTION
It can use another delimiter instead of commna(',').

Reported-by hito4t <thitoshi@cac.co.jp>