### PR TITLE
Regression: csv.rb cannot guess csv file.

### DIFF
--- a/lib/embulk/guess/csv.rb
+++ b/lib/embulk/guess/csv.rb
@@ -28,7 +28,8 @@ module Embulk
       NO_SKIP_DETECT_LINES = 10
 
       def guess_lines(config, sample_lines)
-        return {} unless config.fetch("type", "csv") == "csv"
+        parser_config = config["parser"] || {}
+        return {} unless parser_config.fetch("type", "csv") == "csv"
 
         delim = guess_delimiter(sample_lines)
         unless delim
@@ -36,7 +37,6 @@ module Embulk
           return {}
         end
 
-        parser_config = config["parser"] || {}
         parser_guessed = DataSource.new.merge({"type" => "csv", "delimiter" => delim})
 
         quote = guess_quote(sample_lines, delim)


### PR DESCRIPTION
# Summary

Embulk v0.5.5/v0.6.0 looks to change lib/embulk/guess/csv.rb file to fix a issue in commit 5c5172fcdf2384465426823812996e7d3dfba66d . It looks to break the original guess behavior and it cannot guess csv file when using embulk example/embulk guess command.

# Details

When I ran embulk example like embulk example/embulk guess based on example command and it cannot guess csv file because of the change.

When running embulk guess command, config.fetch("type", "csv") returns "file" because config instance is for 'in' config. If my understanding is correct, the line would like to check "type" value for "parser" config. If so, it should check config["parser"]["type"] instead of config["type"].

My change is to check config["parser"]["type"] instead of config["type"]. I have no testcase for the original problem. So, my change may not be applicable for the original issue. Please check the original issue and the current regression behavior to resolve this issue.


# Testcase

Run `embulk example` command

```
$ embulk example try1
2015-04-08 14:02:34.609 -0700: Embulk v0.6.0
Creating try1 directory...
  Creating try1/
  Creating try1/csv/
  Creating try1/csv/sample_01.csv.gz
  Creating try1/example.yml

...
```

And then run `embulk guess` command

```
$ embulk guess try1/example.yml -o config.yml
2015-04-08 14:03:22.848 -0700: Embulk v0.6.0
2015-04-08 14:03:23.863 -0700 [INFO] (guess): Listing local files at directory '...<snip>.../try1/csv' filtering filename by prefix 'sample_'
2015-04-08 14:03:23.867 -0700 [INFO] (guess): Loading files [...<snip>.../try1/csv/sample_01.csv.gz]
exec: {}
in:
  type: file
  path_prefix: ...<snip>.../try1/csv/sample_
  decoders:
  - {type: gzip}
  parser: {charset: UTF-8, newline: CRLF}
out: {type: stdout}

Created 'config.yml' file.
```

If the guess command works well, the output should have columns instead of newline only.

Please let me know if you have any questions.
