### PR TITLE
Fix selfupdate subcommand

### DIFF
--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -253,7 +253,7 @@ examples:
 
     when :selfupdate
       require 'embulk/command/embulk_selfupdate'
-      Embulk.selfupdate(system)
+      Embulk.selfupdate(options)
 
     else
       require 'json'

--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -173,7 +173,7 @@ examples:
 
     when :selfupdate
       op.on('-f', "Skip corruption check", TrueClass) do |b|
-        system[:force] = true
+        options[:force] = true
       end
       args = 0..0
 


### PR DESCRIPTION
To avoid curious result, I use `options` in Embulk.selfupdate argument instead of `system`.

Related to #280.