### PR TITLE
Fix schema_guess.rb fails to detect boolean column when there is false value in the column.

### DIFF
--- a/lib/embulk/guess/schema_guess.rb
+++ b/lib/embulk/guess/schema_guess.rb
@@ -45,7 +45,7 @@ module Embulk::Guess
       private
 
       def guess_type(str)
-        if TRUE_STRINGS[str]
+        if TRUE_STRINGS[str] || FALSE_STRINGS[str]
           return "boolean"
         end
 
@@ -84,6 +84,15 @@ module Embulk::Guess
         y Y
         on On ON
         1
+      ].map {|k| [k, true] }]
+
+      # When matching to false string, then retrun 'true'
+      FALSE_STRINGS = Hash[%w[
+        false False FALSE
+        no No NO
+        n N
+        off Off OFF
+        0
       ].map {|k| [k, true] }]
 
       TYPE_COALESCE = Hash[{


### PR DESCRIPTION
## Summary

`schema_guess.rb` can detect `true` strings for boolean column. But, if there is a `false` string, then the guessed column type becomes `string` type instead of `boolean`.

## Description

Current guess plugin can detect boolean column when all rows have `true` value using `TRUE_STRINGS` hash table. However, there is a `false` value, then the column becomes `string` type. I think this should be able to guess both `true` and `false`. From this, my change is to add `FALSE_STRINGS` and the values are similar values as `TRUE_STRINGS` except all values mean false values.


## Testcase

- Setup latest embulk version to be able to detect true column.
- Create a sample.

```
$ embulk example try1
```

- Remove gz sample csv file.

```
$ rm try1/csv/sample_01.csv.gz
```

- Create like the following csv file

```
$ cat try1/csv/sample_01.csv 
id,boolean_column
0,false
1,true
2,no
```

- Then run guess command.

```
$ embulk/bin/embulk guess try1/example.yml 
```

When there is a problem, you will see like the following column type.

```
    columns:
    - {name: id, type: long}
    - {name: boolean_column, type: string}
```

`boolean_column` should have `type: boolean` instead of `type: string`.

- The following csv file may be better to use to test guess boolean column.

```
$ cat try1/csv/sample_01.csv 
id,boolean_column
0,false
1,False
2,FALSE
3,no
4,No
5,NO
6,n
7,N
8,off
9,Off
10,OFF
11,0
12,true
13,True
14,TRUE
15,yes
16,Yes
17,YES
18,y
19,Y
20,on
21,On
22,ON
23,1
```

Please let me know if you have any questions.

Thanks,
Hiroki
