### PR TITLE
Add RetryExecutor and RetryableInputStream

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/util/RetryExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/RetryExecutor.java
@@ -1,0 +1,129 @@
+package org.embulk.spi.util;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+public class RetryExecutor
+{
+    public static RetryExecutor retryExecutor()
+    {
+        // TODO default configuration
+        return new RetryExecutor(3, 500, 30*1000);
+    }
+
+    public static class RetryGiveupException
+            extends ExecutionException
+    {
+        public RetryGiveupException(String message, Exception cause)
+        {
+            super(cause);
+        }
+
+        public RetryGiveupException(Exception cause)
+        {
+            super(cause);
+        }
+
+        public Exception getCause()
+        {
+            return (Exception) super.getCause();
+        }
+    }
+
+    public static interface Retryable<T>
+            extends Callable<T>
+    {
+        public T call()
+            throws Exception;
+
+        public boolean isRetryableException(Exception exception);
+
+        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+            throws RetryGiveupException;
+
+        public void onGiveup(Exception firstException, Exception lastException)
+            throws RetryGiveupException;
+    }
+
+    private final int retryLimit;
+    private final int initialRetryWait;
+    private final int maxRetryWait;
+
+    private RetryExecutor(int retryLimit, int initialRetryWait, int maxRetryWait)
+    {
+        this.retryLimit = retryLimit;
+        this.initialRetryWait = initialRetryWait;
+        this.maxRetryWait = maxRetryWait;
+    }
+
+    public RetryExecutor withRetryLimit(int count)
+    {
+        return new RetryExecutor(count, initialRetryWait, maxRetryWait);
+    }
+
+    public RetryExecutor withInitialRetryWait(int msec)
+    {
+        return new RetryExecutor(retryLimit, msec, maxRetryWait);
+    }
+
+    public RetryExecutor withMaxRetryWait(int msec)
+    {
+        return new RetryExecutor(retryLimit, initialRetryWait, msec);
+    }
+
+    public <T> T runInterruptible(Retryable<T> op)
+            throws InterruptedException, RetryGiveupException
+    {
+        return run(op, true);
+    }
+
+    public <T> T run(Retryable<T> op)
+            throws RetryGiveupException
+    {
+        try {
+            return run(op, false);
+        } catch (InterruptedException ex) {
+            throw new RetryGiveupException("Unexpected interruption", ex);
+        }
+    }
+
+    private <T> T run(Retryable<T> op, boolean interruptible)
+            throws InterruptedException, RetryGiveupException
+    {
+        int retryWait = initialRetryWait;
+        int retryCount = 0;
+
+        Exception firstException = null;
+
+        while(true) {
+            try {
+                return op.call();
+            } catch (Exception exception) {
+                if (firstException == null) {
+                    firstException = exception;
+                }
+                if (!op.isRetryableException(exception) || retryCount >= retryLimit) {
+                    op.onGiveup(firstException, exception);
+                    throw new RetryGiveupException(firstException);
+                }
+
+                retryCount++;
+                op.onRetry(exception, retryCount, retryLimit, retryWait);
+
+                try {
+                    Thread.sleep(retryWait);
+                } catch (InterruptedException ex) {
+                    if (interruptible) {
+                        throw ex;
+                    }
+                }
+
+                // exponential back-off with hard limit
+                retryWait *= 2;
+                if (retryWait > maxRetryWait) {
+                    retryWait = maxRetryWait;
+                }
+            }
+        }
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/util/RetryableInputStream.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/RetryableInputStream.java
@@ -1,0 +1,128 @@
+package org.embulk.spi.util;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+public class RetryableInputStream
+        extends InputStream
+{
+    public interface Reopener
+    {
+        public InputStream reopen(long offset, Exception closedCause) throws IOException;
+    }
+
+    private final Reopener reopener;
+    protected InputStream in;
+    private long offset;
+    private long markedOffset;
+
+    public RetryableInputStream(InputStream initialInputStream, Reopener reopener)
+    {
+        this.reopener = reopener;
+        this.in = initialInputStream;
+        this.offset = 0L;
+        this.markedOffset = 0L;
+    }
+
+    public RetryableInputStream(Reopener reopener) throws IOException
+    {
+        this(reopener.reopen(0, null), reopener);
+    }
+
+    private void reopen(Exception closedCause) throws IOException
+    {
+        if (in != null) {
+            in.close();
+            in = null;
+        }
+        in = reopener.reopen(offset, closedCause);
+    }
+
+    @Override
+    public int read() throws IOException
+    {
+        while (true) {
+            try {
+                int v = in.read();
+                offset += 1;
+                return v;
+            } catch (IOException | RuntimeException ex) {
+                reopen(ex);
+            }
+        }
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException
+    {
+        while (true) {
+            try {
+                int r = in.read(b);
+                offset += r;
+                return r;
+            } catch (IOException | RuntimeException ex) {
+                reopen(ex);
+            }
+        }
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException
+    {
+        while (true) {
+            try {
+                int r = in.read(b, off, len);
+                offset += r;
+                return r;
+            } catch (IOException | RuntimeException ex) {
+                reopen(ex);
+            }
+        }
+    }
+
+    @Override
+    public long skip(long n) throws IOException
+    {
+        while (true) {
+            try {
+                long r = in.skip(n);
+                offset += r;
+                return r;
+            } catch (IOException | RuntimeException ex) {
+                reopen(ex);
+            }
+        }
+    }
+
+    @Override
+    public int available() throws IOException
+    {
+        return in.available();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        in.close();
+    }
+
+    @Override
+    public void mark(int readlimit)
+    {
+        in.mark(readlimit);
+        markedOffset = offset;
+    }
+
+    @Override
+    public void reset() throws IOException
+    {
+        in.reset();
+        offset = markedOffset;
+    }
+
+    @Override
+    public boolean markSupported()
+    {
+        return in.markSupported();
+    }
+}


### PR DESCRIPTION
This pull-request add RetryExecutor and RetryableInputStream utility classes to org.embulk.spi.util package.
Originally I implemented them for private code. Then I ported them to embulk-input-s3 and embulk-input-ftp. They're generic useful utility classes for all file input plugins.
