### PR TITLE
Import Schema#builder API from Java to Ruby style

### DIFF
--- a/lib/embulk/builder.rb
+++ b/lib/embulk/builder.rb
@@ -1,0 +1,21 @@
+module Embulk
+
+  require 'embulk/column'
+
+  class Builder
+    def self.add(name, type_str_or_sym)
+      Column.new(nil, name, type_str_or_sym.to_sym)
+    end
+
+    def self.build(column_config)
+      columns = []
+      column_config.each do |column|
+        name = column["name"]
+        type = column["type"].to_sym
+
+        columns << Column.new(nil, name, type)
+      end
+    end
+  end
+
+end

--- a/lib/embulk/parser_plugin.rb
+++ b/lib/embulk/parser_plugin.rb
@@ -1,5 +1,6 @@
 module Embulk
 
+  require 'embulk/builder'
   require 'embulk/data_source'
   require 'embulk/schema'
   require 'embulk/page_builder'


### PR DESCRIPTION
Related to #228.

Following code 

```ruby
 columns = []
 schema = config.param(:schema, :array, default: [])
 schema.each do |column|
   name = column["name"]
   type = column["type"].to_sym
   
   columns << Column.new(nil, name, type)
 end
```

will become:

```ruby
column_config = config.param(:schema, :array, default: [])
columns = Builder.build(column_config)
```

Or this API can more simplize?