### PR TITLE
guess-csv keeps delimiter if already set

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -86,6 +86,13 @@ public class CsvParserPlugin
         @Config("allow_extra_columns")
         @ConfigDefault("false")
         public boolean getAllowExtraColumns();
+
+        @Config("error")
+        @ConfigDefault("{\"type\": \"warning\"}")
+        public ConfigSource getErrorConfig();
+
+        public TaskSource getErorrTaskSource();
+        public void setErrorTaskSource(TaskSource errorTask);
     }
 
     private final Logger log;

--- a/lib/embulk/guess/csv.rb
+++ b/lib/embulk/guess/csv.rb
@@ -35,13 +35,17 @@ module Embulk
       def guess_lines(config, sample_lines)
         return {} unless config.fetch("parser", {}).fetch("type", "csv") == "csv"
 
-        delim = guess_delimiter(sample_lines)
-        unless delim
-          # not CSV file
-          return {}
+        parser_config = config["parser"] || {}
+        if parser_config["type"] == "csv" && parser_config["delimiter"]
+          delim = parser_config["delimiter"]
+        else
+          delim = guess_delimiter(sample_lines)
+          unless delim
+            # not CSV file
+            return {}
+          end
         end
 
-        parser_config = config["parser"] || {}
         parser_guessed = DataSource.new.merge(parser_config).merge({"type" => "csv", "delimiter" => delim})
 
         unless parser_guessed.has_key?("quote")


### PR DESCRIPTION
If a file format is space-deliminated values, guess-csv doesn't work. It is good if we can write only `type: csv` and `delimiter: ' '` to parser config and run guess. This applies log files created by Amazon ELB, for example.
This pull-request improves guess-csv so that it keeps using `delimiter: ` parameter is already set rather than overwrite it every time.

