### PR TITLE
Additional Support for Windows in run.sh

### DIFF
--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -3,6 +3,7 @@
 @echo off
 setlocal enabledelayedexpansion
 
+rem 変数宣言
 SET java_args=
 SET jruby_args=
 SET default_optimize=0
@@ -12,102 +13,154 @@ SET JAVA_FILE_FLAG=0
 SET JRUBY_FILE_FLAG=0
 SET OTHER_FLAG=
 
+rem :SHIFTにあるshiftコマンドにて変数がシフトする
+rem (%2 -> %1)ので、%1をチェックし空ならこれ以上オプションが無いとする
 if "%1" == "" goto :OPT_END
 
+rem オプションパーサ開始
 :OPT_START
-rem Get args
+rem 引数を取得
+rem %~nでダブルクオテーションを展開する
 SET ARGS=%~1
-rem Argument is to empty if OPT_END
+rem 引数が空ならオプションパーサを終了
 if "%ARGS%"== "" goto :OPT_END
 
-rem java wo/optimization
+rem runオプション
+rem デフォルト最適化オプションフラグを有効化
 if /i "%ARGS%" == "run" (
     SET default_optimize=1
+    rem 次の引数をパースする
     goto SHIFT
 )
 
+rem -J filename の対応
+rem Win32 BATでは-Jのあとのオプションを取れないので
+rem フラグを立てて次の引数をファイルと見なす
 if %JAVA_FILE_FLAG% == 1 (
-  rem hmm...
+  rem ファイルが存在しない場合には
+  rem 引数と見なす
   if NOT EXIST "%ARGS%" (
     SET java_args=%java_args% %ARGS%
     goto ARGS_FILE_READ_RESUME
   )
+  rem ファイルからオプションを読み込む
+  rem Win32 BATではIF内でFORなどを使って読み込んでも
+  rem 正常に読み込めないので、一旦gotoで擬似的に関数っぽく読み出す
   goto ARGS_FILE_READ
+  rem ARGS_FILE_READからここに戻る
   :ARGS_FILE_READ_RESUME
+  rem 読み込んだ内容を反映する
   SET java_args=%java_args% %file_args%
+  rem ファイル読み込みフラグを折る
+  rem こうしないと延々とファイルとして扱ってしまう
   SET JAVA_FILE_FLAG=0
   goto SHIFT
 )
 
 if %JRUBY_FILE_FLAG% == 1 (
-  rem hmm...
+  rem ファイルが存在しない場合には
+  rem 引数と見なす
   if NOT EXIST "%ARGS%" (
     SET jruby_args=%jruby_args% %ARGS%
     goto ARGS_FILE_READ_RESUME
   )
+  rem ファイルからオプションを読み込む
+  rem Win32 BATではIF内でFORなどを使って読み込んでも
+  rem 正常に読み込めないので、一旦gotoで擬似的に関数っぽく読み出す
+  rem JRUBY_ARGSフラグを立てることでARGS_FILE_READから戻るgoto先を制御している
+  SET JRUBY_ARGS=1
   goto ARGS_FILE_READ
-  :ARGS_FILE_READ_RESUME
+  rem ARGS_FILE_READから戻ってくる
+  :JRUBY_ARGS_FILE_READ_RESUME
+  rem 読み込んだ内容を反映する
   SET jruby_args=%jruby_args% %file_args%
+  rem ファイル読み込みフラグを折る
+  rem こうしないと延々とファイルとして扱ってしまう
   SET JRUBY_FILE_FLAG=0
   goto SHIFT
 )
 
+rem オプションパーサコア
+rem 引数から2文字切り出す
+rem 例: -J+O => -J
 SET OPTION=%ARGS:~0,2%
+rem それ以外を切り出す
+rem ARGSからOPTIONの文字列を空に置換することで行っている。
+rem 例: -J+O => +O
 SET OPTION_ARG=!ARGS:%OPTION%=!
