### PR TITLE
Fix unavailable URL to access to 'How to acquire bintray API Keys'

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,5 +206,5 @@ git tag v$VERSION
 
 See also:
 * [Bintray](https://bintray.com)
-* [How to acquire bintray API Keys](https://bintray.com/docs/usermanual/interacting/interacting_apikeys.html)
+* [How to acquire bintray API Keys](https://bintray.com/docs/usermanual/interacting/interacting_editingyouruserprofile.html#anchorAPIKEY)
 


### PR DESCRIPTION
Access to the current URL gives us 404 status code.