### PR TITLE
Replace ':' with '-' in temp file space name.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/TempFileAllocator.java
+++ b/embulk-core/src/main/java/org/embulk/exec/TempFileAllocator.java
@@ -27,6 +27,7 @@ public class TempFileAllocator
     public TempFileSpace newSpace(String subdir)
     {
         // TODO support multiple files
-        return new TempFileSpace(new File(dirs[0], subdir));
+    	// Windows cannot include ':' as file name.
+        return new TempFileSpace(new File(dirs[0], subdir.replace(':', '-')));
     }
 }


### PR DESCRIPTION
Because Windows cannot include ':' as file name.
<pre>
2015-08-14 18:04:41.602 +0900 [INFO] (transaction): {done:  1 / 1, running: 0}
java.nio.file.InvalidPathException: Illegal char <:> at index 61: C:\...\Temp\embulk\2015-08-14 09:04:38.267 UTC
        at sun.nio.fs.WindowsPathParser.normalize(sun/nio/fs/WindowsPathParser.java:182)
        at sun.nio.fs.WindowsPathParser.parse(sun/nio/fs/WindowsPathParser.java:153)
        at sun.nio.fs.WindowsPathParser.parse(sun/nio/fs/WindowsPathParser.java:77)
        at sun.nio.fs.WindowsPath.parse(sun/nio/fs/WindowsPath.java:94)
        at sun.nio.fs.WindowsFileSystem.getPath(sun/nio/fs/WindowsFileSystem.java:255)
        at java.io.File.toPath(java/io/File.java:2186)
        at org.embulk.spi.TempFileSpace.deleteFilesIfExistsRecursively(org/embulk/spi/TempFileSpace.java:63)
        at org.embulk.spi.TempFileSpace.cleanup(org/embulk/spi/TempFileSpace.java:52)
        at org.embulk.spi.ExecSession.cleanup(org/embulk/spi/ExecSession.java:209)
        at org.embulk.command.Runner.run(org/embulk/command/Runner.java:195)
        at org.embulk.command.Runner.main(org/embulk/command/Runner.java:117)
        at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:606)
        ...
</pre>