+rem -Jオプション
 if /i "%OPTION%" == "-J" (
+  rem -J+O
   if /i "%OPTION_ARG%" == "+O" (
     SET overwrite_optimize=1
     goto SHIFT
   )
+  rem -J-O
   if /i "%OPTION_ARG%" == "-O" (
     SET overwrite_optimize=0
     goto SHIFT
   )
-  rem java flag(file)
+  rem ファイルの引数指定
   if "%OPTION_ARG%" == "" (
     SET JAVA_FILE_FLAG=1
     goto SHIFT
   )
-  
-  SET java_args=%OPTION_ARG%
+  rem -Jjavaoption
+  SET java_args=%java_args% %OPTION_ARG%
   goto SHIFT
 )
 
+rem -Rオプション
 if /i "%OPTION%" == "-R" (
-  rem jruby flag(file)
+  rem ファイルの引数指定
   if "%OPTION_ARG%" == "" (
     SET JRUBY_FILE_FLAG=1
     goto SHIFT
   )
-  
-  SET java_args=%OPTION_ARG%
+  rem -Rjrubyoption
+  SET jruby_args=%jruby_args% %OPTION_ARG%
   goto SHIFT
 )
 
-rem Other *)
+rem その他全てのオプション
 SET OTHER_FLAG=%OTHER_FLAG% %ARGS%
 
+rem バッチファイル引数シフト
+rem %2が%1に移動する
+rem 次のオプションがないか分からないのでここで再度パースする
 :SHIFT
 shift /1
 goto :OPT_START
 
+rem ファイルを読み込む
 :ARGS_FILE_READ
+rem usebackqを使わないとinの後のファイル名にてダブルクオテーションを利用出来ない
+rem delimsに何も指定しないので1行全てを読み込む
 for /f "usebackq  delims=" %%a in ("%ARGS%") do (
     SET file_args=%%a
 )
-goto ARGS_FILE_READ_RESUME
+rem JRUBYかJAVAかを判断してgoto先を変更する
+if %JRUBY_ARGS% == 1 (
+  goto JRUBY_ARGS_FILE_READ_RESUME
+) else (
+  goto ARGS_FILE_READ_RESUME
+)
 
+rem オプションパーサコア終了
 :OPT_END
 
+rem Win32 BATではORが使えないので強引にORを作り出す
 SET FLAG=FALSE
 if %overwrite_optimize% == 1 SET FLAG=TRUE
 if %default_optimize% == 1 SET FLAG=TRUE
+rem ここは if overwrite_optimize OR default_optimize then となる
 if %FLAG% == TRUE (
   SET java_args=-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC %java_args%
 ) ELSE (
   SET java_args=-XX:+AggressiveOpts -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none %java_args%
 )
 
+rem 実際に実行する
 java %java_args% -jar %~0 %jruby_args% %OTHER_FLAG%
 
 exit /B

--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -7,6 +7,7 @@ SET default_optimize=0
 SET overwrite_optimize=0
 SET file_args=
 SET FILE_FLAG=0
+SET OTHER_FLAG=
 
 if "%1" == "" goto :OPT_END
 
@@ -53,7 +54,7 @@ if /i "%OPTION%" == "-J" (
 )
 
 rem Other *)
-goto :OPT_END
+SET OTHER_FLAG=%OTHER_FLAG% %ARGS%
 
 :SHIFT
 shift /1
@@ -70,6 +71,6 @@ if %FLAG% == TRUE (
   SET java_args=-XX:+AggressiveOpts -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none %java_args%
 )
 
-echo java %java_args% -jar %~0 %jruby_args% %*
+echo java %java_args% -jar %~0 %jruby_args% %OTHER_FLAG%
 
 exit /B

--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -1,6 +1,6 @@
 
 : <<BAT
-@echo on
+@echo off
 setlocal enabledelayedexpansion
 
 SET java_args=
@@ -8,7 +8,7 @@ SET jruby_args=
 SET default_optimize=0
 SET overwrite_optimize=0
 SET file_args=
-SET FILE_FLAG=0
+SET JAVA_FILE_FLAG=0
 SET JRUBY_FILE_FLAG=0
 SET OTHER_FLAG=
 
