### PR TITLE
Add allow_optional_columns option

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -1,6 +1,5 @@
 package org.embulk.standards;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import org.embulk.config.Task;
@@ -21,7 +20,6 @@ import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FileInput;
 import org.embulk.spi.PageOutput;
-import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.util.LineDecoder;
 import org.slf4j.Logger;
 
@@ -76,6 +74,10 @@ public class CsvParserPlugin
         @Config("max_quoted_size_limit")
         @ConfigDefault("131072") //128kB
         public long getMaxQuotedSizeLimit();
+
+        @Config("allow_optional_columns")
+        @ConfigDefault("false")
+        public boolean getAllowOptionalColumns();
     }
 
     private final Logger log;
@@ -127,6 +129,7 @@ public class CsvParserPlugin
         LineDecoder lineDecoder = new LineDecoder(input, task);
         final CsvTokenizer tokenizer = new CsvTokenizer(lineDecoder, task);
         final String nullStringOrNull = task.getNullString().orNull();
+        final boolean allowOptionalColumns = task.getAllowOptionalColumns();
         int skipHeaderLines = task.getSkipHeaderLines();
 
         try (final PageBuilder pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)) {
@@ -147,7 +150,7 @@ public class CsvParserPlugin
                         schema.visitColumns(new ColumnVisitor() {
                             public void booleanColumn(Column column)
                             {
-                                String v = nextColumn(schema, tokenizer, nullStringOrNull);
+                                String v = nextColumn(schema, tokenizer, nullStringOrNull, allowOptionalColumns);
                                 if (v == null) {
                                     pageBuilder.setNull(column);
                                 } else {
@@ -157,7 +160,7 @@ public class CsvParserPlugin
 
                             public void longColumn(Column column)
                             {
-                                String v = nextColumn(schema, tokenizer, nullStringOrNull);
+                                String v = nextColumn(schema, tokenizer, nullStringOrNull, allowOptionalColumns);
                                 if (v == null) {
                                     pageBuilder.setNull(column);
                                 } else {
@@ -172,7 +175,7 @@ public class CsvParserPlugin
 
                             public void doubleColumn(Column column)
                             {
-                                String v = nextColumn(schema, tokenizer, nullStringOrNull);
+                                String v = nextColumn(schema, tokenizer, nullStringOrNull, allowOptionalColumns);
                                 if (v == null) {
                                     pageBuilder.setNull(column);
                                 } else {
@@ -187,7 +190,7 @@ public class CsvParserPlugin
 
                             public void stringColumn(Column column)
                             {
-                                String v = nextColumn(schema, tokenizer, nullStringOrNull);
+                                String v = nextColumn(schema, tokenizer, nullStringOrNull, allowOptionalColumns);
                                 if (v == null) {
                                     pageBuilder.setNull(column);
                                 } else {
@@ -197,7 +200,7 @@ public class CsvParserPlugin
 
                             public void timestampColumn(Column column)
                             {
-                                String v = nextColumn(schema, tokenizer, nullStringOrNull);
+                                String v = nextColumn(schema, tokenizer, nullStringOrNull, allowOptionalColumns);
                                 if (v == null) {
                                     pageBuilder.setNull(column);
                                 } else {
@@ -226,8 +229,11 @@ public class CsvParserPlugin
         }
     }
 
-    private static String nextColumn(Schema schema, CsvTokenizer tokenizer, String nullStringOrNull)
+    private static String nextColumn(Schema schema, CsvTokenizer tokenizer, String nullStringOrNull, boolean allowOptionalColumns)
     {
+        if(allowOptionalColumns && !tokenizer.hasNextColumn()) {
+            return null;
+        }
         String v = tokenizer.nextColumn();
         if (!v.isEmpty()) {
             if (v.equals(nullStringOrNull)) {

--- a/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
@@ -1,7 +1,6 @@
 package org.embulk.standards;
 
 import org.junit.Rule;
-import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import java.nio.charset.Charset;
@@ -34,6 +33,7 @@ public class TestCsvParserPlugin
         assertEquals(false, task.getHeaderLine().or(false));
         assertEquals(',', task.getDelimiterChar());
         assertEquals('\"', task.getQuoteChar());
+        assertEquals(false, task.getAllowOptionalColumns());
     }
 
     @Test(expected = ConfigException.class)
@@ -53,6 +53,7 @@ public class TestCsvParserPlugin
                 .set("header_line", true)
                 .set("delimiter", "\t")
                 .set("quote", "\\")
+                .set("allow_optional_columns", true)
                 .set("columns", ImmutableList.of(
                             ImmutableMap.of(
                                 "name", "date_code",
@@ -65,5 +66,6 @@ public class TestCsvParserPlugin
         assertEquals(true, task.getHeaderLine().or(false));
         assertEquals('\t', task.getDelimiterChar());
         assertEquals('\\', task.getQuoteChar());
+        assertEquals(true, task.getAllowOptionalColumns());
     }
 }


### PR DESCRIPTION
I want to parse the CSV with the optional columns, such as the following.
```
id,name,country,favorite(optional)
1,shinichi,JP,karaoke
2,scott,US
```

This pull-request add the option to allow CSV to have insufficient columns.(default is "false")
```
  parser:
    type: csv
    delimiter: ','
    allow_optional_columns: true
    columns:
    - {name: id,       type: long}
    - {name: name,     type: string}
    - {name: country,  type: string}
    - {name: favorite, type: string}
```