### PR TITLE
Add DataException and UserDataException tag interface

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/ConfigException.java
+++ b/embulk-core/src/main/java/org/embulk/config/ConfigException.java
@@ -2,6 +2,7 @@ package org.embulk.config;
 
 public class ConfigException
         extends RuntimeException
+        implements UserDataException
 {
     public ConfigException(String message)
     {

--- a/embulk-core/src/main/java/org/embulk/config/UserDataException.java
+++ b/embulk-core/src/main/java/org/embulk/config/UserDataException.java
@@ -1,0 +1,4 @@
+package org.embulk.config;
+
+public interface UserDataException
+{ }

--- a/embulk-core/src/main/java/org/embulk/config/UserDataExceptions.java
+++ b/embulk-core/src/main/java/org/embulk/config/UserDataExceptions.java
@@ -1,0 +1,17 @@
+package org.embulk.config;
+
+public class UserDataExceptions
+{
+    private UserDataExceptions() { }
+
+    public boolean isUserDataException(Throwable exception)
+    {
+        while (exception != null) {
+            if (exception instanceof UserDataException) {
+                return true;
+            }
+            exception = exception.getCause();
+        }
+        return false;
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/DataException.java
+++ b/embulk-core/src/main/java/org/embulk/spi/DataException.java
@@ -1,0 +1,23 @@
+package org.embulk.spi;
+
+import org.embulk.config.UserDataException;
+
+public class DataException
+        extends RuntimeException
+        implements UserDataException
+{
+    public DataException(String message)
+    {
+        super(message);
+    }
+
+    public DataException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public DataException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParseException.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParseException.java
@@ -1,7 +1,10 @@
 package org.embulk.spi.time;
 
+import org.embulk.config.UserDataException;
+
 public class TimestampParseException
         extends Exception
+        implements UserDataException
 {
     public TimestampParseException(String message)
     {

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -22,6 +22,7 @@ import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FileInput;
 import org.embulk.spi.PageOutput;
+import org.embulk.spi.DataException;
 import org.embulk.spi.util.LineDecoder;
 import org.embulk.spi.util.Timestamps;
 import org.slf4j.Logger;
@@ -369,7 +370,7 @@ public class CsvParserPlugin
     }
 
     static class CsvRecordValidateException
-            extends RuntimeException
+            extends DataException
     {
         CsvRecordValidateException(Throwable cause)
         {

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.ArrayDeque;
+import org.embulk.spi.DataException;
 import org.embulk.spi.util.LineDecoder;
 
 public class CsvTokenizer
@@ -365,7 +366,7 @@ public class CsvTokenizer
     }
 
     public static class InvalidFormatException
-            extends RuntimeException
+            extends DataException
     {
         public InvalidFormatException(String message)
         {
@@ -374,7 +375,7 @@ public class CsvTokenizer
     }
 
     public static class InvalidValueException
-            extends RuntimeException
+            extends DataException
     {
         public InvalidValueException(String message)
         {

--- a/lib/embulk/error.rb
+++ b/lib/embulk/error.rb
@@ -1,6 +1,15 @@
 
 module Embulk
+  module UserDataError
+    include Java::Config::UserDataException
+  end
+
   class ConfigError < StandardError
+    include UserDataError
+  end
+
+  class DataError < StandardError
+    include UserDataError
   end
 
   class PluginLoadError < StandardError


### PR DESCRIPTION
An exception class DataException is expected to be thrown if input data
has a problem (e.g. unexpected timestamp format).

An interface UserDataException is implemented by exception classes which
represent a problem of input data by users. For example,
ConfigException, DataException and TimestampParseException. If those
exceptions are thrown, applications are suggested not to retry this bulk
load because retried bulk import will fail again unless user's input
data is fixed.

