### PR TITLE
Create JRuby run and its execution environment for each Injector instances

### DIFF
--- a/embulk-cli/src/main/java/org/embulk/cli/Main.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/Main.java
@@ -4,8 +4,6 @@ public class Main
 {
     public static void main(String[] args)
     {
-        // TODO set GEM_HOME to point the internal gem repository created by gem-maven-plugin?
-
         // $ java -jar jruby-complete.jar classpath:embulk/command/embulk.rb "$@"
         String[] jrubyArgs = new String[args.length + 1];
         jrubyArgs[0] = "classpath:embulk/command/embulk.rb";

--- a/embulk-core/src/main/java/org/embulk/command/Runner.java
+++ b/embulk-core/src/main/java/org/embulk/command/Runner.java
@@ -50,6 +50,9 @@ public class Runner
 
         private List<PluginType> guessPlugins;
         public List<PluginType> getGuessPlugins() { return guessPlugins; }
+
+        private boolean useGlobalRubyRuntime;
+        public boolean getUseGlobalRubyRuntime() { return useGlobalRubyRuntime; }
     }
 
     private final Options options;
@@ -72,15 +75,22 @@ public class Runner
     {
         String logLevel = options.getLogLevel();
         if (logLevel != null) {
+            // used by LoggerProvider
             systemConfig.set("log_level", logLevel);
         }
 
         List<PluginType> guessPlugins = options.getGuessPlugins();
         if (guessPlugins != null && !guessPlugins.isEmpty()) {
+            // used by GuessExecutor
             List<PluginType> list = new ArrayList<PluginType>() { };
             list = systemConfig.get((Class<List<PluginType>>) list.getClass(), "guess_plugins", list);
             list.addAll(guessPlugins);
             systemConfig.set("guess_plugins", list);
+        }
+
+        if (options.getUseGlobalRubyRuntime()) {
+            // used by JRubyScriptingModule
+            systemConfig.set("use_global_ruby_runtime", true);
         }
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/Exec.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Exec.java
@@ -2,6 +2,7 @@ package org.embulk.spi;
 
 import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
+import com.google.inject.Injector;
 import org.embulk.config.Task;
 import org.embulk.config.ModelManager;
 import org.embulk.config.CommitReport;
@@ -36,6 +37,11 @@ public class Exec
             throw new NullPointerException("Exec is used outside of Exec.doWith");
         }
         return session;
+    }
+
+    public static Injector getInjector()
+    {
+        return session().getInjector();
     }
 
     public static Logger getLogger(String name)

--- a/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
@@ -80,7 +80,7 @@ public class FileInputRunner
             throw new NoSampleException("Can't get sample data because the first input file is empty");
         }
 
-        GuessExecutor guessExecutor = Exec.session().getInjector().getInstance(GuessExecutor.class);
+        GuessExecutor guessExecutor = Exec.getInjector().getInstance(GuessExecutor.class);
         return guessExecutor.guessParserConfig(sample, config, Exec.session().getExecConfig());
     }
 

--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -39,7 +39,12 @@ module Embulk
     load_paths = []
     classpaths = []
     classpath_separator = java.io.File.pathSeparator
-    options = {}
+
+    options = {
+      # use the global ruby runtime (the jruby Runtime running this embulk_run.rb script) for all
+      # ScriptingContainer injected by the org.embulk.command.Runner.
+      useGlobalRubyRuntime: true,
+    }
 
     op.on('-b', '--bundle BUNDLE_DIR', 'Path to a Gemfile directory') do |path|
       # only for help message. implemented at lib/embulk/command/embulk.rb

--- a/lib/embulk/java/bootstrap.rb
+++ b/lib/embulk/java/bootstrap.rb
@@ -5,13 +5,13 @@ module Embulk
 
     module Injected
       # Following constats are set by org.embulk.jruby.JRubyScriptingModule:
+      #   Injector
       #   ModelManager
       #   BufferAllocator
     end
 
     def self.injector
-      # TODO use org.embulk.spi.Exec.getInjector
-      Injector
+      Injected::Injector
     end
   end
 end

--- a/lib/embulk/plugin.rb
+++ b/lib/embulk/plugin.rb
@@ -190,7 +190,7 @@ module Embulk
 
     # TODO lookup should fallback to Java PluginSource
     # if not found so that ruby plugins can call java plugins.
-    # call injector.newPlugin and wrap the instance in a reverse bridge object.
+    # call Java.injector.newPlugin and wrap the instance in a reverse bridge object.
 
     def lookup(category, type)
       @registries[category].lookup(type)


### PR DESCRIPTION
When running test cases, it shows this message:

```
warning: already initialized constant Injector
...
```

This warning happens when a JVM process Instantiates multiple Injectors because `ScriptingContainer` uses `LocalContextScope.SINGLETON` mode which means there is only one JRuby runtime environment in the JVM.

By this pull-request, Injector (`JRubyScriptingModule.ScriptingContainerProvider`) creates JRuby runtime for each Injector instances. So, each Injectors have isolated JRuby runtime and execution environment.
