### PR TITLE
Implement selfrun.sh for Windows

### DIFF
--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -14,22 +14,13 @@ set status=
 set error=
 set args=
 
-:loop
+rem In jar file, cannot goto ahread for some reason.
+
 for %%a in ( %* ) do (
     call :check_arg %%a
 )
 
 if "%error%" == "true" exit /b 1
-
-rem :read
-rem 
-rem for /f "delims=" %%i in (%~2) do set java_args=%java_args% %%i
-rem shift
-rem shift
-rem 
-rem goto loop
-
-:end
 
 set optimize=false
 if "%overwrite_optimize%" == "true" (
@@ -55,7 +46,15 @@ endlocal
 exit /b
 
 :check_arg
-set arg=%1
+set arg=%*
+
+rem Remove double quotations
+set p1=%arg:~0,1%
+set p1=%p1:"=%
+set p2=%arg:~-1,1%
+set p2=%p2:"=%
+set arg=%p1%%arg:~1,-1%%p2%
+
 if "%status%" == "rest" (
     set args=%args% %arg%
     

--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -5,7 +5,6 @@
 setlocal
 
 set this=%~f0
-echo %this%
 set java_args=
 set jruby_args=
 set default_optimize=

--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -2,7 +2,91 @@
 : <<BAT
 @echo off
 
-java -jar %~f0 %*
+setlocal
+
+set this=%0
+set java_args=
+set jruby_args=
+set default_optimize=
+set overwrite_optimize=
+
+:loop
+    set temp=%~1
+    if "%temp%" == "-J+O" (
+        set overwrite_optimize=true
+        shift
+        goto end
+        
+    ) else if "%temp%" == "-J-O" (
+        set overwrite_optimize=false
+        shift
+        goto end
+        
+    ) else if "%temp:~0,2%" == "-J" (
+        if not "%temp:~2%" == "" (
+            set java_args=%java_args% %temp:~2%
+        ) else (
+            if not exist "%~2" (
+                echo "failed to load java argument file."
+                exit /b 1
+            )
+            goto read
+        )
+        shift
+        goto loop
+        
+    ) else if "%temp:~0,2%" == "-R" (
+        set jruby_args=%jruby_args% %temp:~2%
+        shift
+        goto loop
+        
+    ) else if "%temp%" == "run" (
+        set default_optimize=true
+        goto end
+        
+    ) else (
+        goto end
+    )
+    
+:read
+
+for /f "delims=" %%i in (%~2) do set java_args=%java_args% %%i
+shift
+shift
+
+goto loop
+
+:end
+
+rem "%*" is not changed by 'shift'
+set args=
+:loop2
+    if "%~1" == "" goto end2
+    set args=%args% %~1
+    shift
+    goto loop2
+:end2
+
+set optimize=false
+if "%overwrite_optimize%" == "true" (
+    set optimize=true
+) else (
+    if "%default_optimize%" == "true" (
+        if not "%overwrite_optimize%" == "false" (
+            set optimize=true
+        )
+    )
+)
+
+if "%optimize%" == "true" (
+    set java_args=-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC %java_args%
+) else (
+    set java_args=-XX:+AggressiveOpts -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none %java_args%
+)
+
+java %java_args% -jar %this% %jruby_args% %args% 
+
+endlocal
 
 exit /B
 BAT

--- a/embulk-cli/src/test/java/org/embulk/cli/DummyMain.java
+++ b/embulk-cli/src/test/java/org/embulk/cli/DummyMain.java
@@ -1,0 +1,18 @@
+package org.embulk.cli;
+
+import java.io.File;
+import java.io.FileWriter;
+
+public class DummyMain {
+
+    public static void main(String[] args) throws Exception {
+        File thisFolder = new File(SelfrunTest.class.getResource("/org/embulk/cli/DummyMain.class").toURI()).getParentFile();
+        try (FileWriter writer = new FileWriter(new File(thisFolder, "args.txt"))) {
+            for (String arg : args) {
+                writer.write(arg);
+                writer.write(System.getProperty("line.separator"));
+            }
+        }
+    }
+
+}

--- a/embulk-cli/src/test/java/org/embulk/cli/DummyMain.java
+++ b/embulk-cli/src/test/java/org/embulk/cli/DummyMain.java
@@ -2,10 +2,12 @@ package org.embulk.cli;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.util.Arrays;
 
 public class DummyMain {
 
     public static void main(String[] args) throws Exception {
+        System.out.println(Arrays.asList(args));
         File thisFolder = new File(SelfrunTest.class.getResource("/org/embulk/cli/DummyMain.class").toURI()).getParentFile();
         try (FileWriter writer = new FileWriter(new File(thisFolder, "args.txt"))) {
             for (String arg : args) {

--- a/embulk-cli/src/test/java/org/embulk/cli/DummyMain.java
+++ b/embulk-cli/src/test/java/org/embulk/cli/DummyMain.java
@@ -1,7 +1,10 @@
 package org.embulk.cli;
 
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 public class DummyMain {
@@ -9,10 +12,10 @@ public class DummyMain {
     public static void main(String[] args) throws Exception {
         System.out.println(Arrays.asList(args));
         File thisFolder = new File(SelfrunTest.class.getResource("/org/embulk/cli/DummyMain.class").toURI()).getParentFile();
-        try (FileWriter writer = new FileWriter(new File(thisFolder, "args.txt"))) {
+        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(new File(thisFolder, "args.txt")), Charset.defaultCharset()))) {
             for (String arg : args) {
                 writer.write(arg);
-                writer.write(System.getProperty("line.separator"));
+                writer.newLine();
             }
         }
     }

--- a/embulk-cli/src/test/java/org/embulk/cli/SelfrunTest.java
+++ b/embulk-cli/src/test/java/org/embulk/cli/SelfrunTest.java
@@ -14,6 +14,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+
+// 原因不明だが、jarに組み込むと動かない
+// 前のラベルに戻るgotoができない
+// バイナリ部分が何か影響している模様
 public class SelfrunTest {
 
     private static File testSelfrun;

--- a/embulk-cli/src/test/java/org/embulk/cli/SelfrunTest.java
+++ b/embulk-cli/src/test/java/org/embulk/cli/SelfrunTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class SelfrunTest {
 
@@ -25,6 +26,7 @@ public class SelfrunTest {
 
         File thisFolder = new File(SelfrunTest.class.getResource("/org/embulk/cli/SelfrunTest.class").toURI()).getParentFile();
         testSelfrun = new File(thisFolder, System.getProperty("file.separator").equals("\\") ? "selfrun.bat" : "selfrun.sh");
+        testSelfrun.setExecutable(true);
 
         File classpath = thisFolder.getParentFile().getParentFile().getParentFile();
         line = line.replaceAll("java ", "java -classpath " + classpath.getAbsolutePath().replaceAll("\\\\", "\\\\\\\\") + " org.embulk.cli.DummyMain ");
@@ -35,10 +37,192 @@ public class SelfrunTest {
 
 
     @Test
-    public void test() throws Exception {
-        System.out.println(execute());
+    public void testNoArgument() throws Exception {
+        List<String> args = execute();
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+TieredCompilation",
+                "-XX:TieredStopAtLevel=1",
+                "-Xverify:none",
+                "-jar",
+                testSelfrun.getAbsolutePath()),
+                args);
     }
 
+    @Test
+    public void testArguments() throws Exception {
+        List<String> args = execute("a1", "a2");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+TieredCompilation",
+                "-XX:TieredStopAtLevel=1",
+                "-Xverify:none",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "a1",
+                "a2"),
+                args);
+    }
+
+    @Test
+    public void testRun() throws Exception {
+        List<String> args = execute("run", "a1");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+UseConcMarkSweepGC",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "run",
+                "a1"),
+                args);
+    }
+
+    @Test
+    public void testJpO() throws Exception {
+        List<String> args = execute("-J+O", "a1", "a2");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+UseConcMarkSweepGC",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "a1",
+                "a2"),
+                args);
+    }
+
+    @Test
+    public void testJmO() throws Exception {
+        List<String> args = execute("-J-O", "a1", "a2");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+TieredCompilation",
+                "-XX:TieredStopAtLevel=1",
+                "-Xverify:none",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "a1",
+                "a2"),
+                args);
+    }
+
+    @Test
+    public void testR1() throws Exception {
+        List<String> args = execute("-Rr1", "a1", "a2");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+TieredCompilation",
+                "-XX:TieredStopAtLevel=1",
+                "-Xverify:none",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "r1",
+                "a1",
+                "a2"),
+                args);
+    }
+
+    @Test
+    public void testR2() throws Exception {
+        List<String> args = execute("-Rr1", "-Rr2", "a1", "a2");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+TieredCompilation",
+                "-XX:TieredStopAtLevel=1",
+                "-Xverify:none",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "r1",
+                "r2",
+                "a1",
+                "a2"),
+                args);
+    }
+
+    @Test
+    public void testRRun() throws Exception {
+        List<String> args = execute("-Rr1", "run", "a1");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+UseConcMarkSweepGC",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "r1",
+                "run",
+                "a1"),
+                args);
+    }
+
+    @Test
+    public void testJ1() throws Exception {
+        List<String> args = execute("-Jj1", "a1", "a2");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+TieredCompilation",
+                "-XX:TieredStopAtLevel=1",
+                "-Xverify:none",
+                "j1",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "a1",
+                "a2"),
+                args);
+    }
+
+    @Test
+    public void testJ2() throws Exception {
+        List<String> args = execute("-Jj1", "-Jj2", "a1", "a2");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+TieredCompilation",
+                "-XX:TieredStopAtLevel=1",
+                "-Xverify:none",
+                "j1",
+                "j2",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "a1",
+                "a2"),
+                args);
+    }
+
+    @Test
+    public void testJR() throws Exception {
+        List<String> args = execute("-Jj1", "-Rr1", "a1", "a2");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+TieredCompilation",
+                "-XX:TieredStopAtLevel=1",
+                "-Xverify:none",
+                "j1",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "r1",
+                "a1",
+                "a2"),
+                args);
+    }
+
+    @Test
+    public void testJFile() throws Exception {
+        File javaArgsFile = new File(testSelfrun.getParentFile(), "java_args.txt");
+        FileSystem fs = FileSystems.getDefault();
+        Files.write(fs.getPath(javaArgsFile.getAbsolutePath()), "j1 j2 j3".getBytes(), StandardOpenOption.CREATE);
+
+        List<String> args = execute("-J", javaArgsFile.getAbsolutePath(), "a1", "a2");
+        assertEquals(Arrays.asList(
+                "-XX:+AggressiveOpts",
+                "-XX:+TieredCompilation",
+                "-XX:TieredStopAtLevel=1",
+                "-Xverify:none",
+                "j1",
+                "j2",
+                "j3",
+                "-jar",
+                testSelfrun.getAbsolutePath(),
+                "a1",
+                "a2"),
+                args);
+    }
 
     private List<String> execute(String... arguments) throws Exception {
         List<String> commands = new ArrayList<String>();
@@ -48,8 +232,9 @@ public class SelfrunTest {
         process.waitFor();
 
         FileSystem fs = FileSystems.getDefault();
-        File args = new File(testSelfrun.getParentFile(), "args.txt");
-        return Files.readAllLines(fs.getPath(args.getAbsolutePath()), Charset.defaultCharset());
+        File argsFile = new File(testSelfrun.getParentFile(), "args.txt");
+        List<String> args = Files.readAllLines(fs.getPath(argsFile.getAbsolutePath()), Charset.defaultCharset());
+        return args;
     }
 
     private static File findSelfrun() {

--- a/embulk-cli/src/test/java/org/embulk/cli/SelfrunTest.java
+++ b/embulk-cli/src/test/java/org/embulk/cli/SelfrunTest.java
@@ -1,0 +1,63 @@
+package org.embulk.cli;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SelfrunTest {
+
+    private static File testSelfrun;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        File selfrun = findSelfrun();
+        FileSystem fs = FileSystems.getDefault();
+        String line = new String(Files.readAllBytes(fs.getPath(selfrun.getAbsolutePath())), Charset.defaultCharset());
+
+        File thisFolder = new File(SelfrunTest.class.getResource("/org/embulk/cli/SelfrunTest.class").toURI()).getParentFile();
+        testSelfrun = new File(thisFolder, System.getProperty("file.separator").equals("\\") ? "selfrun.bat" : "selfrun.sh");
+
+        File classpath = thisFolder.getParentFile().getParentFile().getParentFile();
+        line = line.replaceAll("java ", "java -classpath " + classpath.getAbsolutePath().replaceAll("\\\\", "\\\\\\\\") + " org.embulk.cli.DummyMain ");
+
+        // Modify selfrun so that arguments are written in 'args.txt' .
+        Files.write(fs.getPath(testSelfrun.getAbsolutePath()), line.getBytes(Charset.defaultCharset()), StandardOpenOption.CREATE);
+    }
+
+
+    @Test
+    public void test() throws Exception {
+        System.out.println(execute());
+    }
+
+
+    private List<String> execute(String... arguments) throws Exception {
+        List<String> commands = new ArrayList<String>();
+        commands.add(testSelfrun.getAbsolutePath());
+        commands.addAll(Arrays.asList(arguments));
+        Process process = Runtime.getRuntime().exec(commands.toArray(new String[commands.size()]));
+        process.waitFor();
+
+        FileSystem fs = FileSystems.getDefault();
+        File args = new File(testSelfrun.getParentFile(), "args.txt");
+        return Files.readAllLines(fs.getPath(args.getAbsolutePath()), Charset.defaultCharset());
+    }
+
+    private static File findSelfrun() {
+        File folder = new File(".");
+        if (new File(folder, "embulk-cli").exists()) {
+            folder = new File(folder, "embulk-cli");
+        }
+        return new File(new File(new File(new File(folder, "src"), "main"), "sh"), "selfrun.sh");
+    }
+
+}


### PR DESCRIPTION
The Windows version is not completely same as the Linux version.
If an argument contains '=', it should be enclosed by double quotations, because otherwise the left side and the right side are divided as two arguments in the bat program.

<pre>
embulk.bat "-J-Dembulk.max_threads=1" run mysql.yml
</pre>