### PR TITLE
csv parser supports allow_extra_columns option to control whether skip orr not rows with too many columns

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -145,6 +145,8 @@ Options
 +----------------------------+----------+----------------------------------------------------------------------------------------------------------------+------------------------+
 | allow\_optional\_columns   | boolean  | If true, set null to insufficient columns. Otherwise, skip the row in case of insufficient number of columns   | ``false`` by default   |
 +----------------------------+----------+----------------------------------------------------------------------------------------------------------------+------------------------+
+| allow\_extra\_columns      | boolean  | If true, ignore too many columns. Otherwise, skip the row in case of too many columns                          | ``false`` by default   |
++----------------------------+----------+----------------------------------------------------------------------------------------------------------------+------------------------+
 | max\_quoted\_size\_limit   | integer  | Maximum number of bytes of a quoted value. If a value exceeds the limit, the row will be skipped               | ``131072`` by default  |
 +----------------------------+----------+----------------------------------------------------------------------------------------------------------------+------------------------+
 | default\_timezone          | string   | Time zone of timestamp columns if the value itself doesn't include time zone description (eg. Asia/Tokyo)      | ``UTC`` by default     |

--- a/lib/embulk/guess/csv.rb
+++ b/lib/embulk/guess/csv.rb
@@ -69,6 +69,9 @@ module Embulk
           parser_guessed["skip_header_lines"] = skip_header_lines
         end
 
+        parser_guessed["allow_extra_columns"] = false
+        parser_guessed["allow_optional_columns"] = false
+
         unless parser_config.has_key?("columns")
           if header_line
             column_names = sample_records.first


### PR DESCRIPTION
Adds `allow_extra_columns` option to csv parser plugin.
The default behavior also changes.