### PR TITLE
Fix NullPointerException after PageBuilder#doFlush fails

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
@@ -200,10 +200,13 @@ public class PageBuilder
 
     public void flush()
     {
-        doFlush();
-        if (buffer == null) {
-            newBuffer();
-        }
+    	try {
+            doFlush();
+    	} finally {
+            if (buffer == null) {
+                newBuffer();
+            }
+    	}
     }
 
     public void finish()

--- a/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
@@ -200,13 +200,13 @@ public class PageBuilder
 
     public void flush()
     {
-    	try {
+        try {
             doFlush();
-    	} finally {
+        } finally {
             if (buffer == null) {
                 newBuffer();
             }
-    	}
+        }
     }
 
     public void finish()


### PR DESCRIPTION
PageBuilder#flush method calls doFlush, then calls newBuffer.
But if doFlush throws an exception, newBuffer won't be called and bufferSlice will be null.
That causes NullPointerException when setXXX is called.
I think newBuffer should be called even if doFlush throws an exception.

And should we call output.finish in PageBuilder#finish even if doFlush throws an exception?