@@ -26,18 +26,29 @@ if /i "%ARGS%" == "run" (
     goto SHIFT
 )
 
-echo %FILE_FLAG%
-if %FILE_FLAG% == 1 (
-  echo flag
+if %JAVA_FILE_FLAG% == 1 (
   rem hmm...
-  if NOT EXIST %ARGS% (
+  if NOT EXIST "%ARGS%" (
     SET java_args=%java_args% %ARGS%
-    goto:JARGS_FILE_READ_RESUME
+    goto ARGS_FILE_READ_RESUME
   )
-  goto JARGS_FILE_READ
-  :JARGS_FILE_READ_RESUME
+  goto ARGS_FILE_READ
+  :ARGS_FILE_READ_RESUME
   SET java_args=%java_args% %file_args%
-  SET FILE_FLAG=0
+  SET JAVA_FILE_FLAG=0
+  goto SHIFT
+)
+
+if %JRUBY_FILE_FLAG% == 1 (
+  rem hmm...
+  if NOT EXIST "%ARGS%" (
+    SET jruby_args=%jruby_args% %ARGS%
+    goto ARGS_FILE_READ_RESUME
+  )
+  goto ARGS_FILE_READ
+  :ARGS_FILE_READ_RESUME
+  SET jruby_args=%jruby_args% %file_args%
+  SET JRUBY_FILE_FLAG=0
   goto SHIFT
 )
 
@@ -54,7 +65,7 @@ if /i "%OPTION%" == "-J" (
   )
   rem java flag(file)
   if "%OPTION_ARG%" == "" (
-    SET FILE_FLAG=1
+    SET JAVA_FILE_FLAG=1
     goto SHIFT
   )
   
@@ -80,12 +91,11 @@ SET OTHER_FLAG=%OTHER_FLAG% %ARGS%
 shift /1
 goto :OPT_START
 
-:JARGS_FILE_READ
+:ARGS_FILE_READ
 for /f "usebackq  delims=" %%a in ("%ARGS%") do (
     SET file_args=%%a
 )
-echo !ERRORLEVEL!
-goto JARGS_FILE_READ_RESUME
+goto ARGS_FILE_READ_RESUME
 
 :OPT_END
 
@@ -98,7 +108,7 @@ if %FLAG% == TRUE (
   SET java_args=-XX:+AggressiveOpts -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none %java_args%
 )
 
-echo java %java_args% -jar %~0 %jruby_args% %OTHER_FLAG%
+java %java_args% -jar %~0 %jruby_args% %OTHER_FLAG%
 
 exit /B
 BAT

--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -1,64 +1,75 @@
+@echo on
+setlocal enabledelayedexpansion
 
-: <<BAT
-@echo off
+SET java_args=
+SET jruby_args=
+SET default_optimize=0
+SET overwrite_optimize=0
+SET file_args=
+SET FILE_FLAG=0
 
-java -jar %~f0 %*
+if "%1" == "" goto :OPT_END
+
+:OPT_START
+rem Get args
+SET ARGS=%1
+rem Argument is to empty if OPT_END
+if "%ARGS%"== "" goto :OPT_END
+
+rem java wo/optimization
+if /i "%ARGS%" == "run" (
+    SET default_optimize=1
+    goto SHIFT
+)
+
+echo %FILE_FLAG%
+if %FILE_FLAG% == 1 (
+  rem for /f %%i in ("%ARGS%") do SET file_args=%%i
+  SET /P file_args=<"%ARGS%"
+  SET java_args=%java_args% %file_args%
+  SET FILE_FLAG=0
+  goto SHIFT
+)
+
+SET OPTION=%ARGS:~0,2%
+SET OPTION_ARG=!ARGS:%OPTION%=!
+if /i "%OPTION%" == "-J" (
+  if /i "%OPTION_ARG%" == "+O" (
+    SET overwrite_optimize=1
+    goto SHIFT
+  )
+  if /i "%OPTION_ARG%" == "-O" (
+    SET overwrite_optimize=0
+    goto SHIFT
+  )
+  rem java flag(file)
+  if "%OPTION_ARG%" == "" (
+    SET FILE_FLAG=1
+    goto SHIFT
+  )
+  
+  SET java_args=%OPTION_ARG%
+  goto SHIFT
+)
+
+rem Other *)
+goto :OPT_END
+
+:SHIFT
+shift /1
+goto :OPT_START
+
+:OPT_END
+
+SET FLAG=FALSE
+if %overwrite_optimize% == 1 SET FLAG=TRUE
+if %default_optimize% == 1 SET FLAG=TRUE
+if %FLAG% == TRUE (
+  SET java_args=-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC %java_args%
+) ELSE (
+  SET java_args=-XX:+AggressiveOpts -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none %java_args%
+)
+
+echo java %java_args% -jar %~0 %jruby_args% %*
 
 exit /B
-BAT
-
-java_args=""
-jruby_args=""
-default_optimize=""
-overwrite_optimize=""
-
-while true; do
-    case "$1" in
-        "-J+O")
-            overwrite_optimize="true"
-            shift
-            break;
-            ;;
-        "-J-O")
-            overwrite_optimize="false"
-            shift
-            break;
-            ;;
-        -J*)
-            v="${1#-J}"
-            if test "$v"; then
-                java_args="$java_args $v"
-            else
-                shift
-                file_args=`cat "$1"`
-                if test $? -ne 0; then
-                    echo "Failed to load java argument file."
-                    exit 1
-                fi
-                java_args="$java_args $file_args"
-            fi
-            shift
-            ;;
-        -R*)
-            v="${1#-R}"
-            jruby_args="$jruby_args $v"
-            shift
-            ;;
-        run)
-            default_optimize="true"
-            break
-            ;;
-        *)
-            break
-            ;;
-    esac
-done
-
-if test "$overwrite_optimize" = "true" -o "$default_optimize" -a "$overwrite_optimize" != "false"; then
-    java_args="-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC $java_args"
-else
-    java_args="-XX:+AggressiveOpts -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none $java_args"
-fi
-
-exec java $java_args -jar "$0" $jruby_args "$@"
-exit 127

