### PR TITLE
Add experimental support for Liquid template engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,15 @@
-
+buildscript {
+    repositories { jcenter() }
+    dependencies {
+        classpath "com.github.jruby-gradle:jruby-gradle-jar-plugin:1.0.1"
+    }
+}
 plugins {
     id 'com.jfrog.bintray' version '1.1'
     id 'com.github.ben-manes.versions' version '0.7'
-    id 'com.github.jruby-gradle.base' version '0.1.5'
     id 'com.github.johnrengelman.shadow' version '1.2.0'
 }
+apply plugin: "com.github.jruby-gradle.jar"
 
 def java_projects = [project(":embulk-core"), project(":embulk-standards"), project(":embulk-cli")]
 def release_projects = [project(":embulk-core"), project(":embulk-standards")]

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -1,6 +1,8 @@
+apply plugin: "com.github.jruby-gradle.jar"
+
 // include ruby scripts to jar. don't use sourceSets.main.resources.srcDirs
 // because IntelliJ causes error if srcDirs includes files out of projectDir.
-processResources.from "${rootProject.projectDir}/lib"
+processResources.from("${rootProject.projectDir}/lib", "${buildDir}/jruby")
 
 configurations {
     // com.google.inject:guice depends on asm and cglib but version of the libraries conflict
@@ -8,6 +10,9 @@ configurations {
     compile.exclude group: 'asm', module: 'asm'
     compile.exclude group: 'org.sonatype.sisu.inject', module: 'cglib'
 }
+
+import com.github.jrubygradle.JRubyExec
+import com.github.jrubygradle.JRubyPrepare
 
 // determine which dependencies have updates: $ gradle dependencyUpdates
 dependencies {
@@ -35,4 +40,15 @@ dependencies {
 
     // for embulk/guess/charset.rb
     compile 'com.ibm.icu:icu4j:54.1.1'
+
+    gems 'rubygems:liquid:3.0.6'
 }
+
+task unpackGems(type: JRubyPrepare) {
+    outputDir file("${buildDir}/jruby/embulk/gems")
+    dependencies configurations.gems
+    doLast {
+        fileTree(dir: "${buildDir}/jruby/embulk/gems/cache", include: "*.gem").each { f -> f.delete() }
+    }
+}
+processResources.dependsOn("unpackGems")

--- a/embulk-core/src/main/java/org/embulk/command/LiquidTemplate.java
+++ b/embulk-core/src/main/java/org/embulk/command/LiquidTemplate.java
@@ -1,0 +1,8 @@
+package org.embulk.command;
+
+import java.util.Map;
+
+public interface LiquidTemplate
+{
+    public String render(String source, Map<String, String> params);
+}

--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -206,6 +206,8 @@ examples:
       args = 0..0
 
     when :gem
+      require 'embulk/gems'
+      Embulk.add_embedded_gem_path
       require 'rubygems/gem_runner'
       Gem::GemRunner.new.run argv
       exit 0

--- a/lib/embulk/gems.rb
+++ b/lib/embulk/gems.rb
@@ -1,0 +1,29 @@
+module Embulk
+  def self.add_embedded_gem_path
+    begin
+      resource_class = org.embulk.command.Runner.java_class
+    rescue NameError
+      begin
+        Embulk.require_classpath
+        resource_class = org.embulk.command.Runner.java_class
+      rescue NameError
+        return nil
+      end
+    end
+
+    gem_path = resource_class.resource("/embulk/gems").to_s.sub(/^jar:/, '')
+    unless gem_path.empty?
+      # GEM_PATH can't include ':'
+      gem_path = gem_path.gsub(/\w{0,5}:(?:\/(?=\/))*/, "")
+      orig = ENV['GEM_PATH'].to_s
+      if orig.empty?
+        ENV['GEM_PATH'] = gem_path
+      elsif !orig.split(Gem.path_separator).include?(gem_path)
+        ENV['GEM_PATH'] = "#{gem_path}:#{orig}"
+      end
+      Gem.clear_paths
+      return ENV['GEM_PATH']
+    end
+    return nil
+  end
+end

--- a/lib/embulk/java/bootstrap.rb
+++ b/lib/embulk/java/bootstrap.rb
@@ -1,7 +1,11 @@
 module Embulk
   module Java
+    require 'embulk/gems'
+    Embulk.add_embedded_gem_path
+
     require 'embulk/java/imports'
     require 'embulk/java/time_helper'
+    require 'embulk/java/liquid_helper'
 
     module Injected
       # Following constats are set by org.embulk.jruby.JRubyScriptingModule:

--- a/lib/embulk/java/liquid_helper.rb
+++ b/lib/embulk/java/liquid_helper.rb
@@ -1,0 +1,17 @@
+module Embulk
+  module Java
+    require 'liquid'
+
+    class LiquidTemplateHelper
+      include org.embulk.command.LiquidTemplate
+
+      def render(source, params)
+        template = Liquid::Template.parse(source)
+        data = {
+          "env" => ENV.to_h,
+        }.merge(params)
+        template.render(data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements #253.
When Embulk loads a configuration file, if file extension is .yml.liquid, it runs Liquid template engine. In the config file, we can use `env` to embed environment variable. For example,

```yaml
# config.yml.liquid
in:
    type: file
    path_prefix: {{ env.prefix }}
```

This is experimental because of following limitations and concerns:

* Once `guess` runs, all variables are embedded. So, written configuration file is yaml. Not liquid.
* Variables won't be escaped or quoted.
* Liquid itself supports nested objects such as arrays and maps. But this code doesn't support them because all variables are String.
