### PR TITLE
Fix guess command ran decoders plugin for both sampling and guess

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
@@ -51,6 +51,7 @@ public class SamplingParserPlugin
         // override in.parser.type so that FileInputRunner creates GuessParserPlugin
         ConfigSource samplingInputConfig = inputConfig.deepCopy();
         samplingInputConfig.getNestedOrSetEmpty("parser").set("type", "system_sampling");
+        samplingInputConfig.set("decoders", null);
 
         try {
             runner.transaction(samplingInputConfig, new InputPlugin.Control() {


### PR DESCRIPTION
When running guess command, 'decoders' is used for sampling and guess. So, when 'decoders' is set explicitly, exception is thrown while running guess.

When running sampling in SamplingParserPlugin.runFileInputSampling(), input config.yml file is used. The method is called from FileInputRunner.guess() and FileInputRunner.guess() also calls guessParserConfig() for the read sampling buffer. In guessParserConfig(), FileInputRunner runs decoders again to guess a file format.

If 'decoders' is set, it is run for both sampling and guess. It will cause a problem when setting decoders in config.yml for guess command.

I think one of using 'decoders' should be removed for guess command. Personally, I thought sampling is better to read a file only. (Or, changing FileInputRunner.guessParserConfig() to remove 'decoders'.)

- Testcase:

The default beheavior of embulk can guess 'gzip' file because gzip is configured for guess command. But, I think it is better to fix this problem to be able to use other non-default decoders for guess command.


```
$ bin/embulk example try1
```

It will create gz file for an example files.

- Change try1/example.yml to add 'gzip' to decoders.

```
in:
  type: file
  path_prefix: <filepath>
  decoders:
    - type: gzip
out:
  type: stdout
```

- Run guess command.

```
$ bin/embulk guess try1/example.yml -o config.yml
```

- The following exception is thrown.

```
...
java.lang.RuntimeException: java.util.zip.ZipException: Not in GZIP format
	at org.embulk.spi.util.InputStreamFileInput.nextFile(org/embulk/spi/util/InputStreamFileInput.java:99)
	at org.embulk.exec.GuessExecutor$GuessParserPlugin.getFirstBuffer(org/embulk/exec/GuessExecutor.java:320)
	at org.embulk.exec.GuessExecutor$GuessParserPlugin.run(org/embulk/exec/GuessExecutor.java:290)
...
Caused by: java.util.zip.ZipException: Not in GZIP format
	at java.util.zip.GZIPInputStream.readHeader(GZIPInputStream.java:164)
	at java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:78)
	at java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:90)
	at org.embulk.standards.GzipFileDecoderPlugin$1.openNext(GzipFileDecoderPlugin.java:46)
	at org.embulk.spi.util.InputStreamFileInput.nextFile(InputStreamFileInput.java:96)
	at org.embulk.exec.GuessExecutor$GuessParserPlugin.getFirstBuffer(GuessExecutor.java:320)
	at org.embulk.exec.GuessExecutor$GuessParserPlugin.run(GuessExecutor.java:290)
...
Error: java.util.zip.ZipException: Not in GZIP format
```

