### PR TITLE
CSV parser plugin supports non-quoted values which contains "

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -23,7 +23,7 @@ Embulk uses a YAML file to define a bulk data loading. Here is an example of the
         type: csv
         delimiter: ','
         quote: '"'
-        escape: ''
+        escape: '"'
         null_string: 'NULL'
         skip_header_lines: 1
         columns:
@@ -133,9 +133,9 @@ Options
 +============================+==========+================================================================================================================+========================+
 | delimiter                  | string   | Delimiter character such as ``,`` for CSV, ``"\t"`` for TSV, ``"|"`` or any single-byte character              | ``,`` by default       |
 +----------------------------+----------+----------------------------------------------------------------------------------------------------------------+------------------------+
-| quote                      | string   | The character surrounding a quoted value                                                                       | ``\"`` by default      |
+| quote                      | string   | The character surrounding a quoted value. Setting ``null`` disables quoting.                                   | ``\"`` by default      |
 +----------------------------+----------+----------------------------------------------------------------------------------------------------------------+------------------------+
-| escape                     | string   | Escape character to escape a special character                                                                 | ``\\`` by default      |
+| escape                     | string   | Escape character to escape a special character. Setting ``null`` disables escaping.                            | ``\\`` by default      |
 +----------------------------+----------+----------------------------------------------------------------------------------------------------------------+------------------------+
 | skip\_header\_lines        | integer  | Skip this number of lines first. Set 1 if the file has header line.                                            | ``0`` by default       |
 +----------------------------+----------+----------------------------------------------------------------------------------------------------------------+------------------------+
@@ -203,7 +203,7 @@ Example
         newline: CRLF
         delimiter: "\t"
         quote: '"'
-        escape: ''
+        escape: '"'
         null_string: 'NULL'
         skip_header_lines: 1
         comment_line_marker: '#'

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -131,6 +131,16 @@ public class CsvParserPlugin
         {
             return new String(new char[] { character });
         }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (!(obj instanceof QuoteCharacter)) {
+                return false;
+            }
+            QuoteCharacter o = (QuoteCharacter) obj;
+            return character == o.character;
+        }
     }
 
     public static class EscapeCharacter
@@ -170,6 +180,16 @@ public class CsvParserPlugin
         public String getOptionalString()
         {
             return new String(new char[] { character });
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (!(obj instanceof EscapeCharacter)) {
+                return false;
+            }
+            EscapeCharacter o = (EscapeCharacter) obj;
+            return character == o.character;
         }
     }
 

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -57,11 +57,11 @@ public class CsvParserPlugin
 
         @Config("quote")
         @ConfigDefault("\"\\\"\"")
-        public char getQuoteChar();
+        public Optional<Character> getQuoteChar();
 
         @Config("escape")
         @ConfigDefault("\"\\\\\"")
-        public char getEscapeChar();
+        public Optional<Character> getEscapeChar();
 
         // Null value handling: if the CsvParser found 'non-quoted empty string's,
         // it replaces them to string that users specified like "\N", "NULL".

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -7,6 +7,7 @@ import java.util.Deque;
 import java.util.ArrayDeque;
 import org.embulk.config.ConfigException;
 import org.embulk.spi.util.LineDecoder;
