### PR TITLE
Add -L, --load PATH argument to use a local plugin

### DIFF
--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -36,6 +36,7 @@ module Embulk
 
     puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%3N %z")}: Embulk v#{Embulk::VERSION}"
 
+    plugin_paths = []
     load_paths = []
     classpaths = []
     classpath_separator = java.io.File.pathSeparator
@@ -61,6 +62,9 @@ module Embulk
       op.on('-l', '--log-level LEVEL', 'Log level (fatal, error, warn, info, debug or trace)') do |level|
         options[:logLevel] = level
       end
+      op.on('-L', '--load PATH', 'Add a local plugin path') do |plugin_path|
+        plugin_paths << plugin_path
+      end
       op.on('-I', '--load-path PATH', 'Add ruby script directory path ($LOAD_PATH)') do |load_path|
         load_paths << load_path
       end
@@ -80,6 +84,9 @@ module Embulk
       op.on('-l', '--log-level LEVEL', 'Log level (fatal, error, warn, info, debug or trace)') do |level|
         options[:logLevel] = level
       end
+      op.on('-L', '--load PATH', 'Add a local plugin path') do |plugin_path|
+        plugin_paths << plugin_path
+      end
       op.on('-I', '--load-path PATH', 'Add ruby script directory path ($LOAD_PATH)') do |load_path|
         load_paths << load_path
       end
@@ -95,6 +102,9 @@ module Embulk
       op.banner = "Usage: preview <config.yml>"
       op.on('-l', '--log-level LEVEL', 'Log level (fatal, error, warn, info, debug or trace)') do |level|
         options[:logLevel] = level
+      end
+      op.on('-L', '--load PATH', 'Add a local plugin path') do |plugin_path|
+        plugin_paths << plugin_path
       end
       op.on('-I', '--load-path PATH', 'Add ruby script directory path ($LOAD_PATH)') do |load_path|
         load_paths << load_path
@@ -114,6 +124,9 @@ module Embulk
       end
       op.on('-o', '--output PATH', 'Path to a file to write the guessed configuration') do |path|
         options[:nextConfigOutputPath] = path
+      end
+      op.on('-L', '--load PATH', 'Add a local plugin path') do |plugin_path|
+        plugin_paths << plugin_path
       end
       op.on('-I', '--load-path PATH', 'Add ruby script directory path ($LOAD_PATH)') do |load_path|
         load_paths << load_path
@@ -186,6 +199,7 @@ examples:
 
       require 'fileutils'
       require 'rubygems/gem_runner'
+      setup_plugin_paths(plugin_paths)
       setup_load_paths(load_paths)
       setup_classpaths(classpaths)
 
@@ -292,6 +306,7 @@ examples:
         end
       end
 
+      setup_plugin_paths(plugin_paths)
       setup_load_paths(load_paths)
       setup_classpaths(classpaths)
 
@@ -331,6 +346,24 @@ examples:
     Gem.clear_paths  # force rubygems to reload GEM_HOME
   end
 
+  def self.setup_plugin_paths(plugin_paths)
+    plugin_paths.each do |path|
+      unless File.directory?(path)
+        raise "Path '#{path}' is not a directory"
+      end
+      specs = Dir[File.join(File.expand_path(path), "*.gemspec")]
+      if specs.empty?
+        raise "Path '#{path}' does not include *.gemspec file. Hint: Did you run './gradlew package' command?"
+      end
+      specs.each do |spec|
+        gem_path = File.dirname(spec)
+        stub = Gem::StubSpecification.new(spec)
+        stub.define_singleton_method(:full_gem_path) { gem_path }
+        Gem::Specification.add_spec(stub)
+      end
+    end
+  end
+
   def self.setup_load_paths(load_paths)
     # first $LOAD_PATH has highet priority. later load_paths should have highest priority.
     load_paths.each do |load_path|
@@ -340,9 +373,9 @@ examples:
   end
 
   def self.setup_classpaths(classpaths)
-    classpaths.each {|classpath|
+    classpaths.each do |classpath|
       $CLASSPATH << classpath  # $CLASSPATH object doesn't have concat method
-    }
+    end
   end
 
   def self.usage(message)

--- a/lib/embulk/data/new/gitignore.erb
+++ b/lib/embulk/data/new/gitignore.erb
@@ -2,6 +2,7 @@
 /pkg/
 /tmp/
 %if language == :java
+*.gemspec
 .gradle/
 /classpath/
 build/

--- a/lib/embulk/data/new/java/build.gradle.erb
+++ b/lib/embulk/data/new/java/build.gradle.erb
@@ -26,15 +26,29 @@ task classpath(type: Copy, dependsOn: ["jar"]) {
     from (configurations.runtime - configurations.provided + files(jar.archivePath))
     into "classpath"
 }
-clean { delete 'classpath' }
+clean { delete "classpath" }
 
-task gem(type: JRubyExec, dependsOn: ["build", "gemspec", "classpath"]) {
+task gem(type: JRubyExec, dependsOn: ["gemspec", "classpath"]) {
     jrubyArgs "-rrubygems/gem_runner", "-eGem::GemRunner.new.run(ARGV)", "build"
-    script "build/gemspec"
+    script "${project.name}.gemspec"
     doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "pkg") }
 }
 
-task gemspec << { file("build/gemspec").write($/
+task gemPush(type: JRubyExec, dependsOn: ["gem"]) {
+    jrubyArgs "-rrubygems/gem_runner", "-eGem::GemRunner.new.run(ARGV)", "push"
+    script "${project.name}-${project.version}.gem"
+}
+
+task "package"(dependsOn: ["gemspec", "classpath"]) << {
+    println "> Build succeeded."
+    println "> You can run embulk with '-L ${file(".").absolutePath}' argument."
+}
+
+task gemspec {
+    ext.gemspecFile = file("${project.name}.gemspec")
+    inputs.file "build.gradle"
+    outputs.file gemspecFile
+    doLast { gemspecFile.write($/
 Gem::Specification.new do |spec|
   spec.name          = "${project.name}"
   spec.version       = "${project.version}"
@@ -54,4 +68,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', ['>= 10.0']
 end
 /$)
+    }
 }
+clean { delete "${project.name}.gemspec" }


### PR DESCRIPTION
Background: plugin developers want to try a plugin without releasing it every time.
This pull-request adds `-L, --load PATH` argument to load a plugin without installing it.

```
$ embulk run -L ./path/to/embulk-input-myplugin config.yml
```

This pull-request also includes changes of build script of java-based plugins so that it generates gemspec file to work with the new -L argument.