--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -4,10 +4,10 @@
 setlocal enabledelayedexpansion
 
 rem 変数宣言
-SET java_args=
-SET jruby_args=
-SET default_optimize=0
-SET overwrite_optimize=0
+SET JAVA_ARGS=
+SET JRUBY_ARGS=
+SET DEFAULT_OPTIMIZE=0
+SET OVERWRITE_OPTIMIZE=0
 SET file_args=
 SET JAVA_FILE_FLAG=0
 SET JRUBY_FILE_FLAG=0
@@ -28,7 +28,7 @@ if "%ARGS%"== "" goto :OPT_END
 rem runオプション
 rem デフォルト最適化オプションフラグを有効化
 if /i "%ARGS%" == "run" (
-    SET default_optimize=1
+    SET DEFAULT_OPTIMIZE=1
     rem 次の引数をパースする
     goto SHIFT
 )
@@ -40,7 +40,7 @@ if %JAVA_FILE_FLAG% == 1 (
   rem ファイルが存在しない場合には
   rem 引数と見なす
   if NOT EXIST "%ARGS%" (
-    SET java_args=%java_args% %ARGS%
+    SET JAVA_ARGS=%JAVA_ARGS% %ARGS%
     goto ARGS_FILE_READ_RESUME
   )
   rem ファイルからオプションを読み込む
@@ -50,7 +50,7 @@ if %JAVA_FILE_FLAG% == 1 (
   rem ARGS_FILE_READからここに戻る
   :ARGS_FILE_READ_RESUME
   rem 読み込んだ内容を反映する
-  SET java_args=%java_args% %file_args%
+  SET JAVA_ARGS=%JAVA_ARGS% %file_args%
   rem ファイル読み込みフラグを折る
   rem こうしないと延々とファイルとして扱ってしまう
   SET JAVA_FILE_FLAG=0
@@ -61,7 +61,7 @@ if %JRUBY_FILE_FLAG% == 1 (
   rem ファイルが存在しない場合には
   rem 引数と見なす
   if NOT EXIST "%ARGS%" (
-    SET jruby_args=%jruby_args% %ARGS%
+    SET JRUBY_ARGS=%JRUBY_ARGS% %ARGS%
     goto ARGS_FILE_READ_RESUME
   )
   rem ファイルからオプションを読み込む
@@ -73,7 +73,7 @@ if %JRUBY_FILE_FLAG% == 1 (
   rem ARGS_FILE_READから戻ってくる
   :JRUBY_ARGS_FILE_READ_RESUME
   rem 読み込んだ内容を反映する
-  SET jruby_args=%jruby_args% %file_args%
+  SET JRUBY_ARGS=%JRUBY_ARGS% %file_args%
   rem ファイル読み込みフラグを折る
   rem こうしないと延々とファイルとして扱ってしまう
   SET JRUBY_FILE_FLAG=0
@@ -92,12 +92,12 @@ rem -Jオプション
 if /i "%OPTION%" == "-J" (
   rem -J+O
   if /i "%OPTION_ARG%" == "+O" (
-    SET overwrite_optimize=1
+    SET OVERWRITE_OPTIMIZE=1
     goto SHIFT
   )
   rem -J-O
   if /i "%OPTION_ARG%" == "-O" (
-    SET overwrite_optimize=0
+    SET OVERWRITE_OPTIMIZE=0
     goto SHIFT
   )
   rem ファイルの引数指定
@@ -106,7 +106,7 @@ if /i "%OPTION%" == "-J" (
     goto SHIFT
   )
   rem -Jjavaoption
-  SET java_args=%java_args% %OPTION_ARG%
+  SET JAVA_ARGS=%JAVA_ARGS% %OPTION_ARG%
   goto SHIFT
 )
 
@@ -118,7 +118,7 @@ if /i "%OPTION%" == "-R" (
     goto SHIFT
   )
   rem -Rjrubyoption
-  SET jruby_args=%jruby_args% %OPTION_ARG%
+  SET JRUBY_ARGS=%JRUBY_ARGS% %OPTION_ARG%
   goto SHIFT
 )
 
@@ -151,17 +151,17 @@ rem オプションパーサコア終了
 
 rem Win32 BATではORが使えないので強引にORを作り出す
 SET FLAG=FALSE
-if %overwrite_optimize% == 1 SET FLAG=TRUE
-if %default_optimize% == 1 SET FLAG=TRUE
-rem ここは if overwrite_optimize OR default_optimize then となる
+if %OVERWRITE_OPTIMIZE% == 1 SET FLAG=TRUE
+if %DEFAULT_OPTIMIZE% == 1 SET FLAG=TRUE
+rem ここは if OVERWRITE_OPTIMIZE OR DEFAULT_OPTIMIZE then となる
 if %FLAG% == TRUE (
-  SET java_args=-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC %java_args%
+  SET JAVA_ARGS=-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC %JAVA_ARGS%
 ) ELSE (
-  SET java_args=-XX:+AggressiveOpts -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none %java_args%
+  SET JAVA_ARGS=-XX:+AggressiveOpts -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none %JAVA_ARGS%
 )
 
 rem 実際に実行する
-java %java_args% -jar %~0 %jruby_args% %OTHER_FLAG%
+java %JAVA_ARGS% -jar %~0 %JRUBY_ARGS% %OTHER_FLAG%
 
 exit /B
 BAT

--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -9,6 +9,7 @@ SET default_optimize=0
 SET overwrite_optimize=0
 SET file_args=
 SET FILE_FLAG=0
+SET JRUBY_FILE_FLAG=0
 SET OTHER_FLAG=
 
 if "%1" == "" goto :OPT_END
@@ -29,8 +30,12 @@ echo %FILE_FLAG%
 if %FILE_FLAG% == 1 (
   echo flag
   rem hmm...
-  goto FILE_READ
-  :FILE_READ_RESUME
+  if NOT EXIST %ARGS% (
+    SET java_args=%java_args% %ARGS%
+    goto:JARGS_FILE_READ_RESUME
+  )
+  goto JARGS_FILE_READ
+  :JARGS_FILE_READ_RESUME
   SET java_args=%java_args% %file_args%
   SET FILE_FLAG=0
   goto SHIFT
@@ -57,6 +62,17 @@ if /i "%OPTION%" == "-J" (
   goto SHIFT
 )
 
+if /i "%OPTION%" == "-R" (
+  rem jruby flag(file)
+  if "%OPTION_ARG%" == "" (
+    SET JRUBY_FILE_FLAG=1
+    goto SHIFT
+  )
+  
+  SET java_args=%OPTION_ARG%
+  goto SHIFT
+)
+
 rem Other *)
 SET OTHER_FLAG=%OTHER_FLAG% %ARGS%
 
@@ -64,11 +80,12 @@ SET OTHER_FLAG=%OTHER_FLAG% %ARGS%
 shift /1
 goto :OPT_START
 
-:FILE_READ
+:JARGS_FILE_READ
 for /f "usebackq  delims=" %%a in ("%ARGS%") do (
     SET file_args=%%a
 )
-goto FILE_READ_RESUME
+echo !ERRORLEVEL!
+goto JARGS_FILE_READ_RESUME
 
 :OPT_END
 

--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -1,3 +1,5 @@
+
+: <<BAT
 @echo on
 setlocal enabledelayedexpansion
 
@@ -82,3 +84,60 @@ if %FLAG% == TRUE (
 echo java %java_args% -jar %~0 %jruby_args% %OTHER_FLAG%
 
 exit /B
+BAT
+
+java_args=""
+jruby_args=""
+default_optimize=""
+overwrite_optimize=""
+
+while true; do
+    case "$1" in
+        "-J+O")
+            overwrite_optimize="true"
+            shift
+            break;
+            ;;
+        "-J-O")
+            overwrite_optimize="false"
+            shift
+            break;
+            ;;
+        -J*)
+            v="${1#-J}"
+            if test "$v"; then
+                java_args="$java_args $v"
+            else
+                shift
+                file_args=`cat "$1"`
+                if test $? -ne 0; then
+                    echo "Failed to load java argument file."
+                    exit 1
+                fi
+                java_args="$java_args $file_args"
+            fi
+            shift
+            ;;
+        -R*)
+            v="${1#-R}"
+            jruby_args="$jruby_args $v"
+            shift
+            ;;
+        run)
+            default_optimize="true"
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if test "$overwrite_optimize" = "true" -o "$default_optimize" -a "$overwrite_optimize" != "false"; then
+    java_args="-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC $java_args"
+else
+    java_args="-XX:+AggressiveOpts -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none $java_args"
+fi
+
+exec java $java_args -jar "$0" $jruby_args "$@"
+exit 127

--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -13,7 +13,7 @@ if "%1" == "" goto :OPT_END
 
 :OPT_START
 rem Get args
-SET ARGS=%1
+SET ARGS=%~1
 rem Argument is to empty if OPT_END
 if "%ARGS%"== "" goto :OPT_END
 
@@ -25,8 +25,10 @@ if /i "%ARGS%" == "run" (
 
 echo %FILE_FLAG%
 if %FILE_FLAG% == 1 (
-  rem for /f %%i in ("%ARGS%") do SET file_args=%%i
-  SET /P file_args=<"%ARGS%"
+  echo flag
+  rem hmm...
+  goto FILE_READ
+  :FILE_READ_RESUME
   SET java_args=%java_args% %file_args%
   SET FILE_FLAG=0
   goto SHIFT
@@ -59,6 +61,12 @@ SET OTHER_FLAG=%OTHER_FLAG% %ARGS%
 :SHIFT
 shift /1
 goto :OPT_START
+
+:FILE_READ
+for /f "usebackq  delims=" %%a in ("%ARGS%") do (
+    SET file_args=%%a
+)
+goto FILE_READ_RESUME
 
 :OPT_END
 


### PR DESCRIPTION
run.sh was implemented to use option option can not be used for win32, but it was so far.