### PR TITLE
Fix failure of `embulk new ruby-*` commands

### DIFF
--- a/lib/embulk/data/new/README.md.erb
+++ b/lib/embulk/data/new/README.md.erb
@@ -2,7 +2,7 @@
 
 %case language
 %when :ruby
-TODO: Write short description here and <%= project_name %>.gemspec file.
+TODO: Write short description here and <%= full_project_name %>.gemspec file.
 %when :java
 TODO: Write short description here and build.gradle file.
 %else


### PR DESCRIPTION
`embulk new ruby-*` commands fails while creating README.md at Embulk v0.6.17.
I fixed it.

```
$ embulk new ruby-input hoge
2015-07-21 18:28:16.154 +0900: Embulk v0.6.17
Creating embulk-input-hoge/
  Creating embulk-input-hoge/README.md
NameError: undefined local variable or method `project_name' for Embulk:Module
      result at (erb):5
        eval at org/jruby/RubyKernel.java:1107
      result at /Users/Satoshi/.embulk/bin/embulk!/META-INF/jruby.home/lib/ruby/1.9/erb.rb:838
         erb at file:/Users/Satoshi/.embulk/bin/embulk!/embulk/data/package_data.rb:35
      cp_erb at file:/Users/Satoshi/.embulk/bin/embulk!/embulk/data/package_data.rb:45
        open at org/jruby/RubyIO.java:1181
      cp_erb at file:/Users/Satoshi/.embulk/bin/embulk!/embulk/data/package_data.rb:45
  new_plugin at file:/Users/Satoshi/.embulk/bin/embulk!/embulk/command/embulk_new_plugin.rb:72
         run at file:/Users/Satoshi/.embulk/bin/embulk!/embulk/command/embulk_run.rb:326
      (root) at classpath:embulk/command/embulk.rb:47
```