### PR TITLE
Fix fail migrate on windows.

### DIFF
--- a/lib/embulk/command/embulk_migrate_plugin.rb
+++ b/lib/embulk/command/embulk_migrate_plugin.rb
@@ -46,7 +46,7 @@ module Embulk
       # gradle < 2.6
       require 'embulk/data/package_data'
       data = PackageData.new("new", migrator.path)
-      migrator.write "gradle/wrapper/gradle-wrapper.jar", data.content("java/gradle/wrapper/gradle-wrapper.jar")
+      migrator.write "gradle/wrapper/gradle-wrapper.jar", data.bincontent("java/gradle/wrapper/gradle-wrapper.jar")
       migrator.write "gradle/wrapper/gradle-wrapper.properties", data.content("java/gradle/wrapper/gradle-wrapper.properties")
     end
 

--- a/lib/embulk/data/package_data.rb
+++ b/lib/embulk/data/package_data.rb
@@ -16,6 +16,10 @@ module Embulk
       File.read(path(src))
     end
 
+    def bincontent(src)
+      File.binread(path(src))
+    end
+
     def erb(src)
       require 'erb'
       ERB.new(content(src), nil, '%').result(@erb_binding)


### PR DESCRIPTION
Use File#binread, when copy 'gradle-wrapper.jar'.
see #286 issue.