### PR TITLE
Added exec.guess_plugins option for guess executor

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -224,7 +224,7 @@ public class EmbulkEmbed
 
     private ExecSession newExecSession(ConfigSource config)
     {
-        ConfigSource execConfig = config.deepCopy().getNestedOrSetEmpty("exec");
+        ConfigSource execConfig = config.deepCopy().getNestedOrGetEmpty("exec");
         return ExecSession.builder(injector).fromExecConfig(execConfig).build();
     }
 

--- a/embulk-core/src/main/java/org/embulk/config/CommitReport.java
+++ b/embulk-core/src/main/java/org/embulk/config/CommitReport.java
@@ -14,6 +14,9 @@ public interface CommitReport
     CommitReport getNestedOrSetEmpty(String attrName);
 
     @Override
+    CommitReport getNestedOrGetEmpty(String attrName);
+
+    @Override
     CommitReport set(String attrName, Object v);
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/config/ConfigDiff.java
+++ b/embulk-core/src/main/java/org/embulk/config/ConfigDiff.java
@@ -10,6 +10,9 @@ public interface ConfigDiff
     ConfigDiff getNestedOrSetEmpty(String attrName);
 
     @Override
+    ConfigDiff getNestedOrGetEmpty(String attrName);
+
+    @Override
     ConfigDiff set(String attrName, Object v);
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/config/ConfigSource.java
+++ b/embulk-core/src/main/java/org/embulk/config/ConfigSource.java
@@ -12,6 +12,9 @@ public interface ConfigSource
     ConfigSource getNestedOrSetEmpty(String attrName);
 
     @Override
+    ConfigSource getNestedOrGetEmpty(String attrName);
+
+    @Override
     ConfigSource set(String attrName, Object v);
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/config/DataSource.java
+++ b/embulk-core/src/main/java/org/embulk/config/DataSource.java
@@ -23,6 +23,8 @@ public interface DataSource
 
     DataSource getNestedOrSetEmpty(String attrName);
 
+    DataSource getNestedOrGetEmpty(String attrName);
+
     DataSource set(String attrName, Object v);
 
     DataSource setNested(String attrName, DataSource v);

--- a/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
+++ b/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
@@ -115,6 +115,18 @@ public class DataSourceImpl
     }
 
     @Override
+    public DataSourceImpl getNestedOrGetEmpty(String attrName)
+    {
+        JsonNode json = data.get(attrName);
+        if (json == null) {
+            json = data.objectNode();
+        } else if (!json.isObject()) {
+            throw new ConfigException("Attribute "+attrName+" must be an object");
+        }
+        return newInstance(model, (ObjectNode) json);
+    }
+
+    @Override
     public DataSourceImpl set(String attrName, Object v)
     {
         if (v == null) {

--- a/embulk-core/src/main/java/org/embulk/config/TaskReport.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskReport.java
@@ -10,6 +10,9 @@ public interface TaskReport
     TaskReport getNestedOrSetEmpty(String attrName);
 
     @Override
+    TaskReport getNestedOrGetEmpty(String attrName);
+
+    @Override
     TaskReport set(String attrName, Object v);
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/config/TaskSource.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskSource.java
@@ -12,6 +12,9 @@ public interface TaskSource
     TaskSource getNestedOrSetEmpty(String attrName);
 
     @Override
+    TaskSource getNestedOrGetEmpty(String attrName);
+
+    @Override
     TaskSource set(String attrName, Object v);
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/exec/ConfigurableGuessInputPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ConfigurableGuessInputPlugin.java
@@ -1,0 +1,9 @@
+package org.embulk.exec;
+
+import org.embulk.config.ConfigSource;
+import org.embulk.config.ConfigDiff;
+
+public interface ConfigurableGuessInputPlugin
+{
+    ConfigDiff guess(ConfigSource execConfig, ConfigSource config);
+}

--- a/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
@@ -98,15 +98,21 @@ public class GuessExecutor
     private ConfigDiff doGuess(ConfigSource config)
     {
         ConfigSource inputConfig = config.getNested("in");
+        ConfigSource execConfig = config.getNestedOrGetEmpty("exec");
 
         InputPlugin input = newInputPlugin(inputConfig);
 
         ConfigDiff inputGuessed;
-        try {
-            inputGuessed = input.guess(inputConfig);
-        } catch (AbstractMethodError ex) {
-            // for backward compatibility with embulk v0.4 interface
-            throw new UnsupportedOperationException(input.getClass().getSimpleName()+".guess(ConfigSource) is not implemented. This input plugin does not support guessing.");
+        if (input instanceof ConfigurableGuessInputPlugin) {
+            inputGuessed = ((ConfigurableGuessInputPlugin) input).guess(execConfig, inputConfig);
+        }
+        else {
+            try {
+                inputGuessed = input.guess(inputConfig);
+            } catch (AbstractMethodError ex) {
+                // for backward compatibility with embulk v0.4 interface
+                throw new UnsupportedOperationException(input.getClass().getSimpleName()+".guess(ConfigSource) is not implemented. This input plugin does not support guessing.");
+            }
         }
 
         ConfigDiff wrapped = Exec.newConfigDiff();


### PR DESCRIPTION
New `exec: {guess_plugins: [array]}` option allows users to configure
list of guess plugins within a configuration file.

This is implemented as following: if an input plugin implements
ConfigurableGuessInputPlugin interface, GuessExecutor gives exec config
to guess method. FileInputRunner implements it and takes
guess.guess_plugins parameter.

Fixes [#266].