### PR TITLE
SchemaGuess doesn't guess 0 and 1 as boolean.

### DIFF
--- a/lib/embulk/guess/schema_guess.rb
+++ b/lib/embulk/guess/schema_guess.rb
@@ -87,7 +87,6 @@ module Embulk::Guess
         yes Yes YES
         t T y Y
         on On ON
-        1
       ].map {|k| [k, true] }]
 
       # When matching to false string, then retrun 'true'
@@ -96,7 +95,6 @@ module Embulk::Guess
         no No NO
         f N n N
         off Off OFF
-        0
       ].map {|k| [k, true] }]
 
       TYPE_COALESCE = Hash[{


### PR DESCRIPTION
It may cause too many wrong guesses. CSV parser still supports
converting 0/1 to boolean. So, this change affects only to guess.