### PR TITLE
Improve warning if failed to parse timestamp.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParseException.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParseException.java
@@ -3,4 +3,8 @@ package org.embulk.spi.time;
 public class TimestampParseException
         extends Exception
 {
+    public TimestampParseException(String message)
+    {
+        super(message);
+    }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
@@ -54,7 +54,7 @@ public class TimestampParser
             // TODO cache parsed zone?
             timeZone = parseDateTimeZone(zone);
             if (timeZone == null) {
-                throw new TimestampParseException();
+                throw new TimestampParseException("No timezone in '" + text + "'");
             }
         }
 

--- a/lib/embulk/java/time_helper.rb
+++ b/lib/embulk/java/time_helper.rb
@@ -26,7 +26,7 @@ module Embulk
       def strptimeUsec(text)
         hash = Date._strptime(text, @format_string)
         unless hash
-          raise Java::TimestampParseException.new
+          raise Java::TimestampParseException.new("Failed to parse '" + text + "'")
         end
 
         if seconds = hash[:seconds]


### PR DESCRIPTION
When preview, I sometimes get warning as below. 
The root cause of the warning is broken data, but I think the messages is not clear.

```
2015-06-11 07:15:59.911 +0000 [WARN] (preview): Skipped line 7 (org.embulk.spi.time.TimestampParseException): abadijo01,1854,11,4,USA,PA,Philadelphia,1905,5,17,USA,NJ,Pemberton,John,Abadie,John W.,192,72,R,R,1875-04-26,1875-06-10,abadj101,abadijo01
```

The change improves it.

```
2015-06-11 07:58:23.784 +0000 [WARN] (preview): Skipped line 7 (org.embulk.spi.time.TimestampParseException: Failed to parse '1875-04-26'): abadijo01,1854,11,4,USA,PA,Philadelphia,1905,5,17,USA,NJ,Pemberton,John,Abadie,John W.,192,72,R,R,1875-04-26,1875-06-10,abadj101,abadijo01
```
