### PR TITLE
Add experimental Mixin mechanism (WIP)

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.5.3'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.5.3'
     compile 'com.fasterxml.jackson.module:jackson-module-guice:2.5.3'
+    compile 'org.msgpack:msgpack-core:0.7.0-p9'
     compile 'ch.qos.logback:logback-classic:1.1.3'
     compile 'org.slf4j:slf4j-api:1.7.12'
     compile 'org.jruby:jruby-complete:' + project.jrubyVersion

--- a/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
@@ -2,6 +2,7 @@ package org.embulk.exec;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ExecutorService;
@@ -15,6 +16,7 @@ import org.embulk.spi.ExecutorPlugin;
 import org.embulk.spi.ProcessTask;
 import org.embulk.spi.ProcessState;
 import org.embulk.spi.Schema;
+import org.embulk.spi.MixinId;
 import org.embulk.spi.util.Executors;
 import org.embulk.spi.util.Executors.ProcessStateCallback;
 
@@ -113,7 +115,7 @@ public class LocalExecutorPlugin
                             state.getInputTaskState(taskIndex).setTaskReport(report);
                         }
 
-                        public void outputCommitted(TaskReport report)
+                        public void outputCommitted(TaskReport report, Map<MixinId, TaskReport> mixinReports)
                         {
                             state.getOutputTaskState(taskIndex).setTaskReport(report);
                         }

--- a/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
@@ -118,6 +118,7 @@ public class LocalExecutorPlugin
                         public void outputCommitted(TaskReport report, Map<MixinId, TaskReport> mixinReports)
                         {
                             state.getOutputTaskState(taskIndex).setTaskReport(report);
+                            state.getOutputTaskState(taskIndex).setMixinReports(mixinReports);
                         }
                     });
                     return null;