+import org.embulk.spi.Exec;
 
 public class CsvTokenizer
 {
@@ -46,7 +47,12 @@ public class CsvTokenizer
     {
         delimiter = task.getDelimiterChar();
         if (task.getQuoteChar().isPresent()) {
-            quote = task.getQuoteChar().get();
+            if (task.getQuoteChar().get() == '\0') {
+                Exec.getLogger(getClass()).warn("Setting '' (empty string) to \"quote\" option is obsoleted. Currently it becomes '\"' automatically but this behavior will be removed. Please set '\"' explicitly.");
+                quote = '"';
+            } else {
+                quote = task.getQuoteChar().get();
+            }
         } else {
             quote = NO_QUOTE;
         }

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -22,8 +22,8 @@ public class CsvTokenizer
     }
 
     private static final char END_OF_LINE = '\0';
-    private static final char NO_QUOTE = '\0';
-    private static final char NO_ESCAPE = '\0';
+    static final char NO_QUOTE = '\0';
+    static final char NO_ESCAPE = '\0';
 
     private final char delimiter;
     private final char quote;
@@ -46,21 +46,8 @@ public class CsvTokenizer
     public CsvTokenizer(LineDecoder input, CsvParserPlugin.PluginTask task)
     {
         delimiter = task.getDelimiterChar();
-        if (task.getQuoteChar().isPresent()) {
-            if (task.getQuoteChar().get() == '\0') {
-                Exec.getLogger(getClass()).warn("Setting '' (empty string) to \"quote\" option is obsoleted. Currently it becomes '\"' automatically but this behavior will be removed. Please set '\"' explicitly.");
-                quote = '"';
-            } else {
-                quote = task.getQuoteChar().get();
-            }
-        } else {
-            quote = NO_QUOTE;
-        }
-        if (task.getEscapeChar().isPresent()) {
-            escape = task.getEscapeChar().get();
-        } else {
-            escape = NO_ESCAPE;
-        }
+        quote = task.getQuoteChar().or(CsvParserPlugin.QuoteCharacter.noQuote()).getCharacter();
+        escape = task.getEscapeChar().or(CsvParserPlugin.EscapeCharacter.noEscape()).getCharacter();
         newline = task.getNewline().getString();
         trimIfNotQuoted = task.getTrimIfNotQuoted();
         maxQuotedSizeLimit = task.getMaxQuotedSizeLimit();

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -370,7 +370,7 @@ public class CsvTokenizer
 
     private boolean isEscape(char c)
     {
-        return quote != NO_ESCAPE && c == escape;
+        return escape != NO_ESCAPE && c == escape;
     }
 
     public static class InvalidFormatException

--- a/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
@@ -4,6 +4,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import java.nio.charset.Charset;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTimeZone;
@@ -33,7 +34,7 @@ public class TestCsvParserPlugin
         assertEquals(Newline.CRLF, task.getNewline());
         assertEquals(false, task.getHeaderLine().or(false));
         assertEquals(',', task.getDelimiterChar());
-        assertEquals('\"', task.getQuoteChar());
+        assertEquals(Optional.of('\"'), task.getQuoteChar());
         assertEquals(false, task.getAllowOptionalColumns());
         assertEquals(DateTimeZone.UTC, task.getDefaultTimeZone());
         assertEquals("%Y-%m-%d %H:%M:%S.%N %z", task.getDefaultTimestampFormat());
@@ -68,7 +69,7 @@ public class TestCsvParserPlugin
         assertEquals(Newline.LF, task.getNewline());
         assertEquals(true, task.getHeaderLine().or(false));
         assertEquals('\t', task.getDelimiterChar());
-        assertEquals('\\', task.getQuoteChar());
+        assertEquals(Optional.of('\\'), task.getQuoteChar());
         assertEquals(true, task.getAllowOptionalColumns());
     }
 }

--- a/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
@@ -34,7 +34,7 @@ public class TestCsvParserPlugin
         assertEquals(Newline.CRLF, task.getNewline());
         assertEquals(false, task.getHeaderLine().or(false));
         assertEquals(',', task.getDelimiterChar());
-        assertEquals(Optional.of('\"'), task.getQuoteChar());
+        assertEquals(Optional.of(new CsvParserPlugin.QuoteCharacter('\"')), task.getQuoteChar());
         assertEquals(false, task.getAllowOptionalColumns());
         assertEquals(DateTimeZone.UTC, task.getDefaultTimeZone());
         assertEquals("%Y-%m-%d %H:%M:%S.%N %z", task.getDefaultTimestampFormat());
@@ -69,7 +69,7 @@ public class TestCsvParserPlugin
         assertEquals(Newline.LF, task.getNewline());
         assertEquals(true, task.getHeaderLine().or(false));
         assertEquals('\t', task.getDelimiterChar());
