### PR TITLE
Provide importing Embulk dependent jars utility API

### DIFF
--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -390,6 +390,14 @@ examples:
     end
   end
 
+  def self.require_jar
+    classpath_dir = Embulk.home("classpath")
+    jars = Dir.entries(classpath_dir).select{|f| f =~ /\.jar$/ }.sort
+    jars.each do |jar|
+      require File.join(classpath_dir, jar)
+    end
+  end
+
   def self.default_gem_home
     if RUBY_PLATFORM =~ /java/i
       user_home = java.lang.System.properties["user.home"]


### PR DESCRIPTION
Related to #234.

I found that embulk plugins written in ruby always use following code:

```ruby
classpath_dir = Embulk.home("classpath")
jars = Dir.entries(classpath_dir).select{|f| f =~ /\.jar$/ }.sort
jars.each do |jar|
  require File.join(classpath_dir, jar)
end
```

How about this patch?
This patch makes above code in embulk plugin test as follows:

```ruby
Embulk.require_jar
```