### PR TITLE
Add AppVeyor settings to start Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+version: "{branch} {build}"
+
+build:
+  verbosity: detailed
+
+build_script:
+  - gradlew.bat --info --no-daemon check rubyTest
+
+cache:
+  - C:\Users\appveyor\.gradle
+
+environment:
+  matrix:
+  - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  # - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
+
+test: off
+
+matrix:
+  fast_finish: true

--- a/build.gradle
+++ b/build.gradle
@@ -240,8 +240,7 @@ project(':embulk-cli') {
 }
 
 task rubyTest(type: JRubyExec) {
-    jrubyArgs '-Ilib', '-Itest', '-rtest/unit', '--debug', '-eARGV.replace([]); Test::Unit::AutoRunner.run(true, "test")'
-    script './lib/embulk/version.rb'  // dummy
+    jrubyArgs '-Ilib', '-Itest', '-rtest/unit', '--debug', './test/run-test.rb'
 }
 rubyTest.dependsOn('classpath')
 

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -1,0 +1,14 @@
+base_dir = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+lib_dir = File.join(base_dir, "lib")
+test_dir = File.join(base_dir, "test")
+
+$LOAD_PATH.unshift(lib_dir)
+$LOAD_PATH.unshift(test_dir)
+
+require "test/unit"
+
+Dir.glob("#{base_dir}/test/**/test{_,-}*.rb") do |file|
+  require file.sub(/\.rb$/,"")
+end
+
+exit Test::Unit::AutoRunner.run


### PR DESCRIPTION
Windows CI settings for AppVeyor.
And I added `run-test.rb` to avoid curious rubyTest error on Windows.

NOTE: Currently, only 64bit version task is enabled.