### PR TITLE
Added org.embulk.spi.unit.ByteSize

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/unit/ByteSize.java
+++ b/embulk-core/src/main/java/org/embulk/spi/unit/ByteSize.java
@@ -1,0 +1,140 @@
+package org.embulk.spi.unit;
+
+import java.util.Objects;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import com.google.common.base.Preconditions;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class ByteSize
+        implements Comparable<ByteSize>
+{
+    private static final Pattern PATTERN = Pattern.compile("\\A(\\d+(?:\\.\\d+)?)\\s?([a-zA-Z]*)\\z");
+
+    private final long bytes;
+    private final Unit displayUnit;
+
+    public ByteSize(double size, Unit unit)
+    {
+        Preconditions.checkArgument(!Double.isInfinite(size), "size is infinite");
+        Preconditions.checkArgument(!Double.isNaN(size), "size is not a number");
+        Preconditions.checkArgument(size >= 0, "size is negative");
+        Preconditions.checkNotNull(unit, "unit is null");
+        Preconditions.checkArgument(size * unit.getFactor() <= (double) Long.MAX_VALUE, "size is large than (2^63)-1 in bytes");
+        this.bytes = (long) (size * unit.getFactor());
+        this.displayUnit = unit;
+    }
+
+    public long getBytes()
+    {
+        return bytes;
+    }
+
+    public long roundTo(Unit unit)
+    {
+        return (long) Math.floor(getValue(unit) + 0.5);
+    }
+
+    public double getValue(Unit unit)
+    {
+        return bytes / (double) unit.getFactor();
+    }
+
+    @JsonCreator
+    public static ByteSize parseByteSize(String size)
+    {
+        Preconditions.checkNotNull(size, "size is null");
+        Preconditions.checkArgument(!size.isEmpty(), "size is empty");
+
+        Matcher matcher = PATTERN.matcher(size);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid byte size string '" + size + "'");
+        }
+
+        double value = Double.parseDouble(matcher.group(1));  // NumberFormatException extends IllegalArgumentException.
+
+        String unitString = matcher.group(2);
+        if (unitString.isEmpty()) {
+            return new ByteSize(value, Unit.BYTES);
+        } else {
+            String upperUnitString = unitString.toUpperCase(Locale.ENGLISH);
+            for (Unit unit : Unit.values()) {
+                if (unit.getUnitString().toUpperCase(Locale.ENGLISH).equals(upperUnitString)) {
+                    return new ByteSize(value, unit);
+                }
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown unit '" + unitString + "'");
+    }
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        double value = getValue(displayUnit);
+        String integer = String.format(Locale.ENGLISH, "%d", (long) value);
+        String decimal = String.format(Locale.ENGLISH, "%.2f", value);
+        if (decimal.equals(integer + ".00")) {
+            return integer + displayUnit.getUnitString();
+        } else {
+            return decimal + displayUnit.getUnitString();
+        }
+    }
+
+    @Override
+    public int compareTo(ByteSize o)
+    {
+        return Long.compare(bytes, o.bytes);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ByteSize)) {
+            return false;
+        }
+        ByteSize o = (ByteSize) obj;
+        return this.bytes == o.bytes;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(bytes);
+    }
+
+    public enum Unit
+    {
+        BYTES(1L, "B"),
+        KB(1L << 10, "KB"),
+        MB(1L << 20, "MB"),
+        GB(1L << 30, "GB"),
+        TB(1L << 40, "TB"),
+        PT(1L << 50, "PB");
+
+        private final long factor;
+        private final String unitString;
+
+        Unit(long factor, String unitString)
+        {
+            this.factor = factor;
+            this.unitString = unitString;
+        }
+
+        long getFactor()
+        {
+            return factor;
+        }
+
+        String getUnitString()
+        {
+            return unitString;
+        }
+    }
+}

--- a/embulk-core/src/test/java/org/embulk/spi/unit/TestByteSize.java
+++ b/embulk-core/src/test/java/org/embulk/spi/unit/TestByteSize.java
@@ -1,0 +1,79 @@
+package org.embulk.spi.unit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+public class TestByteSize
+{
+    @Test
+    public void testUnitPatterns()
+    {
+        assertByteSize(42L, "42");
+        assertByteSize(42L, "42B");
+        assertByteSize(42L*(1L << 10), "42KB");
+        assertByteSize(42L*(1L << 20), "42MB");
+        assertByteSize(42L*(1L << 30), "42GB");
+        assertByteSize(42L*(1L << 40), "42TB");
+        assertByteSize(42L*(1L << 50), "42PB");
+        assertByteSize(42L, "42 B");
+        assertByteSize(42L*(1L << 10), "42 KB");
+    }
+
+    @Test
+    public void testUnknownUnits()
+    {
+        assertInvalidByteSize("42XB");
+        assertInvalidByteSize("42 XB");
+    }
+
+    @Test
+    public void testInvalidPatterns()
+    {
+        assertInvalidByteSize(" 42");
+        assertInvalidByteSize("42  B");
+        assertInvalidByteSize("42 B ");
+        assertInvalidByteSize("42B ");
+        assertInvalidByteSize("42  KB");
+        assertInvalidByteSize("42 KB ");
+        assertInvalidByteSize("42KB ");
+    }
+
+    @Test
+    public void testInvalidValues()
+    {
+        assertInvalidByteSize("9223372036854775KB");
+    }
+
+    @Test
+    public void testToString()
+    {
+        assertByteSizeString("42B", "42 B");
+        assertByteSizeString("42KB", "42 KB");
+        assertByteSizeString("42MB", "42 MB");
+        assertByteSizeString("42GB", "42 GB");
+        assertByteSizeString("42TB", "42 TB");
+        assertByteSizeString("42PB", "42 PB");
+        assertByteSizeString("42.20KB", "42.2 KB");
+        assertByteSizeString("42.33KB", "42.33KB");
+    }
+
+    private static void assertByteSize(long bytes, String string)
+    {
+        assertEquals(bytes, ByteSize.parseByteSize(string).getBytes());
+    }
+
+    private static void assertByteSizeString(String expected, String string)
+    {
+        assertEquals(expected, ByteSize.parseByteSize(string).toString());
+    }
+
+    private static void assertInvalidByteSize(String string)
+    {
+        try {
+            ByteSize.parseByteSize(string);
+            fail();
+        } catch (IllegalArgumentException ex) {
+        }
+    }
+}


### PR DESCRIPTION
This pull-request adds `org.embulk.spi.unit.ByteSize` so that plugins can get formatted values in configuration parameter. For example,

```
public interface PluginTask implements Task
{
    @Config("batch_size")
    public ByteSize getBatchSize();
}
```

with this code, we can use this format in configuration file:

```
batch_size: 10B
batch_size: 42KB
batch_size: 4.2MB
batch_size: 0.5GB
```

This fixes part of #156.