### PR TITLE
Avoid ArrayIndexOutOfBoundsException of file input plugin

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/LocalFileInputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/LocalFileInputPlugin.java
@@ -81,8 +81,12 @@ public class LocalFileInputPlugin
 
         List<String> files = new ArrayList<String>(task.getFiles());
         Collections.sort(files);
-        return Exec.newConfigDiff().
-            set("last_path", files.get(files.size() - 1));
+        
+        ConfigDiff configDiff = Exec.newConfigDiff();
+        if (!files.isEmpty()) {
+            configDiff.set("last_path", files.get(files.size() - 1));
+        }
+        return configDiff;
     }
 
     @Override


### PR DESCRIPTION
If file input plug-in is selected with last_path parameter and no new file exists in path_prefix, following exception is thrown:

```
2015-05-27 23:02:04.246 +0900 [INFO] (transaction): Loading files []
java.lang.ArrayIndexOutOfBoundsException: -1
	at java.util.ArrayList.elementData(java/util/ArrayList.java:418)
	at java.util.ArrayList.get(java/util/ArrayList.java:431)
	at org.embulk.standards.LocalFileInputPlugin.resume(org/embulk/standards/LocalFileInputPlugin.java:84)
	at org.embulk.standards.LocalFileInputPlugin.transaction(org/embulk/standards/LocalFileInputPlugin.java:70)
	at org.embulk.spi.FileInputRunner.transaction(org/embulk/spi/FileInputRunner.java:63)
	at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:477)
	at org.embulk.exec.BulkLoader.access$100(org/embulk/exec/BulkLoader.java:36)
	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:342)
	at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:338)
	at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:24)
	at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:338)
	at org.embulk.command.Runner.run(org/embulk/command/Runner.java:148)
	at org.embulk.command.Runner.main(org/embulk/command/Runner.java:101)
	at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:483)
	at RUBY.run(file:/Users/myoshiz/.embulk/bin/embulk!/embulk/command/embulk_run.rb:339)
	at classpath_3a_embulk.command.embulk.(root)(classpath:embulk/command/embulk.rb:43)
	at classpath_3a_embulk.command.embulk.(root)(classpath_3a_embulk/command/classpath:embulk/command/embulk.rb:43)
	at org.embulk.cli.Main.main(org/embulk/cli/Main.java:11)

Error: -1
```

So I fixed LocalFileInputPlugin same as [Merge pull request #5 from embulk/fix_ArrayIndexOutOfBoundsException_… · embulk/embulk-input-s3@7d900d9 · GitHub](https://github.com/embulk/embulk-input-s3/commit/7d900d96785e6a707a432946c4d02e9e284ed3a2 "Merge pull request #5 from embulk/fix_ArrayIndexOutOfBoundsException_… · embulk/embulk-input-s3@7d900d9 · GitHub") and the exception was avoided as follows.

```
2015-05-27 23:19:24.054 +0900 [INFO] (transaction): Listing local files at directory '/Users/myoshiz/devel/try1/csv' filtering filename by prefix 'sample_'
2015-05-27 23:19:24.058 +0900 [INFO] (transaction): Loading files []
2015-05-27 23:19:24.117 +0900 [INFO] (main): Committed.
2015-05-27 23:19:24.117 +0900 [INFO] (main): Next config diff: {"in":{},"out":{}}
```