### PR TITLE
Add spi.TempFileSpace and spi.unit.LocalFile

### DIFF
--- a/embulk-core/src/main/java/org/embulk/command/Runner.java
+++ b/embulk-core/src/main/java/org/embulk/command/Runner.java
@@ -143,6 +143,7 @@ public class Runner
         ExecutionResult result;
         try {
             if (resume != null) {
+                // exec is not used here
                 result = loader.resume(config, resume);
             } else {
                 result = loader.run(exec, config);
@@ -153,6 +154,11 @@ public class Runner
                 exec.getLogger(Runner.class).info("Transaction partially failed. Cleaning up the intermediate data. Use -r option to make it resumable.");
                 try {
                     loader.cleanup(config, partial.getResumeState());
+                } catch (Throwable ex) {
+                    partial.addSuppressed(ex);
+                }
+                try {
+                    exec.cleanup();
                 } catch (Throwable ex) {
                     partial.addSuppressed(ex);
                 }
@@ -169,6 +175,7 @@ public class Runner
         if (options.getResumeStatePath() != null) {
             boolean dontCare = new File(options.getResumeStatePath()).delete();
         }
+        exec.cleanup();
 
         // write next config
         ConfigDiff configDiff = result.getConfigDiff();
@@ -187,7 +194,6 @@ public class Runner
         ConfigSource resumeConfig = loadYamlConfig(resumePath);
         ResumeState resume = resumeConfig.loadConfig(ResumeState.class);
 
-        //ExecSession exec = newExecSession(config);  // not necessary
         BulkLoader loader = injector.getInstance(BulkLoader.class);
         loader.cleanup(config, resume);
 
@@ -200,9 +206,16 @@ public class Runner
         ConfigSource config = loadYamlConfig(partialConfigPath);
         checkFileWritable(options.getNextConfigOutputPath());
 
-        ExecSession exec = newExecSession(config);
-        GuessExecutor guess = injector.getInstance(GuessExecutor.class);
-        ConfigDiff configDiff = guess.guess(exec, config);
+        ConfigDiff configDiff;
+        {
+            ExecSession exec = newExecSession(config);
+            try {
+                GuessExecutor guess = injector.getInstance(GuessExecutor.class);
+                configDiff = guess.guess(exec, config);
+            } finally {
+                exec.cleanup();
+            }
+        }
 
         String yml = writeNextConfig(options.getNextConfigOutputPath(), config, configDiff);
         System.err.println(yml);
@@ -244,10 +257,17 @@ public class Runner
 
     public void preview(String partialConfigPath)
     {
-        ConfigSource config = loadYamlConfig(partialConfigPath);
-        ExecSession exec = newExecSession(config);
-        PreviewExecutor preview = injector.getInstance(PreviewExecutor.class);
-        PreviewResult result = preview.preview(exec, config);
+        PreviewResult result;
+        {
+            ConfigSource config = loadYamlConfig(partialConfigPath);
+            ExecSession exec = newExecSession(config);
+            try {
+                PreviewExecutor preview = injector.getInstance(PreviewExecutor.class);
+                result = preview.preview(exec, config);
+            } finally {
+                exec.cleanup();
+            }
+        }
         ModelManager modelManager = injector.getInstance(ModelManager.class);
 
         PreviewPrinter printer;

--- a/embulk-core/src/main/java/org/embulk/command/Runner.java
+++ b/embulk-core/src/main/java/org/embulk/command/Runner.java
@@ -294,7 +294,8 @@ public class Runner
 
     private ExecSession newExecSession(ConfigSource config)
     {
-        return new ExecSession(injector, config.getNestedOrSetEmpty("exec"));
+        ConfigSource execConfig = config.deepCopy().getNestedOrSetEmpty("exec");
+        return ExecSession.builder(injector).fromExecConfig(execConfig).build();
     }
 
     private static class MapType extends HashMap<String, Object> {

--- a/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
+++ b/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
@@ -352,7 +352,7 @@ public class BulkLoader
     {
         try {
             ExecSession exec = ExecSession.builder(injector).fromExecConfig(resume.getExecSessionConfigSource()).build();
-            return Exec.doWith(exec, new ExecAction<ExecutionResult>() {
+            ExecutionResult result = Exec.doWith(exec, new ExecAction<ExecutionResult>() {
                 public ExecutionResult run()
                 {
                     try (SetCurrentThreadName dontCare = new SetCurrentThreadName("resume")) {
@@ -360,6 +360,8 @@ public class BulkLoader
                     }
                 }
             });
+            exec.cleanup();
+            return result;
         } catch (ExecutionException ex) {
             throw Throwables.propagate(ex.getCause());
         }
@@ -378,6 +380,7 @@ public class BulkLoader
                     }
                 }
             });
+            exec.cleanup();
         } catch (ExecutionException ex) {
             throw Throwables.propagate(ex.getCause());
         }

--- a/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
+++ b/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
@@ -320,7 +320,7 @@ public class BulkLoader
         public ResumeState buildResumeState(ExecSession exec)
         {
             return new ResumeState(
-                    exec.getSessionConfigSource(),
+                    exec.getSessionExecConfig(),
                     inputTaskSource, outputTaskSource,
                     first(schemas), executorSchema,
                     getInputCommitReports(), getOutputCommitReports());
@@ -351,7 +351,7 @@ public class BulkLoader
     public ExecutionResult resume(final ConfigSource config, final ResumeState resume)
     {
         try {
-            ExecSession exec = new ExecSession(injector, resume.getExecSessionConfigSource());
+            ExecSession exec = ExecSession.builder(injector).fromExecConfig(resume.getExecSessionConfigSource()).build();
             return Exec.doWith(exec, new ExecAction<ExecutionResult>() {
                 public ExecutionResult run()
                 {
@@ -368,7 +368,7 @@ public class BulkLoader
     public void cleanup(final ConfigSource config, final ResumeState resume)
     {
         try {
-            ExecSession exec = new ExecSession(injector, resume.getExecSessionConfigSource());
+            ExecSession exec = ExecSession.builder(injector).fromExecConfig(resume.getExecSessionConfigSource()).build();
             Exec.doWith(exec, new ExecAction<Void>() {
                 public Void run()
                 {

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -16,6 +16,7 @@ import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.ExecutorPlugin;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.util.CharsetSerDe;
+import org.embulk.spi.unit.LocalFileSerDe;
 import static org.embulk.plugin.InjectedPluginSource.registerPluginTo;
 
 public class ExecModule
@@ -29,6 +30,7 @@ public class ExecModule
         binder.bind(ILoggerFactory.class).toProvider(LoggerProvider.class);
         binder.bind(ModelManager.class).in(Scopes.SINGLETON);
         binder.bind(BufferAllocator.class).to(PooledBufferAllocator.class).in(Scopes.SINGLETON);
+        binder.bind(TempFileAllocator.class).in(Scopes.SINGLETON);
 
         // GuessExecutor
         registerPluginTo(binder, ParserPlugin.class, "system_guess", GuessExecutor.GuessParserPlugin.class);
@@ -43,6 +45,7 @@ public class ExecModule
         DateTimeZoneSerDe.configure(mapper);
         TimestampSerDe.configure(mapper);
         CharsetSerDe.configure(mapper);
+        LocalFileSerDe.configure(mapper);
         mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
         mapper.registerModule(new JodaModule());  // jackson-datatype-joda
         mapper.configure(binder);

--- a/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
@@ -60,7 +60,7 @@ public class PreviewExecutor
     public PreviewResult preview(ExecSession exec, final ConfigSource config)
     {
         try {
-            return Exec.doWith(exec.copyForPreview(), new ExecAction<PreviewResult>() {
+            return Exec.doWith(exec.forPreview(), new ExecAction<PreviewResult>() {
                 public PreviewResult run()
                 {
                     try (SetCurrentThreadName dontCare = new SetCurrentThreadName("preview")) {

--- a/embulk-core/src/main/java/org/embulk/exec/TempFileAllocator.java
+++ b/embulk-core/src/main/java/org/embulk/exec/TempFileAllocator.java
@@ -15,7 +15,13 @@ public class TempFileAllocator
     public TempFileAllocator(@ForSystemConfig ConfigSource systemConfig)
     {
         // TODO get `temp_dirs` from system config
-        this.dirs = new File[] { new File(System.getProperty("java.io.tmpdir")) };
+        String s = System.getProperty("java.io.tmpdir");
+        if (s == null || s.isEmpty()) {
+            s = "/tmp";
+        }
+        this.dirs = new File[] {
+            new File(s, "embulk")
+        };
     }
 
     public TempFileSpace newSpace(String subdir)

--- a/embulk-core/src/main/java/org/embulk/exec/TempFileAllocator.java
+++ b/embulk-core/src/main/java/org/embulk/exec/TempFileAllocator.java
@@ -1,0 +1,26 @@
+package org.embulk.exec;
+
+import java.io.File;
+import com.google.inject.Inject;
+import org.embulk.config.ConfigSource;
+import org.embulk.spi.TempFileSpace;
+
+// TODO change this class to interface
+// TODO don't use this class directly. Use spi.Exec.getTempFileSpace() instead.
+public class TempFileAllocator
+{
+    private final File[] dirs;
+
+    @Inject
+    public TempFileAllocator(@ForSystemConfig ConfigSource systemConfig)
+    {
+        // TODO get `temp_dirs` from system config
+        this.dirs = new File[] { new File(System.getProperty("java.io.tmpdir")) };
+    }
+
+    public TempFileSpace newSpace(String subdir)
+    {
+        // TODO support multiple files
+        return new TempFileSpace(new File(dirs[0], subdir));
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/Exec.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Exec.java
@@ -88,6 +88,12 @@ public class Exec
         return session().newTaskSource();
     }
 
+    // TODO this method is still beta
+    public static TempFileSpace getTempFileSpace()
+    {
+        return session().getTempFileSpace();
+    }
+
     public static boolean isPreview()
     {
         return session().isPreview();

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -23,7 +23,6 @@ import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.time.TimestampFormatter.FormatterTask;
 
 public class ExecSession
-        implements AutoCloseable
 {
     private final Injector injector;
     private final ILoggerFactory loggerFactory;
@@ -205,9 +204,8 @@ public class ExecSession
         return preview;
     }
 
-    @Override
-    public void close()
+    public void cleanup()
     {
-        tempFileSpace.clean();
+        tempFileSpace.cleanup();
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -1,5 +1,6 @@
 package org.embulk.spi;
 
+import java.io.File;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.ILoggerFactory;
@@ -14,6 +15,7 @@ import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskSource;
 import org.embulk.config.DataSourceImpl;
+import org.embulk.exec.TempFileAllocator;
 import org.embulk.plugin.PluginType;
 import org.embulk.plugin.PluginManager;
 import org.embulk.spi.time.Timestamp;
@@ -21,6 +23,7 @@ import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.time.TimestampFormatter.FormatterTask;
 
 public class ExecSession
+        implements AutoCloseable
 {
     private final Injector injector;
     private final ILoggerFactory loggerFactory;
@@ -28,25 +31,67 @@ public class ExecSession
     private final PluginManager pluginManager;
     private final BufferAllocator bufferAllocator;
 
-    private final ConfigSource execConfig;
     private final Timestamp transactionTime;
-    private final DateTimeZone transactionTimeZone;
+    private final TempFileSpace tempFileSpace;
 
     private final boolean preview;
 
+    @Deprecated
     public interface SessionTask
             extends Task
     {
         @Config("transaction_time")
         @ConfigDefault("null")
         Optional<Timestamp> getTransactionTime();
-
-        @Config("transaction_time_zone")
-        @ConfigDefault("\"UTC\"")
-        DateTimeZone getTransactionTimeZone();
     }
 
-    public ExecSession(Injector injector, ConfigSource execConfig)
+    public static class Builder
+    {
+        private final Injector injector;
+        private Timestamp transactionTime;
+
+        public Builder(Injector injector)
+        {
+            this.injector = injector;
+        }
+
+        public Builder fromExecConfig(ConfigSource configSource)
+        {
+            this.transactionTime = configSource.get(Timestamp.class, "transaction_time", null);
+            return this;
+        }
+
+        public Builder setTransactionTime(Timestamp timestamp)
+        {
+            this.transactionTime = timestamp;
+            return this;
+        }
+
+        public ExecSession build()
+        {
+            if (transactionTime == null) {
+                transactionTime = Timestamp.ofEpochMilli(System.currentTimeMillis());  // TODO get nanoseconds for default
+            }
+            return new ExecSession(injector, transactionTime);
+        }
+    }
+
+    public static Builder builder(Injector injector)
+    {
+        return new Builder(injector);
+    }
+
+    @Deprecated
+    public ExecSession(Injector injector, ConfigSource configSource)
+    {
+        this(injector,
+                configSource.loadConfig(SessionTask.class).getTransactionTime().or(
+                    Timestamp.ofEpochMilli(System.currentTimeMillis())
+                )
+            );  // TODO get nanoseconds for default
+    }
+
+    private ExecSession(Injector injector, Timestamp transactionTime)
     {
         this.injector = injector;
         this.loggerFactory = injector.getInstance(ILoggerFactory.class);
@@ -54,10 +99,10 @@ public class ExecSession
         this.pluginManager = injector.getInstance(PluginManager.class);
         this.bufferAllocator = injector.getInstance(BufferAllocator.class);
 
-        this.execConfig = execConfig.deepCopy();
-        SessionTask task = execConfig.loadConfig(SessionTask.class);
-        this.transactionTime = task.getTransactionTime().or(Timestamp.ofEpochMilli(System.currentTimeMillis()));  // TODO get nanoseconds for default
-        this.transactionTimeZone = task.getTransactionTimeZone();
+        this.transactionTime = transactionTime;
+
+        TempFileAllocator tempFileAllocator = injector.getInstance(TempFileAllocator.class);
+        this.tempFileSpace = tempFileAllocator.newSpace(transactionTime.toString());
 
         this.preview = false;
     }
@@ -70,23 +115,21 @@ public class ExecSession
         this.pluginManager = copy.pluginManager;
         this.bufferAllocator = copy.bufferAllocator;
 
-        this.execConfig = copy.execConfig;
         this.transactionTime = copy.transactionTime;
-        this.transactionTimeZone = copy.transactionTimeZone;
+        this.tempFileSpace = copy.tempFileSpace;
 
         this.preview = preview;
     }
 
-    public ExecSession copyForPreview()
+    public ExecSession forPreview()
     {
         return new ExecSession(this, true);
     }
 
-    public ConfigSource getSessionConfigSource()
+    public ConfigSource getSessionExecConfig()
     {
         return newConfigSource()
-            .set("transaction_time", transactionTime)
-            .set("transaction_time_zone", transactionTimeZone);
+            .set("transaction_time", transactionTime);
     }
 
     public Injector getInjector()
@@ -97,11 +140,6 @@ public class ExecSession
     public Timestamp getTransactionTime()
     {
         return transactionTime;
-    }
-
-    public DateTimeZone getTransactionTimeZone()
-    {
-        return transactionTimeZone;
     }
 
     public Logger getLogger(String name)
@@ -122,11 +160,6 @@ public class ExecSession
     public ModelManager getModelManager()
     {
         return modelManager;
-    }
-
-    public ConfigSource getExecConfig()
-    {
-        return execConfig;
     }
 
     public <T> T newPlugin(Class<T> iface, PluginType type)
@@ -162,8 +195,19 @@ public class ExecSession
         return new TimestampFormatter(format, formatterTask);
     }
 
+    public TempFileSpace getTempFileSpace()
+    {
+        return tempFileSpace;
+    }
+
     public boolean isPreview()
     {
         return preview;
+    }
+
+    @Override
+    public void close()
+    {
+        tempFileSpace.clean();
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
@@ -81,7 +81,7 @@ public class FileInputRunner
         }
 
         GuessExecutor guessExecutor = Exec.getInjector().getInstance(GuessExecutor.class);
-        return guessExecutor.guessParserConfig(sample, config, Exec.session().getExecConfig());
+        return guessExecutor.guessParserConfig(sample, config, Exec.session().getSessionExecConfig());
     }
 
     private class RunnerControl

--- a/embulk-core/src/main/java/org/embulk/spi/TempFileException.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TempFileException.java
@@ -1,0 +1,19 @@
+package org.embulk.spi;
+
+import java.io.IOException;
+
+public class TempFileException
+        extends RuntimeException
+{
+    public TempFileException(IOException cause)
+    {
+        super(cause);
+    }
+
+
+    @Override
+    public IOException getCause()
+    {
+        return (IOException) super.getCause();
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
@@ -1,0 +1,49 @@
+package org.embulk.spi;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.io.File;
+import java.io.IOException;
+
+public class TempFileSpace
+{
+    private final File dir;
+    private boolean dirCreated;
+
+    public TempFileSpace(File dir)
+    {
+        this.dir = dir;
+    }
+
+    public File createTempFile()
+    {
+        return createTempFile("tmp");
+    }
+
+    public File createTempFile(String fileExt)
+    {
+        return createTempFile(Thread.currentThread().getName()+"_", fileExt);
+    }
+
+    public File createTempFile(String prefix, String fileExt)
+    {
+        try {
+            if (!dirCreated) {
+                dir.mkdirs();
+                dirCreated = true;
+            }
+            return File.createTempFile(prefix, "."+fileExt, dir);
+        } catch (IOException ex) {
+            throw new TempFileException(ex);
+        }
+    }
+
+    public void clean()
+    {
+        for (File e : dir.listFiles()) {
+            e.delete();
+        }
+        dir.delete();
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.io.File;
 import java.io.IOException;
+import com.google.common.base.Preconditions;
 
 public class TempFileSpace
 {
@@ -13,6 +14,7 @@ public class TempFileSpace
 
     public TempFileSpace(File dir)
     {
+        Preconditions.checkArgument(dir != null, "dir is null");
         this.dir = dir;
     }
 
@@ -39,11 +41,16 @@ public class TempFileSpace
         }
     }
 
-    public void clean()
+    public void cleanup()
     {
-        for (File e : dir.listFiles()) {
-            e.delete();
+        File[] files = dir.listFiles();
+        if (files != null) {
+            for (File e : files) {
+                e.delete();
+                // TODO delete directory recursively
+            }
         }
         dir.delete();
+        dirCreated = false;
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/unit/LocalFile.java
+++ b/embulk-core/src/main/java/org/embulk/spi/unit/LocalFile.java
@@ -1,0 +1,106 @@
+package org.embulk.spi.unit;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.embulk.spi.Exec;
+import org.embulk.spi.TempFileSpace;
+import org.embulk.spi.TempFileException;
+
+public class LocalFile
+{
+    public static LocalFile of(File path) throws IOException
+    {
+        return of(path.toPath());
+    }
+
+    public static LocalFile of(Path path) throws IOException
+    {
+        return new LocalFile(path, Files.readAllBytes(path));
+    }
+
+    public static LocalFile of(String path) throws IOException
+    {
+        return of(Paths.get(path));
+    }
+
+    public static LocalFile ofContent(byte[] content)
+    {
+        return new LocalFile(content);
+    }
+
+    public static LocalFile ofContent(String content)
+    {
+        return new LocalFile(content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Path path;
+    private final byte[] content;
+
+    private LocalFile(Path path, byte[] content)
+    {
+        this.path = path;
+        this.content = content;
+    }
+
+    private LocalFile(byte[] content)
+    {
+        this.path = null;
+        this.content = content;
+    }
+
+    public File getFile()
+    {
+        return getPath(Exec.getTempFileSpace()).toFile();
+    }
+
+    public File getFile(TempFileSpace space)
+    {
+        return getPath(space).toFile();
+    }
+
+    public Path getPath()
+    {
+        return getPath(Exec.getTempFileSpace());
+    }
+
+    public synchronized Path getPath(TempFileSpace tempFileSpace)
+    {
+        if (path == null) {
+            Path temp = tempFileSpace.createTempFile().toPath();
+            try {
+                Files.write(temp, content);
+            } catch (IOException ex) {
+                throw new TempFileException(ex);
+            }
+            this.path = temp;
+        }
+        return path;
+    }
+
+    public byte[] getContent()
+    {
+        return content;
+    }
+
+    public String getContentAsString()
+    {
+        return new String(content);
+    }
+
+    public String getContentAsString(Charset charset)
+    {
+        return new String(content, charset);
+    }
+
+    public InputStream newContentInputStream()
+    {
+        return new ByteArrayInputStream(content);
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/util/Inputs.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Inputs.java
@@ -62,13 +62,4 @@ public class Inputs
             }
         };
     }
-
-    public static String formatPath(String pathFormat)
-    {
-        Timestamp timestamp = Exec.session().getTransactionTime();
-        DateTimeZone timezone = Exec.session().getTransactionTimeZone();
-        // newTimestampFormatter (eventually calls org.jruby.util.RubyDateFormat.<init> doesn't throw exceptions
-        TimestampFormatter formatter = Exec.session().newTimestampFormatter(pathFormat, timezone);
-        return formatter.format(timestamp);  // TimestampFormatter.format doesn't throw exceptions
-    }
 }

--- a/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
+++ b/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
@@ -52,7 +52,7 @@ public class EmbulkTestRuntime
         super(new TestRuntimeModule());
         Injector injector = getInjector();
         ConfigSource execConfig = new DataSourceImpl(injector.getInstance(ModelManager.class));
-        this.exec = new ExecSession(injector, execConfig);
+        this.exec = ExecSession.builder(injector).fromExecConfig(execConfig).build();
     }
 
     public ExecSession getExec()

--- a/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
+++ b/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
@@ -96,6 +96,8 @@ public class EmbulkTestRuntime
                     });
                 } catch (RuntimeException ex) {
                     throw ex.getCause();
+                } finally {
+                    exec.cleanup();
                 }
             }
         };


### PR DESCRIPTION
* ExecSession has cleanup() method. Callers should call it so that
  it deletes local temporary files.
* ExecSession should be created using builder. The public constructor of
  ExecSession is deprecated.
* ExecSession.getTransactionTimeZone is removed.
