### PR TITLE
Added SwitchPageReader and SwitchPageBuilder utilities.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/type/BooleanType.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/BooleanType.java
@@ -1,5 +1,9 @@
 package org.embulk.spi.type;
 
+import org.embulk.spi.Column;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.PageReader;
+
 public class BooleanType
         extends AbstractType
 {
@@ -8,5 +12,70 @@ public class BooleanType
     private BooleanType()
     {
         super("boolean", boolean.class, 1);
+    }
+
+    public static class Sink
+            implements TypeSink
+    {
+        private final PageBuilder pageBuilder;
+        private final Column column;
+
+        public Sink(PageBuilder pageBuilder, Column column)
+        {
+            this.pageBuilder = pageBuilder;
+            this.column = column;
+        }
+
+        public void setNull()
+        {
+            pageBuilder.setNull(column);
+        }
+
+        public void setBoolean(boolean value)
+        {
+            pageBuilder.setBoolean(column, value);
+        }
+    }
+
+    private static class Source
+            implements TypeSource
+    {
+        private final PageReader pageReader;
+        private final Column column;
+
+        public Source(PageReader pageReader, Column column)
+        {
+            this.pageReader = pageReader;
+            this.column = column;
+        }
+
+        @Override
+        public void getTo(ValueConsumer consumer)
+        {
+            if (pageReader.isNull(column)) {
+                consumer.whenNull(column);
+            } else {
+                consumer.whenBoolean(column, pageReader.getBoolean(column));
+            }
+        }
+    }
+
+    @Override
+    public <C> TypeSinkCaller<C> newTypeSinkCaller(final ValueProducer<C> producer, PageBuilder pageBuilder, final Column column)
+    {
+        final Sink sink = new Sink(pageBuilder, column);
+        return new TypeSinkCaller<C>() {
+            @Override
+            public void call(C context)
+            {
+                producer.whenBoolean(context, column, sink);
+            }
+        };
+    }
+
+    @Override
+    public TypeSource newSource(PageReader pageReader, Column column)
+    {
+        return new Source(pageReader, column);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/type/DoubleType.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/DoubleType.java
@@ -1,5 +1,9 @@
 package org.embulk.spi.type;
 
+import org.embulk.spi.Column;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.PageReader;
+
 public class DoubleType
         extends AbstractType
 {
@@ -8,5 +12,70 @@ public class DoubleType
     private DoubleType()
     {
         super("double", double.class, 8);
+    }
+
+    public static class Sink
+            implements TypeSink
+    {
+        private final PageBuilder pageBuilder;
+        private final Column column;
+
+        public Sink(PageBuilder pageBuilder, Column column)
+        {
+            this.pageBuilder = pageBuilder;
+            this.column = column;
+        }
+
+        public void setNull()
+        {
+            pageBuilder.setNull(column);
+        }
+
+        public void setDouble(double value)
+        {
+            pageBuilder.setDouble(column, value);
+        }
+    }
+
+    private static class Source
+            implements TypeSource
+    {
+        private final PageReader pageReader;
+        private final Column column;
+
+        public Source(PageReader pageReader, Column column)
+        {
+            this.pageReader = pageReader;
+            this.column = column;
+        }
+
+        @Override
+        public void getTo(ValueConsumer consumer)
+        {
+            if (pageReader.isNull(column)) {
+                consumer.whenNull(column);
+            } else {
+                consumer.whenDouble(column, pageReader.getDouble(column));
+            }
+        }
+    }
+
+    @Override
+    public <C> TypeSinkCaller<C> newTypeSinkCaller(final ValueProducer<C> producer, PageBuilder pageBuilder, final Column column)
+    {
+        final Sink sink = new Sink(pageBuilder, column);
+        return new TypeSinkCaller<C>() {
+            @Override
+            public void call(C context)
+            {
+                producer.whenDouble(context, column, sink);
+            }
+        };
+    }
+
+    @Override
+    public TypeSource newSource(PageReader pageReader, Column column)
+    {
+        return new Source(pageReader, column);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/type/LongType.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/LongType.java
@@ -1,5 +1,9 @@
 package org.embulk.spi.type;
 
+import org.embulk.spi.Column;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.PageReader;
+
 public class LongType
         extends AbstractType
 {
@@ -8,5 +12,70 @@ public class LongType
     private LongType()
     {
         super("long", long.class, 8);
+    }
+
+    public static class Sink
+            implements TypeSink
+    {
+        private final PageBuilder pageBuilder;
+        private final Column column;
+
+        public Sink(PageBuilder pageBuilder, Column column)
+        {
+            this.pageBuilder = pageBuilder;
+            this.column = column;
+        }
+
+        public void setNull()
+        {
+            pageBuilder.setNull(column);
+        }
+
+        public void setLong(long value)
+        {
+            pageBuilder.setLong(column, value);
+        }
+    }
+
+    private static class Source
+            implements TypeSource
+    {
+        private final PageReader pageReader;
+        private final Column column;
+
+        public Source(PageReader pageReader, Column column)
+        {
+            this.pageReader = pageReader;
+            this.column = column;
+        }
+
+        @Override
+        public void getTo(ValueConsumer consumer)
+        {
+            if (pageReader.isNull(column)) {
+                consumer.whenNull(column);
+            } else {
+                consumer.whenLong(column, pageReader.getLong(column));
+            }
+        }
+    }
+
+    @Override
+    public <C> TypeSinkCaller<C> newTypeSinkCaller(final ValueProducer<C> producer, PageBuilder pageBuilder, final Column column)
+    {
+        final Sink sink = new Sink(pageBuilder, column);
+        return new TypeSinkCaller<C>() {
+            @Override
+            public void call(C context)
+            {
+                producer.whenLong(context, column, sink);
+            }
+        };
+    }
+
+    @Override
+    public TypeSource newSource(PageReader pageReader, Column column)
+    {
+        return new Source(pageReader, column);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/type/StringType.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/StringType.java
@@ -1,5 +1,9 @@
 package org.embulk.spi.type;
 
+import org.embulk.spi.Column;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.PageReader;
+
 public class StringType
         extends AbstractType
 {
@@ -8,5 +12,70 @@ public class StringType
     private StringType()
     {
         super("string", String.class, 4);
+    }
+
+    public static class Sink
+            implements TypeSink
+    {
+        private final PageBuilder pageBuilder;
+        private final Column column;
+
+        public Sink(PageBuilder pageBuilder, Column column)
+        {
+            this.pageBuilder = pageBuilder;
+            this.column = column;
+        }
+
+        public void setNull()
+        {
+            pageBuilder.setNull(column);
+        }
+
+        public void setString(String value)
+        {
+            pageBuilder.setString(column, value);
+        }
+    }
+
+    private static class Source
+            implements TypeSource
+    {
+        private final PageReader pageReader;
+        private final Column column;
+
+        public Source(PageReader pageReader, Column column)
+        {
+            this.pageReader = pageReader;
+            this.column = column;
+        }
+
+        @Override
+        public void getTo(ValueConsumer consumer)
+        {
+            if (pageReader.isNull(column)) {
+                consumer.whenNull(column);
+            } else {
+                consumer.whenString(column, pageReader.getString(column));
+            }
+        }
+    }
+
+    @Override
+    public <C> TypeSinkCaller<C> newTypeSinkCaller(final ValueProducer<C> producer, PageBuilder pageBuilder, final Column column)
+    {
+        final Sink sink = new Sink(pageBuilder, column);
+        return new TypeSinkCaller<C>() {
+            @Override
+            public void call(C context)
+            {
+                producer.whenString(context, column, sink);
+            }
+        };
+    }
+
+    @Override
+    public TypeSource newSource(PageReader pageReader, Column column)
+    {
+        return new Source(pageReader, column);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/type/TimestampType.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/TimestampType.java
@@ -1,6 +1,9 @@
 package org.embulk.spi.type;
 
 import org.embulk.spi.time.Timestamp;
+import org.embulk.spi.Column;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.PageReader;
 
 public class TimestampType
         extends AbstractType
@@ -35,5 +38,70 @@ public class TimestampType
         } else {
             return format;
         }
+    }
+
+    public static class Sink
+            implements TypeSink
+    {
+        private final PageBuilder pageBuilder;
+        private final Column column;
+
+        public Sink(PageBuilder pageBuilder, Column column)
+        {
+            this.pageBuilder = pageBuilder;
+            this.column = column;
+        }
+
+        public void setNull()
+        {
+            pageBuilder.setNull(column);
+        }
+
+        public void setTimestamp(Timestamp value)
+        {
+            pageBuilder.setTimestamp(column, value);
+        }
+    }
+
+    private static class Source
+            implements TypeSource
+    {
+        private final PageReader pageReader;
+        private final Column column;
+
+        public Source(PageReader pageReader, Column column)
+        {
+            this.pageReader = pageReader;
+            this.column = column;
+        }
+
+        @Override
+        public void getTo(ValueConsumer consumer)
+        {
+            if (pageReader.isNull(column)) {
+                consumer.whenNull(column);
+            } else {
+                consumer.whenTimestamp(column, pageReader.getTimestamp(column));
+            }
+        }
+    }
+
+    @Override
+    public <C> TypeSinkCaller<C> newTypeSinkCaller(final ValueProducer<C> producer, PageBuilder pageBuilder, final Column column)
+    {
+        final Sink sink = new Sink(pageBuilder, column);
+        return new TypeSinkCaller<C>() {
+            @Override
+            public void call(C context)
+            {
+                producer.whenTimestamp(context, column, sink);
+            }
+        };
+    }
+
+    @Override
+    public TypeSource newSource(PageReader pageReader, Column column)
+    {
+        return new Source(pageReader, column);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/type/Type.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/Type.java
@@ -2,6 +2,9 @@ package org.embulk.spi.type;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.embulk.spi.Column;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.PageReader;
 
 @JsonDeserialize(using=TypeDeserializer.class)
 public interface Type
@@ -12,4 +15,8 @@ public interface Type
     public Class<?> getJavaType();
 
     public byte getFixedStorageSize();
+
+    public <C> TypeSinkCaller<C> newTypeSinkCaller(final ValueProducer<C> producer, PageBuilder pageBuilder, Column column);
+
+    public TypeSource newSource(PageReader pageReader, Column column);
 }

--- a/embulk-core/src/main/java/org/embulk/spi/type/TypeSink.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/TypeSink.java
@@ -1,0 +1,5 @@
+package org.embulk.spi.type;
+
+public interface TypeSink
+{
+}

--- a/embulk-core/src/main/java/org/embulk/spi/type/TypeSinkCaller.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/TypeSinkCaller.java
@@ -1,0 +1,6 @@
+package org.embulk.spi.type;
+
+public interface TypeSinkCaller <T>
+{
+    public void call(T context);
+}

--- a/embulk-core/src/main/java/org/embulk/spi/type/TypeSource.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/TypeSource.java
@@ -1,0 +1,6 @@
+package org.embulk.spi.type;
+
+public interface TypeSource
+{
+    public void getTo(ValueConsumer consumer);
+}

--- a/embulk-core/src/main/java/org/embulk/spi/type/ValueConsumer.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/ValueConsumer.java
@@ -1,0 +1,21 @@
+package org.embulk.spi.type;
+
+import org.embulk.spi.Column;
+import org.embulk.spi.type.LongType;
+import org.embulk.spi.type.StringType;
+import org.embulk.spi.time.Timestamp;
+
+public interface ValueConsumer
+{
+    public void whenNull(Column column);
+
+    public void whenBoolean(Column column, boolean value);
+
+    public void whenLong(Column column, long value);
+
+    public void whenDouble(Column column, double value);
+
+    public void whenString(Column column, String value);
+
+    public void whenTimestamp(Column column, Timestamp value);
+}

--- a/embulk-core/src/main/java/org/embulk/spi/type/ValueProducer.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/ValueProducer.java
@@ -1,0 +1,21 @@
+package org.embulk.spi.type;
+
+import org.embulk.spi.Column;
+import org.embulk.spi.type.LongType;
+import org.embulk.spi.type.BooleanType;
+import org.embulk.spi.type.DoubleType;
+import org.embulk.spi.type.StringType;
+import org.embulk.spi.type.TimestampType;
+
+public interface ValueProducer <C>
+{
+    public void whenBoolean(C context, Column column, BooleanType.Sink sink);
+
+    public void whenLong(C context, Column column, LongType.Sink sink);
+
+    public void whenDouble(C context, Column column, DoubleType.Sink sink);
+
+    public void whenString(C context, Column column, StringType.Sink sink);
+
+    public void whenTimestamp(C context, Column column, TimestampType.Sink sink);
+}

--- a/embulk-core/src/main/java/org/embulk/spi/util/ColumnSwitch.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/ColumnSwitch.java
@@ -1,0 +1,23 @@
+package org.embulk.spi.util;
+
+import org.embulk.spi.Column;
+import org.embulk.spi.type.ValueProducer;
+import org.embulk.spi.type.LongType;
+import org.embulk.spi.type.BooleanType;
+import org.embulk.spi.type.DoubleType;
+import org.embulk.spi.type.StringType;
+import org.embulk.spi.type.TimestampType;
+
+public abstract class ColumnSwitch <C>
+        implements ValueProducer<C>
+{
+    public abstract void whenBoolean(C context, Column column, BooleanType.Sink sink);
+
+    public abstract void whenLong(C context, Column column, LongType.Sink sink);
+
+    public abstract void whenDouble(C context, Column column, DoubleType.Sink sink);
+
+    public abstract void whenString(C context, Column column, StringType.Sink sink);
+
+    public abstract void whenTimestamp(C context, Column column, TimestampType.Sink sink);
+}

--- a/embulk-core/src/main/java/org/embulk/spi/util/SwitchPageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/SwitchPageBuilder.java
@@ -1,0 +1,60 @@
+package org.embulk.spi.util;
+
+import java.util.List;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
+import org.embulk.spi.Schema;
+import org.embulk.spi.Column;
+import org.embulk.spi.BufferAllocator;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.type.TypeSinkCaller;
+import org.embulk.spi.type.ValueProducer;
+
+public class SwitchPageBuilder <C>
+        implements AutoCloseable
+{
+    private final PageBuilder pageBuilder;
+    private final ColumnSwitch<C> producer;
+    private final List<TypeSinkCaller<C>> callers;
+
+    public SwitchPageBuilder(BufferAllocator allocator, Schema schema, PageOutput output, ColumnSwitch<C> producer)
+    {
+        this.pageBuilder = new PageBuilder(allocator, schema, output);
+        this.producer = producer;
+        this.callers = ImmutableList.copyOf(Lists.transform(
+                    schema.getColumns(), new Function<Column, TypeSinkCaller<C>>()
+                    {
+                        public TypeSinkCaller<C> apply(Column column)
+                        {
+                            return findSwitchCaseCaller(column, pageBuilder, (ColumnSwitch<C>) SwitchPageBuilder.this.producer);
+                        }
+                    }
+                ));
+    }
+
+    public SwitchPageBuilder<C> apply(C context)
+    {
+        for (TypeSinkCaller<C> caller : callers) {
+            caller.call(context);
+        }
+        return this;
+    }
+
+    public void addRecord()
+    {
+        pageBuilder.addRecord();
+    }
+
+    @Override
+    public void close()
+    {
+        pageBuilder.close();
+    }
+
+    private static <C> TypeSinkCaller<C> findSwitchCaseCaller(Column column, PageBuilder pageBuilder, ColumnSwitch<C> valueProducer)
+    {
+        return column.getType().newTypeSinkCaller(valueProducer, pageBuilder, column);
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/util/SwitchPageReader.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/SwitchPageReader.java
@@ -1,0 +1,74 @@
+package org.embulk.spi.util;
+
+import java.util.List;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
+import org.embulk.spi.Page;
+import org.embulk.spi.Schema;
+import org.embulk.spi.Column;
+import org.embulk.spi.PageReader;
+import org.embulk.spi.type.TypeSource;
+import org.embulk.spi.type.ValueConsumer;
+
+public class SwitchPageReader
+    implements AutoCloseable
+{
+    private static class TypeSourceCaller
+    {
+        private final TypeSource source;
+        private final ValueConsumer consumer;
+
+        public TypeSourceCaller(TypeSource source, ValueConsumer consumer)
+        {
+            this.source = source;
+            this.consumer = consumer;
+        }
+
+        public void call()
+        {
+            source.getTo(consumer);
+        }
+    }
+
+    private final PageReader pageReader;
+    private final ValueSwitch consumer;
+    private final List<TypeSourceCaller> callers;
+
+    public SwitchPageReader(Schema schema, ValueSwitch consumer)
+    {
+        this.pageReader = new PageReader(schema);
+        this.consumer = consumer;
+        this.callers = ImmutableList.copyOf(Lists.transform(
+                    schema.getColumns(), new Function<Column, TypeSourceCaller>()
+                    {
+                        public TypeSourceCaller apply(Column column)
+                        {
+                            return findSwitchCaseCaller(column, pageReader, SwitchPageReader.this.consumer);
+                        }
+                    }
+                ));
+    }
+
+    public void read(Page page)
+    {
+        pageReader.setPage(page);
+        while (pageReader.nextRecord()) {
+            for (TypeSourceCaller caller : callers) {
+                caller.call();
+            }
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        pageReader.close();
+    }
+
+    private static TypeSourceCaller findSwitchCaseCaller(Column column, PageReader pageReader, ValueSwitch consumer)
+    {
+        TypeSource source = column.getType().newSource(pageReader, column);
+        return new TypeSourceCaller(source, consumer);
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/util/ValueSwitch.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/ValueSwitch.java
@@ -1,0 +1,38 @@
+package org.embulk.spi.util;
+
+import org.embulk.spi.Column;
+import org.embulk.spi.type.ValueConsumer;
+import org.embulk.spi.time.Timestamp;
+
+public abstract class ValueSwitch
+        implements ValueConsumer
+{
+    public abstract void whenNull(Column column);
+
+    public abstract void whenElse(Column column, Object value);
+
+    public void whenBoolean(Column column, boolean value)
+    {
+        whenElse(column, value);
+    }
+
+    public void whenLong(Column column, long value)
+    {
+        whenElse(column, value);
+    }
+
+    public void whenDouble(Column column, double value)
+    {
+        whenElse(column, value);
+    }
+
+    public void whenString(Column column, String value)
+    {
+        whenElse(column, value);
+    }
+
+    public void whenTimestamp(Column column, Timestamp value)
+    {
+        whenElse(column, value);
+    }
+}


### PR DESCRIPTION
The goal is to make type system extensible without breaking plugin API
compatibility.

* SwitchPageReader calls ValueSwitch#whenXxx methods where Xxx is name
  of a type. If a plugin does not know type Xxx, whenElse method is
  called. Plugins must implement whenElse and whenNull methods at least.
* SwitchPageBuilder calls ColumnSwitch#whenXxx methods where Xxx is name
  of a type. If a plugin does not implement those methods, calling those
  methods cause a exception. But as long as the methods are not called,
  plugin loading itself succeeds and plugin runs without exception.

The next step is to add array/map/json/decimal type support (#120).
