### PR TITLE
Fix trivial increment bug at CsvFormatterPlugin

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvFormatterPlugin.java
@@ -112,6 +112,7 @@ public class CsvFormatterPlugin
                 Optional<TimestampColumnOption> option = Optional.fromNullable(columnOptions.get(column.getName()));
                 formatters[i] = new TimestampFormatter(formatterTask, option);
             }
+            i++;
         }
         return formatters;
     }


### PR DESCRIPTION
Hi @frsyuki, I just found a very simple bug which is increment of a counter in loop is missing at CsvFormatterPlugin, when create timeformatters array.
The bug cause for every input which have timestamp field with index bigger then 0 to be Null Exception.