--- a/embulk-core/src/main/java/org/embulk/exec/MixinContexts.java
+++ b/embulk-core/src/main/java/org/embulk/exec/MixinContexts.java
@@ -1,0 +1,146 @@
+package org.embulk.exec;
+
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.UUID;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.embulk.config.TaskReport;
+import org.embulk.spi.MixinId;
+
+public class MixinContexts
+{
+    private static final InheritableThreadLocal<MixinSession> session = new InheritableThreadLocal<MixinSession>();
+
+    public static <T> T transaction(ReportCollector collector, Action<T> action)
+    {
+        MixinSession before = session.get();
+        try {
+            session.set(new MixinSession(collector));
+            return action.run();
+        }
+        finally {
+            session.set(before);
+        }
+    }
+
+    public interface ReportCollector
+    {
+        List<Map<MixinId, TaskReport>> getMixinReports();
+    }
+
+    public static List<TaskReport> getTransactionReport(MixinId instanceId)
+    {
+        MixinSession s = session.get();
+        if (s == null) {
+            throw new NullPointerException("Not in Transaction");
+        }
+        return s.getTransactionReport(instanceId);
+    }
+
+    private static class MixinSession
+    {
+        private final ReportCollector collector;
+
+        public MixinSession(ReportCollector collector)
+        {
+            this.collector = collector;
+        }
+
+        public List<TaskReport> getTransactionReport(MixinId instanceId)
+        {
+            List<Map<MixinId, TaskReport>> reports = collector.getMixinReports();
+
+            ImmutableList.Builder<TaskReport> builder = ImmutableList.builder();
+            for (Map<MixinId, TaskReport> report : reports) {
+                TaskReport r = report.get(instanceId);
+                if (r != null) {
+                    builder.add(r);
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private static final InheritableThreadLocal<MixinTaskSession> taskSession = new InheritableThreadLocal<MixinTaskSession>();
+
+    public static <T> ResultWithReports<T> runTask(Action<T> action)
+    {
+        MixinTaskSession before = taskSession.get();
+        try {
+            MixinTaskSession s = new MixinTaskSession(before);
+            taskSession.set(s);
+            T result = action.run();
+            return new ResultWithReports<T>(result, s.getTaskReports());
+        }
+        finally {
+            taskSession.set(before);
+        }
+    }
+
+    public static void reportTask(MixinId instanceId, TaskReport taskReport)
+    {
+        MixinTaskSession ts = taskSession.get();
+        if (ts == null) {
+            throw new NullPointerException("Not running a task");
+        }
+        ts.reportTask(instanceId, taskReport);
+    }
+
+    public static MixinId newMixinId()
+    {
+        return new MixinId(UUID.randomUUID().toString());
+    }
+
+    private static class MixinTaskSession
+    {
+        private final MixinTaskSession nestedSession;
+        private Map<MixinId, TaskReport> map = new HashMap<MixinId, TaskReport>();
+
+        public MixinTaskSession(MixinTaskSession nestedSession)
+        {
+            this.nestedSession = nestedSession;
+        }
+
+        public void reportTask(MixinId instanceId, TaskReport report)
+        {
+            map.put(instanceId, report);
+            if (nestedSession != null) {
+                nestedSession.reportTask(instanceId, report);
+            }
+        }
+
+        public Map<MixinId, TaskReport> getTaskReports()
+        {
+            return ImmutableMap.copyOf(map);
+        }
+    }
+
+    public static interface Action <T>
+    {
+        T run();
+    }
+
+    public static class ResultWithReports <T>
+    {
+        private final T result;
+        private final Map<MixinId, TaskReport> reports;
+
+        public ResultWithReports(T result, Map<MixinId, TaskReport> reports)
+        {
+            this.result = result;
+            this.reports = reports;
+        }
+
+        public T getResult()
+        {
+            return result;
+        }
+
+        public Map<MixinId, TaskReport> getReports()
+        {
+            return reports;
+        }
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/exec/ResumeState.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ResumeState.java
@@ -1,6 +1,7 @@
 package org.embulk.exec;
 
 import java.util.List;
+import java.util.Map;
 import com.google.common.base.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -10,6 +11,7 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.CommitReport;
 import org.embulk.spi.Schema;
+import org.embulk.spi.MixinId;
 
 public class ResumeState
 {
@@ -20,6 +22,8 @@ public class ResumeState
     private final Schema outputSchema;
     private final List<Optional<TaskReport>> inputTaskReports;
     private final List<Optional<TaskReport>> outputTaskReports;
+    private final List<Map<MixinId, TaskReport>> inputMixinReports;
+    private final List<Map<MixinId, TaskReport>> outputMixinReports;
 
     @JsonCreator
     public ResumeState(
@@ -29,7 +33,9 @@ public class ResumeState
             @JsonProperty("in_schema") Schema inputSchema,
             @JsonProperty("out_schema") Schema outputSchema,
             @JsonProperty("in_reports") List<Optional<TaskReport>> inputTaskReports,
-            @JsonProperty("out_reports") List<Optional<TaskReport>> outputTaskReports)
+            @JsonProperty("out_reports") List<Optional<TaskReport>> outputTaskReports,
+            @JsonProperty("in_mixin_reports") List<Map<MixinId, TaskReport>> inputMixinReports,
+            @JsonProperty("out_mixin_reports") List<Map<MixinId, TaskReport>> outputMixinReports)
     {
         this.execSessionConfigSource = execSessionConfigSource;
         this.inputTaskSource = inputTaskSource;
@@ -38,6 +44,8 @@ public class ResumeState
         this.outputSchema = outputSchema;
         this.inputTaskReports = inputTaskReports;
         this.outputTaskReports = outputTaskReports;
+        this.inputMixinReports = inputMixinReports;
+        this.outputMixinReports = outputMixinReports;
     }
 
     @JsonProperty("exec_task")
@@ -96,5 +104,17 @@ public class ResumeState
     public List<Optional<CommitReport>> getOutputCommitReports()
     {
         return (List) outputTaskReports;  // the only implementation of TaskReport is DataSourceImpl which implements CommitReport;
+    }
+
+    @JsonProperty("in_mixin_reports")
+    public List<Map<MixinId, TaskReport>> getInputMixinReports()
+    {
+        return inputMixinReports;
+    }
+
+    @JsonProperty("out_mixin_reports")
+    public List<Map<MixinId, TaskReport>> getOutputMixinReports()
+    {
+        return outputMixinReports;
     }
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginManager.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginManager.java
@@ -72,8 +72,8 @@ public class PluginManager
 
         for (Field targetField : plugin.getClass().getDeclaredFields()) {
             if (targetField.getAnnotation(PluginMixin.class) != null) {
-                Class<?> mixinClass = targetField.getClass();
-                if (Mixin.class.isAssignableFrom(mixinClass)) {
+                Class<?> mixinClass = targetField.getType();
+                if (!Mixin.class.isAssignableFrom(mixinClass)) {
                     throw new NullPointerException(String.format(
                                 "Field %s.%s with @PluginMixin must be subclass of Mixin<%s>",
                                 plugin.getClass().getName(), targetField.getName(), iface.getSimpleName()));
@@ -110,7 +110,7 @@ public class PluginManager
                                 plugin.getClass().getName(), setterMethod.getName()));
                 }
                 Class<?> mixinClass = args[0];
-                if (Mixin.class.isAssignableFrom(mixinClass)) {
+                if (!Mixin.class.isAssignableFrom(mixinClass)) {
                     throw new NullPointerException(String.format(
                                 "Argument of method %s.%s with @PluginMixin must be subclass of Mixin<%s>",
                                 plugin.getClass().getName(), setterMethod.getName(), iface.getSimpleName()));

--- a/embulk-core/src/main/java/org/embulk/spi/ErrorPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ErrorPlugin.java
@@ -1,0 +1,18 @@
+package org.embulk.spi;
+
+import java.util.List;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskSource;
+import org.embulk.config.TaskReport;
+
+public interface ErrorPlugin
+{
+    public static interface Control
+    {
+        List<TaskReport> run(TaskSource taskSource);
+    }
+
+    void transaction(ConfigSource config, ErrorPlugin.Control control);
+
+    TransactionalValueOutput open(TaskSource taskSource);
+}

--- a/embulk-core/src/main/java/org/embulk/spi/Exec.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Exec.java
@@ -1,5 +1,6 @@
 package org.embulk.spi;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import com.google.inject.Injector;
@@ -10,6 +11,7 @@ import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskSource;
 import org.embulk.plugin.PluginType;
+import org.embulk.spi.MixinId;
 import org.embulk.spi.time.Timestamp;
 
 public class Exec
@@ -20,13 +22,14 @@ public class Exec
 
     public static <T> T doWith(ExecSession session, ExecAction<T> action) throws ExecutionException
     {
+        ExecSession before = Exec.session.get();
         Exec.session.set(session);
         try {
             return action.run();
         } catch (Exception ex) {
             throw new ExecutionException(ex);
         } finally {
-            Exec.session.set(null);
+            Exec.session.set(before);
         }
     }
 
@@ -109,5 +112,20 @@ public class Exec
     public static boolean isPreview()
     {
         return session().isPreview();
+    }
+
+    public static MixinId newMixinId()
+    {
+        return session().newMixinId();
+    }
+
+    public static void reportMixinTask(MixinId instanceId, TaskReport taskReport)
+    {
+        session().reportMixinTask(instanceId, taskReport);
+    }
+
+    public static List<TaskReport> getMixinReports(MixinId instanceId)
+    {
+        return session().getMixinReports(instanceId);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -1,5 +1,6 @@
 package org.embulk.spi;
 
+import java.util.List;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.ILoggerFactory;
@@ -15,6 +16,7 @@ import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskSource;
 import org.embulk.config.DataSourceImpl;
+import org.embulk.exec.MixinContexts;
 import org.embulk.exec.TempFileAllocator;
 import org.embulk.plugin.PluginType;
 import org.embulk.plugin.PluginManager;
@@ -208,6 +210,21 @@ public class ExecSession
     public boolean isPreview()
     {
         return preview;
+    }
+
+    public MixinId newMixinId()
+    {
+        return MixinContexts.newMixinId();
+    }
+
+    public void reportMixinTask(MixinId instanceId, TaskReport taskReport)
+    {
+        MixinContexts.reportTask(instanceId, taskReport);
+    }
+
+    public List<TaskReport> getMixinReports(MixinId instanceId)
+    {
+        return MixinContexts.getTransactionReport(instanceId);
     }
 
     public void cleanup()

--- a/embulk-core/src/main/java/org/embulk/spi/Mixin.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Mixin.java
@@ -1,0 +1,6 @@
+package org.embulk.spi;
+
+public interface Mixin <T>
+{
+    public T mixin(T target);
+}

--- a/embulk-core/src/main/java/org/embulk/spi/MixinId.java
+++ b/embulk-core/src/main/java/org/embulk/spi/MixinId.java
@@ -1,0 +1,43 @@
+package org.embulk.spi;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class MixinId
+{
+    private String id;
+
+    @JsonCreator
+    public MixinId(String id)
+    {
+        this.id = id;
+    }
+
+    @JsonValue
+    public String getString()
+    {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof MixinId)) {
+            return false;
+        }
+        MixinId obj = (MixinId) o;
+        return id.equals(obj.id);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return id;
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/PluginMixin.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PluginMixin.java
@@ -1,0 +1,14 @@
+package org.embulk.spi;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface PluginMixin
+{
+}

--- a/embulk-core/src/main/java/org/embulk/spi/TaskState.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TaskState.java
@@ -1,6 +1,9 @@
 package org.embulk.spi;
 
+import java.util.Map;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import org.embulk.spi.MixinId;
 import org.embulk.config.TaskReport;
 import org.embulk.config.CommitReport;
 
@@ -9,6 +12,7 @@ public class TaskState
     private volatile boolean started = false;
     private volatile boolean finished = false;
     private volatile Optional<TaskReport> taskReport = Optional.absent();
+    private volatile Map<MixinId, TaskReport> mixinReports = ImmutableMap.of();
     private volatile Optional<Throwable> exception = Optional.absent();
 
     public void start()
@@ -33,6 +37,11 @@ public class TaskState
     {
         this.started = true;
         this.taskReport = Optional.<TaskReport>of(commitReport);
+    }
+
+    public void setMixinReports(Map<MixinId, TaskReport> mixinReports)
+    {
+        this.mixinReports = mixinReports;
     }
 
     public void setException(Throwable exception)
@@ -72,6 +81,11 @@ public class TaskState
     public Optional<CommitReport> getCommitReport()
     {
         return (Optional) taskReport;  // the only implementation of TaskReport is DataSourceImpl which implements CommitReport;
+    }
+
+    public Map<MixinId, TaskReport> getMixinReports()
+    {
+        return mixinReports;
     }
 
     public Optional<Throwable> getException()

--- a/embulk-core/src/main/java/org/embulk/spi/TransactionalValueOutput.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TransactionalValueOutput.java
@@ -1,0 +1,16 @@
+package org.embulk.spi;
+
+import org.msgpack.value.Value;
+import org.embulk.config.TaskReport;
+
+public interface TransactionalValueOutput
+        extends Transactional, ValueOutput
+{
+    void add(Value value);
+
+    void abort();
+
+    TaskReport commit();
+
+    void close();
+}

--- a/embulk-core/src/main/java/org/embulk/spi/ValueOutput.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ValueOutput.java
@@ -1,0 +1,12 @@
+package org.embulk.spi;
+
+import org.msgpack.value.Value;
+
+public interface ValueOutput
+        extends AutoCloseable
+{
+    void add(Value value);
+
+    void close();
+}
+

--- a/embulk-core/src/main/java/org/embulk/spi/util/ParserErrorMixin.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/ParserErrorMixin.java
@@ -1,0 +1,127 @@
+package org.embulk.spi.util;
+
+import java.util.List;
+import com.google.common.base.Optional;
+import org.msgpack.value.Value;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.Task;
+import org.embulk.config.TaskSource;
+import org.embulk.config.TaskReport;
+import org.embulk.plugin.PluginType;
+import org.embulk.spi.ParserPlugin;
+import org.embulk.spi.TransactionalValueOutput;
+import org.embulk.spi.ErrorPlugin;
+import org.embulk.spi.Schema;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.Exec;
+import org.embulk.spi.Mixin;
+import org.embulk.spi.MixinId;
+import org.embulk.spi.FileInput;
+
+public class ParserErrorMixin
+        implements Mixin<ParserPlugin>
+{
+    private Wrapper wrapper;
+
+    public static ParserErrorMixin empty()
+    {
+        // TODO return something meaningful
+        return null;
+    }
+
+    @Override
+    public ParserPlugin mixin(ParserPlugin plugin)
+    {
+        this.wrapper = new Wrapper(plugin);
+        return wrapper;
+    }
+
+    public void add(Value record)
+    {
+        TransactionalValueOutput out = wrapper.errorOutput;
+        if (out == null) {
+            throw new IllegalStateException("ParserErrorMixin.error is available only at task context");
+        }
+        out.add(record);
+    }
+
+    private static class Wrapper
+            implements ParserPlugin
+    {
+        public static interface WrapperTask
+                extends Task
+        {
+            @Config("error")
+            @ConfigDefault("null")
+            public Optional<ConfigSource> getErrorConfig();
+        }
+
+        private final ParserPlugin plugin;
+        private TransactionalValueOutput errorOutput;
+
+        public Wrapper(ParserPlugin plugin)
+        {
+            this.plugin = plugin;
+        }
+
+        public void transaction(ConfigSource config, final ParserPlugin.Control control)
+        {
+            WrapperTask task = config.loadConfig(WrapperTask.class);
+            final ConfigSource errorConfig = task.getErrorConfig().or(
+                    Exec.newConfigSource().set("type", "warn")  // TODO configurable default error plugin type
+                    );
+            final PluginType errorType = errorConfig.get(PluginType.class, "type");
+            final ErrorPlugin error = Exec.newPlugin(ErrorPlugin.class, errorType);
+
+            plugin.transaction(config, new ParserPlugin.Control() {
+                public void run(final TaskSource pluginTaskSource, final Schema pluginSchema)
+                {
+                    error.transaction(errorConfig, new ErrorPlugin.Control() {
+                        public List<TaskReport> run(TaskSource errorTaskSource)
+                        {
+                            MixinId mixinId = Exec.newMixinId();
+                            TaskSource taskSource = Exec.newTaskSource()
+                                .set("PluginTaskSource", pluginTaskSource)
+                                .set("ErrorPluginType", errorType)
+                                .set("ErrorTaskSource", errorTaskSource)
+                                .set("MixinId", mixinId);
+                            control.run(taskSource, pluginSchema);
+                            return Exec.getMixinReports(mixinId);
+                        }
+                    });
+                }
+            });
+        }
+
+        public void run(TaskSource taskSource, Schema schema,
+                FileInput input, PageOutput output)
+        {
+            TaskSource pluginTaskSource = taskSource.get(TaskSource.class, "PluginTaskSource");
+            PluginType errorType = taskSource.get(PluginType.class, "ErrorPluginType");
+            TaskSource errorTaskSource = taskSource.get(TaskSource.class, "ErrorTaskSource");
+            ErrorPlugin error = Exec.newPlugin(ErrorPlugin.class, errorType);
+            MixinId mixinId = taskSource.get(MixinId.class, "MixinId");
+
+            TransactionalValueOutput tran = errorOutput = error.open(errorTaskSource);
+            try {
+                plugin.run(pluginTaskSource, schema, input, output);
+                TaskReport report = tran.commit();
+                tran = null;
+                Exec.reportMixinTask(mixinId, report);
+            }
+            finally {
+                try {
+                    if (tran != null) {
+                        tran.abort();
+                    }
+                }
+                finally {
+                    errorOutput.close();
+                    errorOutput = null;
+                }
+            }
+        }
+    }
+}

--- a/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
@@ -3,6 +3,7 @@ package org.embulk.standards;
 import com.google.common.base.Preconditions;
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import org.embulk.spi.ErrorPlugin;
 import org.embulk.spi.FilterPlugin;
 import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
@@ -44,6 +45,9 @@ public class StandardPluginModule
 
         // filter plugins
         registerPluginTo(binder, FilterPlugin.class, "rename", RenameFilterPlugin.class);
+
+        // error plugins
+        registerPluginTo(binder, ErrorPlugin.class, "warn", WarnErrorPlugin.class);
 
         // default guess plugins
         registerDefaultGuessPluginTo(binder, new PluginType("gzip"));

--- a/embulk-standards/src/main/java/org/embulk/standards/WarnErrorPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/WarnErrorPlugin.java
@@ -2,12 +2,16 @@ package org.embulk.standards;
 
 import java.util.List;
 import org.slf4j.Logger;
+import com.google.common.base.Optional;
 import org.msgpack.value.Value;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.Exec;
+import org.embulk.spi.DataException;
 import org.embulk.spi.TransactionalValueOutput;
 import org.embulk.spi.ErrorPlugin;
 
@@ -19,30 +23,40 @@ public class WarnErrorPlugin
     public static interface PluginTask
             extends Task
     {
+        @Config("max_error_records")
+        @ConfigDefault("null")
+        public Optional<Long> getMaxErrorRecords();
     }
 
     public void transaction(ConfigSource config, ErrorPlugin.Control control)
     {
         PluginTask task = config.loadConfig(PluginTask.class);
         List<TaskReport> reports = control.run(task.dump());
-        int total = 0;
+        long total = 0;
         for (TaskReport report : reports) {
-            total += report.get(int.class, "error_count");
+            total += report.get(long.class, "error_count");
+        }
+        if (task.getMaxErrorRecords().isPresent() && total > task.getMaxErrorRecords().get()) {
+            throw new DataException("Number of error records exceeds max_error_records");
         }
         logger.info("Error records: {}", total);
     }
 
     public TransactionalValueOutput open(TaskSource taskSource)
     {
-        PluginTask task = taskSource.loadTask(PluginTask.class);
+        final PluginTask task = taskSource.loadTask(PluginTask.class);
         return new TransactionalValueOutput()
         {
-            private int count = 0;
+            private long count = 0;
+            private long maxErrorRecords = task.getMaxErrorRecords().or(-1L);
 
             public void add(Value value)
             {
                 logger.warn("Error record: "+value);
                 count++;
+                if (count > maxErrorRecords) {
+                    throw new DataException("Number of error records exceeds max_error_records");
+                }
             }
 
             public void abort()

--- a/embulk-standards/src/main/java/org/embulk/standards/WarnErrorPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/WarnErrorPlugin.java
@@ -1,0 +1,63 @@
+package org.embulk.standards;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.msgpack.value.Value;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.Task;
+import org.embulk.config.TaskSource;
+import org.embulk.config.TaskReport;
+import org.embulk.spi.Exec;
+import org.embulk.spi.TransactionalValueOutput;
+import org.embulk.spi.ErrorPlugin;
+
+public class WarnErrorPlugin
+        implements ErrorPlugin
+{
+    private Logger logger = Exec.getLogger(WarnErrorPlugin.class);
+
+    public static interface PluginTask
+            extends Task
+    {
+    }
+
+    public void transaction(ConfigSource config, ErrorPlugin.Control control)
+    {
+        PluginTask task = config.loadConfig(PluginTask.class);
+        List<TaskReport> reports = control.run(task.dump());
+        int total = 0;
+        for (TaskReport report : reports) {
+            total += report.get(int.class, "error_count");
+        }
+        logger.info("Error records: {}", total);
+    }
+
+    public TransactionalValueOutput open(TaskSource taskSource)
+    {
+        PluginTask task = taskSource.loadTask(PluginTask.class);
+        return new TransactionalValueOutput()
+        {
+            private int count = 0;
+
+            public void add(Value value)
+            {
+                logger.warn("Error record: "+value);
+                count++;
+            }
+
+            public void abort()
+            {
+            }
+
+            public TaskReport commit()
+            {
+                return Exec.newTaskReport()
+                    .set("error_count", count);
+            }
+
+            public void close()
+            {
+            }
+        };
+    }
+}


### PR DESCRIPTION
Mixin is a meta-plugin that wraps another plugin. A mixin enhances
functionality of a plugin, and/or provides API to a plugin.

Plugins with fields annotated by @PluginMixin can use mixin:

```
@PluginMixin
ParserErrorMixin error;
```

or

```
@PluginMixin
void setError(ParserErrorMixin error)
```

This field is filled by PluginManager. Plugins can call methods of the
mixin instance at transaction and run/open methods.

A mixin class (such as LineParserErrorMixin) implements `T mixin(T)`
method where T is an instance of the plugin. Typically, it returns a
wrapped plugin instance.

Mixin classes can use TaskReport mechanism. At transaction stage, mixin
class calls `Exec.newMixinId()` to get a MixinId. At task stage, mixin
sets TaskReport using `Exec.reportMixinTask(MixinId, TaskReport` method.
Then at transaction stage again, mixin gathers TaskReport of tasks using
`Exec.getMixinReports(MixinId)` method.
