### PR TITLE
GuessExecutor skips files smaller than 40 bytes.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
@@ -139,7 +139,7 @@ public class GuessExecutor
             ConfigSource originalConfig = config.deepCopy().merge(lastGuessed);
             ConfigSource guessInputConfig = originalConfig.deepCopy();
             guessInputConfig.getNestedOrSetEmpty("parser")
-                .set("type", "system_guess")  // override in.parser.type so that FileInputPlugin creates GuessParserPlugin
+                .set("type", "system_guess")  // override in.parser.type so that FileInputRunner.run uses GuessParserPlugin
                 .set("guess_plugins", guessPlugins)
                 .set("orig_config", originalConfig);
 
@@ -153,7 +153,6 @@ public class GuessExecutor
                         if (taskCount == 0) {
                             throw new NoSampleException("No input files to guess");
                         }
-                        // TODO repeat runwith taskIndex++ if NoSampleException happens
                         input.run(inputTaskSource, null, 0, new PageOutput() {
                             @Override
                             public void add(Page page)
@@ -170,6 +169,7 @@ public class GuessExecutor
                         throw new AssertionError("Guess executor must throw GuessedNoticeError");
                     }
                 });
+
                 throw new AssertionError("Guess executor must throw GuessedNoticeError");
 
             } catch (GuessedNoticeError error) {
@@ -319,6 +319,7 @@ public class GuessExecutor
 
         private static Buffer getFirstBuffer(FileInput input)
         {
+            // The first buffer is created by SamplingParserPlugin. See FileInputRunner.guess.
             RuntimeException decodeException = null;
             try {
                 while (input.nextFile()) {

--- a/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
@@ -2,6 +2,7 @@ package org.embulk.exec;
 
 import java.util.List;
 import com.google.inject.Inject;
+import com.google.common.base.Preconditions;
 import org.embulk.config.TaskSource;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.CommitReport;
@@ -24,31 +25,9 @@ import static org.embulk.spi.util.Inputs.each;
 public class SamplingParserPlugin
         implements ParserPlugin
 {
-    private final int maxSampleSize;
-
-    @Inject
-    public SamplingParserPlugin(@ForSystemConfig ConfigSource systemConfig)
-    {
-        this.maxSampleSize = 32*1024;  // TODO get sample syze from system config
-    }
-
-    @Override
-    public void transaction(ConfigSource config, ParserPlugin.Control control)
-    {
-        control.run(Exec.newTaskSource(), null);
-    }
-
-    @Override
-    public void run(TaskSource taskSource, Schema schema,
-            FileInput input, PageOutput output)
-    {
-        Buffer buffer = getSample(input, maxSampleSize);
-        throw new SampledNoticeError(buffer);
-    }
-
     public static Buffer runFileInputSampling(final FileInputRunner runner, ConfigSource inputConfig)
     {
-        // override in.parser.type so that FileInputRunner creates GuessParserPlugin
+        // override in.parser.type so that FileInputRunner creates SamplingParserPlugin
         ConfigSource samplingInputConfig = inputConfig.deepCopy();
         samplingInputConfig.getNestedOrSetEmpty("parser").set("type", "system_sampling");
         samplingInputConfig.set("decoders", null);
@@ -60,48 +39,31 @@ public class SamplingParserPlugin
                     if (taskCount == 0) {
                         throw new NoSampleException("No input files to read sample data");
                     }
-                    // TODO repeat runwith taskIndex++ if NoSampleException happens
-                    runner.run(taskSource, schema, 0, new PageOutput() {
-                        @Override
-                        public void add(Page page)
-                        {
-                            throw new RuntimeException("Input plugin must be a FileInputPlugin to guess parser configuration");  // TODO exception class
+                    for (int taskIndex=0; taskIndex < taskCount; taskIndex++) {
+                        try {
+                            runner.run(taskSource, schema, taskIndex, new PageOutput() {
+                                @Override
+                                public void add(Page page)
+                                {
+                                    throw new RuntimeException("Input plugin must be a FileInputPlugin to guess parser configuration");  // TODO exception class
+                                }
+
+                                public void finish() { }
+
+                                public void close() { }
+                            });
+                        } catch (NotEnoughSampleError ex) {
+                            continue;
                         }
-
-                        public void finish() { }
-
-                        public void close() { }
-                    });
-                    throw new NoSampleException("No input files to guess parser configuration");
+                    }
+                    throw new NoSampleException("All input files are smaller than minimum sampling size");  // TODO include minSampleSize in message
                 }
             });
             throw new AssertionError("SamplingParserPlugin must throw SampledNoticeError");
         } catch (SampledNoticeError error) {
+            System.out.println("using sample buffer - size: "+error.getSample().limit());
             return error.getSample();
         }
-    }
-
-    private static Buffer getSample(FileInput fileInput, int maxSampleSize)
-    {
-        if (!fileInput.nextFile()) {
-            // no input files
-            return Buffer.EMPTY;
-        }
-
-        Buffer sample = Buffer.allocate(maxSampleSize);
-        int sampleSize = 0;
-
-        for (Buffer buffer : each(fileInput)) {
-            int size = Math.min(buffer.limit(), sample.capacity() - sampleSize);
-            sample.setBytes(sampleSize, buffer, 0, size);
-            sampleSize += size;
-            buffer.release();
-            if (sampleSize >= maxSampleSize) {
-                break;
-            }
-        }
-        sample.limit(sampleSize);
-        return sample;
     }
 
     public static class SampledNoticeError
@@ -118,5 +80,61 @@ public class SamplingParserPlugin
         {
             return sample;
         }
+    }
+
+    public static class NotEnoughSampleError
+            extends Error
+    { }
+
+    private final int minSampleSize;
+    private final int sampleSize;
+
+    @Inject
+    public SamplingParserPlugin(@ForSystemConfig ConfigSource systemConfig)
+    {
+        this.minSampleSize = 40;  // empty gzip file is 33 bytes. // TODO get sample size from system config
+        this.sampleSize = 32*1024;  // TODO get sample size from system config
+        Preconditions.checkArgument(minSampleSize < sampleSize, "minSampleSize must be smaller than sampleSize");
+    }
+
+    @Override
+    public void transaction(ConfigSource config, ParserPlugin.Control control)
+    {
+        control.run(Exec.newTaskSource(), null);
+    }
+
+    @Override
+    public void run(TaskSource taskSource, Schema schema,
+            FileInput input, PageOutput output)
+    {
+        Buffer buffer = readSample(input, sampleSize);
+        System.out.println("sample buffer size: "+buffer.limit());
+        if (buffer.limit() < minSampleSize) {
+            throw new NotEnoughSampleError();
+        }
+        throw new SampledNoticeError(buffer);
+    }
+
+    private static Buffer readSample(FileInput fileInput, int sampleSize)
+    {
+        if (!fileInput.nextFile()) {
+            // no input files
+            return Buffer.EMPTY;
+        }
+
+        Buffer sample = Buffer.allocate(sampleSize);
+        int offset = 0;
+
+        for (Buffer buffer : each(fileInput)) {
+            int size = Math.min(buffer.limit(), sample.capacity() - offset);
+            sample.setBytes(offset, buffer, 0, size);
+            offset += size;
+            buffer.release();
+            if (offset >= sampleSize) {
+                break;
+            }
+        }
+        sample.limit(offset);
+        return sample;
     }
 }


### PR DESCRIPTION
If there is an empty file first, guess fails with "No input buffer to
guess" message. Or the first file is too small, guess doesn't work well.