### PR TITLE
Add out_columns parameter definition (ruby-filter template)

### DIFF
--- a/lib/embulk/data/new/ruby/filter.rb.erb
+++ b/lib/embulk/data/new/ruby/filter.rb.erb
@@ -12,6 +12,14 @@ module Embulk
           "option3" => config.param("option3", :string, default: nil),        # string, optional
         }
 
+        columns = [
+          Column.new(nil, "example", :string),
+          Column.new(nil, "column", :long),
+          Column.new(nil, "value", :double),
+        ]
+
+       out_columns = in_schema + columns
+
         yield(task, out_columns)
       end
 
@@ -27,8 +35,9 @@ module Embulk
 
       def add(page)
         # filtering code:
+        add_columns = ["example",1,1.0]
         page.each do |record|
-          page_builder.add(record)
+          page_builder.add(record + add_columns)
         end
       end
 


### PR DESCRIPTION
ruby-filter template does not define ``out_columns``

alternative idea

```ruby
yield(task, in_schema)
```