### PR TITLE
Refactor ColumnVisitor instances in loop for CsvParserPlugin and CsvFormatterPlugin

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
@@ -45,27 +45,12 @@ public class CsvFormatterPlugin
         control.run(task.dump());
     }
 
-    private Map<Integer, TimestampFormatter> newTimestampFormatters(
-            TimestampFormatter.FormatterTask task, Schema schema)
-    {
-        ImmutableMap.Builder<Integer, TimestampFormatter> builder = new ImmutableBiMap.Builder<>();
-        for (Column column : schema.getColumns()) {
-            if (column.getType() instanceof TimestampType) {
-                TimestampType tt = (TimestampType) column.getType();
-                builder.put(column.getIndex(), new TimestampFormatter(tt.getFormat(), task));
-            }
-        }
-        return builder.build();
-    }
-
     @Override
     public PageOutput open(TaskSource taskSource, final Schema schema,
             FileOutput output)
     {
         final PluginTask task = taskSource.loadTask(PluginTask.class);
         final LineEncoder encoder = new LineEncoder(output, task);
-        final Map<Integer, TimestampFormatter> timestampFormatters =
-                newTimestampFormatters(task, schema);
         final String delimiter = task.getDelimiterChar();
 
         // create a file
@@ -82,58 +67,9 @@ public class CsvFormatterPlugin
             public void add(Page page)
             {
                 pageReader.setPage(page);
+                CsvColumnVisitor columnVisitor = new CsvColumnVisitor(pageReader, encoder, task, schema);
                 while (pageReader.nextRecord()) {
-                    schema.visitColumns(new ColumnVisitor() {
-                        public void booleanColumn(Column column)
-                        {
-                            addDelimiter(column);
-                            if (!pageReader.isNull(column)) {
-                                encoder.addText(Boolean.toString(pageReader.getBoolean(column)));
-                            }
-                        }
-
-                        public void longColumn(Column column)
-                        {
-                            addDelimiter(column);
-                            if (!pageReader.isNull(column)) {
-                                encoder.addText(Long.toString(pageReader.getLong(column)));
-                            }
-                        }
-
-                        public void doubleColumn(Column column)
-                        {
-                            addDelimiter(column);
-                            if (!pageReader.isNull(column)) {
-                                encoder.addText(Double.toString(pageReader.getDouble(column)));
-                            }
-                        }
-
-                        public void stringColumn(Column column)
-                        {
-                            addDelimiter(column);
-                            if (!pageReader.isNull(column)) {
-                                // TODO escape and quoting
-                                encoder.addText(pageReader.getString(column));
-                            }
-                        }
-
-                        public void timestampColumn(Column column)
-                        {
-                            addDelimiter(column);
-                            if (!pageReader.isNull(column)) {
-                                Timestamp value = pageReader.getTimestamp(column);
-                                encoder.addText(timestampFormatters.get(column.getIndex()).format(value));
-                            }
-                        }
-
-                        private void addDelimiter(Column column)
-                        {
-                            if (column.getIndex() != 0) {
-                                encoder.addText(delimiter);
-                            }
-                        }
-                    });
-
+                    schema.visitColumns(columnVisitor);
                     encoder.addNewLine();
                 }
             }
@@ -159,5 +95,83 @@ public class CsvFormatterPlugin
             encoder.addText(column.getName());
         }
         encoder.addNewLine();
+    }
+
+    static class CsvColumnVisitor implements ColumnVisitor
+    {
+        private PageReader pageReader;
+        private LineEncoder encoder;
+        private Map<Integer, TimestampFormatter> timestampFormatters;
+        private String delimiter;
+
+        CsvColumnVisitor(PageReader pageReader, LineEncoder encoder, PluginTask task, Schema schema)
+        {
+            this.pageReader = pageReader;
+            this.encoder = encoder;
+            this.timestampFormatters = newTimestampFormatters(task, schema);
+            this.delimiter = task.getDelimiterChar();
+        }
+
+        public void booleanColumn(Column column)
+        {
+            addDelimiter(column);
+            if (!pageReader.isNull(column)) {
+                encoder.addText(Boolean.toString(pageReader.getBoolean(column)));
+            }
+        }
+
+        public void longColumn(Column column)
+        {
+            addDelimiter(column);
+            if (!pageReader.isNull(column)) {
+                encoder.addText(Long.toString(pageReader.getLong(column)));
+            }
+        }
+
+        public void doubleColumn(Column column)
+        {
+            addDelimiter(column);
+            if (!pageReader.isNull(column)) {
+                encoder.addText(Double.toString(pageReader.getDouble(column)));
+            }
+        }
+
+        public void stringColumn(Column column)
+        {
+            addDelimiter(column);
+            if (!pageReader.isNull(column)) {
+                // TODO escape and quoting
+                encoder.addText(pageReader.getString(column));
+            }
+        }
+
+        public void timestampColumn(Column column)
+        {
+            addDelimiter(column);
+            if (!pageReader.isNull(column)) {
+                Timestamp value = pageReader.getTimestamp(column);
+                encoder.addText(timestampFormatters.get(column.getIndex()).format(value));
+            }
+        }
+
+        private void addDelimiter(Column column)
+        {
+            if (column.getIndex() != 0) {
+                encoder.addText(delimiter);
+            }
+        }
+
+        private Map<Integer, TimestampFormatter> newTimestampFormatters(
+                TimestampFormatter.FormatterTask task, Schema schema)
+        {
+            ImmutableMap.Builder<Integer, TimestampFormatter> builder = new ImmutableBiMap.Builder<>();
+            for (Column column : schema.getColumns()) {
+                if (column.getType() instanceof TimestampType) {
+                    TimestampType tt = (TimestampType) column.getType();
+                    builder.put(column.getIndex(), new TimestampFormatter(tt.getFormat(), task));
+                }
+            }
+            return builder.build();
+        }
     }
 }

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
@@ -63,11 +63,11 @@ public class CsvFormatterPlugin
 
         return new PageOutput() {
             private final PageReader pageReader = new PageReader(schema);
+            private CsvColumnVisitor columnVisitor = new CsvColumnVisitor(pageReader, encoder, task, schema);
 
             public void add(Page page)
             {
                 pageReader.setPage(page);
-                CsvColumnVisitor columnVisitor = new CsvColumnVisitor(pageReader, encoder, task, schema);
                 while (pageReader.nextRecord()) {
                     schema.visitColumns(columnVisitor);
                     encoder.addNewLine();


### PR DESCRIPTION
# Description

This is a refactoring request relates to CsvParserPlugin and CsvFormatterPlugin relates to creating new instances in each loop.

I wonder if I should make this pull request or not. So, it is no problem for me to reject this request because this change can affect very little performance.

# Details

Commonly, it may be high cost to create instances in a loop. Current CsvFormatterPlugin and CsvParserPlugin creates ColumnVisitor for each record. It may be better to create the instance outside of the loop.

When using hprof profile for heap=site with my test and it shows 0.04% accumulate.(It depends on the number of records.) So, it affects very few memory allocation and it may be difficult to measure the performance improvement. (I guess the current majority of memory allocations are jruby code.)
