### PR TITLE
Remove unnecessary `srcDirs` in embulk-core to fix import error in IntelliJ

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -1,10 +1,4 @@
 // include ruby scripts
-sourceSets {
-    main.resources {
-        srcDirs "${rootProject.projectDir}/lib"
-    }
-}
-
 configurations {
     // com.google.inject:guice depends on asm and cglib but version of the libraries conflict
     // with ones bundled in jruby-complete and cause bytecode compatibility error


### PR DESCRIPTION
I ran into the following import failure in IntelliJ.

```
2015-05-09 17:19:07,167 [607421007]   WARN - nal.AbstractExternalSystemTask - Can't register given path of type 'RESOURCE' because it's out of content root.
Content root: '/Users/komamitsu/Git/embulk/embulk-core'
Given path: '/Users/komamitsu/Git/embulk/lib'
com.intellij.openapi.externalSystem.model.ExternalSystemException: Can't register given path of type 'RESOURCE' because it's out of content root.
Content root: '/Users/komamitsu/Git/embulk/embulk-core'
Given path: '/Users/komamitsu/Git/embulk/lib'
    at org.jetbrains.plugins.gradle.service.project.AbstractProjectImportErrorHandler.createUserFriendlyError(AbstractProjectImportErrorHandler.java:106)
```

Removing `srdDirs` directive fixes this issue and `gradle install` command works well on console.