-        assertEquals(Optional.of('\\'), task.getQuoteChar());
+        assertEquals(Optional.of(new CsvParserPlugin.QuoteCharacter('\\')), task.getQuoteChar());
         assertEquals(true, task.getAllowOptionalColumns());
     }
 }

--- a/lib/embulk/guess/csv.rb
+++ b/lib/embulk/guess/csv.rb
@@ -60,6 +60,7 @@ module Embulk
           end
           parser_guessed["quote"] = quote
         end
+        parser_guessed["quote"] = '"' if parser_guessed["quote"] == ''  # setting '' is not allowed any more. this line converts obsoleted config syntax to explicit syntax.
 
         unless parser_guessed.has_key?("escape")
           if quote = parser_guessed["quote"]

--- a/lib/embulk/guess/csv.rb
+++ b/lib/embulk/guess/csv.rb
@@ -14,7 +14,7 @@ module Embulk
       ]
 
       ESCAPE_CANDIDATES = [
-        "\\"
+        "\\", '"'
       ]
 
       NULL_STRING_CANDIDATES = [
@@ -50,12 +50,32 @@ module Embulk
 
         unless parser_guessed.has_key?("quote")
           quote = guess_quote(sample_lines, delim)
-          parser_guessed["quote"] = quote ? quote : ''
+          unless quote
+            if !guess_force_no_quote(sample_lines, delim, '"')
+              # assuming CSV follows RFC for quoting
+              quote = '"'
+            else
+              # disable quoting (set null)
+            end
+          end
+          parser_guessed["quote"] = quote
         end
 
         unless parser_guessed.has_key?("escape")
-          escape = guess_escape(sample_lines, delim, quote)
-          parser_guessed["escape"] = escape ? escape : ''
+          if quote = parser_guessed["quote"]
+            escape = guess_escape(sample_lines, delim, quote)
+            unless escape
+              if quote == '"'
+                # assuming this CSV follows RFC for escaping
+                escape = '"'
+              else
+                # disable escaping (set null)
+              end
+              parser_guessed["escape"] = escape
+            end
+          else
+            # escape does nothing if quote is disabled
+          end
         end
 
         unless parser_guessed.has_key?("null_string")
@@ -220,13 +240,18 @@ module Embulk
         end
       end
 
-      def guess_escape(sample_lines, delim, optional_quote)
+      def guess_force_no_quote(sample_lines, delim, quote_candidate)
+        delim_regexp = Regexp.escape(delim)
+        q_regexp = Regexp.escape(quote_candidate)
+        sample_lines.any? do |line|
+          # quoting character appear at the middle of a non-quoted value
+          line =~ /(?:\A|#{delim_regexp})\s*[^#{q_regexp}]+#{q_regexp}/
+        end
+      end
+
+      def guess_escape(sample_lines, delim, quote)
         guessed = ESCAPE_CANDIDATES.map do |str|
-          if optional_quote
-            regexp = /#{Regexp.quote(str)}(?:#{Regexp.quote(delim)}|#{Regexp.quote(optional_quote)})/
-          else
-            regexp = /#{Regexp.quote(str)}#{Regexp.quote(delim)}/
-          end
+          regexp = /#{Regexp.quote(str)}(?:#{Regexp.quote(delim)}|#{Regexp.quote(quote)})/
           counts = sample_lines.map {|line| line.scan(regexp).count }
           count = counts.inject(0) {|r,c| r + c }
           [str, count]


### PR DESCRIPTION
This change includes 3 changes:

* CSV parser supports null to `quote` and `escape` options. It means
  disabling quoting or escaping.
* CSV guess plugin uses `quote: null` if some values contain '"' in
  middle of non-quoted string.
* <del>CSV parser assumes `quote: ''` (or `escape: ''`) mean disabling
  quoting (or escaping). This is backward incompatible because previous
  behavior was assuming quote='"' (or escape="\\")</del>