### PR TITLE
Fix schema_guess fails to detect boolean type

### DIFF
--- a/lib/embulk/guess/schema_guess.rb
+++ b/lib/embulk/guess/schema_guess.rb
@@ -84,7 +84,7 @@ module Embulk::Guess
         y Y
         on On ON
         1
-      ].map {|k| [k, true] }]
+      ].map {|k| [k, true] }.flatten]
 
       TYPE_COALESCE = Hash[{
         long: :double,


### PR DESCRIPTION
## Summary

schema_guess.rb failed to detect boolean type because TRUE_STRINGS defined in schema_guess.rb has wrong hash table to detect 'true' strings.

## Description

schema_guess.rb try to detect column types from column values. `guess_type(str)` checks values and then return column type like boolean, long, double, or string. When `str` value is 'true' then it checks boolean value using `TRUE_STRINGS` hash table. The code expects `TRUE_STRINGS` has key=value pair like 'true' => true. But, the current code table is like the following one.

```
TRUE_STRINGS {
 ["true", true]=>["True", true],
 ["TRUE", true]=>["yes", true],
 ["Yes", true]=>["YES", true],
 ["y", true]=>["Y", true],
 ["on", true]=>["On", true],
 ["ON", true]=>["1", true]}
```

I think it is wrong hash table. The expected table is like the following one:

```
TRUE_STRINGS {
 "true"=>true, "True"=>true, "TRUE"=>true,
 "yes"=>true, "Yes"=>true, "YES"=>true,
 "y"=>true, "Y"=>true,
 "on"=>true, "On"=>true, "ON"=>true, "1"=>true}
```

To fix this problem, I added `flatten` to create the above expected hash table for true strings.

## Testcase:

- Setup example.

```
$ embulk example try1
```

- Remote sample_01.csv.gz to create a new csv file.

```
$ rm try1/csv/sample_01.csv.gz
```

- Create a new csv file which has a boolean column like the following one.

```
$ vi try1/csv/sample_01.csv
$ cat try1/csv/sample_01.csv
id,boolean_column
0,true
1,true
2,true
```

- Run `guess` command.

```
$ embulk guess try1/example.yml -o config.yml
```

- You will see like the following column type output:

```
...
    skip_header_lines: 1
    columns:
    - {name: id, type: long}
    - {name: boolean_column, type: string}
out: {type: stdout}
...
```

The problem is that 'boolean_column' only has 'true' value. But, the guess plugin detect it as 'string' type because TRUE_STRINGS has wrong hash table.

- After fixing the problem, I can see like the following boolean type.

```
...
    columns:
    - {name: id, type: long}
    - {name: boolean_column, type: boolean}
out: {type: stdout}
...
```
