### PR TITLE
Expose @java_file_input for parser plugins

### DIFF
--- a/lib/embulk/file_input.rb
+++ b/lib/embulk/file_input.rb
@@ -3,6 +3,8 @@ module Embulk
   require 'embulk/buffer'
 
   class FileInput
+    attr_reader :java_file_input
+
     def initialize(java_file_input)
       @java_file_input = java_file_input
       @buffer = nil


### PR DESCRIPTION
`@java_file_input` is needed by ruby parser plugins.

e.g.:
https://github.com/treasure-data/embulk-parser-query_string/pull/6/files#diff-1e7234223ad807f67a382ee2242b79d5R40
https://github.com/shun0102/embulk-parser-jsonl/blob/master/lib/embulk/parser/jsonl.rb#L26

So I added `attr_reader` for it.