### PR TITLE
Added '--logback-config' option.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/LoggerProvider.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LoggerProvider.java
@@ -55,6 +55,18 @@ public class LoggerProvider
             throw new RuntimeException(ex);
         }
 
+        String logbackConfig = systemConfig.get(String.class, "logback_config", "-");
+
+        if (!logbackConfig.equals("-")) {
+            System.setProperty("embulk.logbackConfig", logbackConfig);
+
+            try {
+                configurator.doConfigure(logbackConfig);
+            } catch (JoranException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
         org.slf4j.Logger logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         if (logger instanceof Logger) {
             ((Logger) logger).setLevel(Level.toLevel(level.toUpperCase(), Level.DEBUG));

--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -47,6 +47,9 @@ module Embulk
       op.on('-l', '--log-level LEVEL', 'Log level (error, warn, info, debug or trace)') do |level|
         options[:system_config][:log_level] = level
       end
+      op.on('--logback-config PATH', 'Logback configuration file (default: -)') do |config|
+        options[:system_config][:logback_config] = config
+      end
       op.on('-X KEY=VALUE', 'Add a performance system config') do |kv|
         k, v = kv.split('=', 2)
         v ||= "true"


### PR DESCRIPTION
Supports --log PATH option in 'v0.7.4'(#291).
But I want more various logger setting.

## Proposal

1. define '--logback-config LOGBACK_CONFIG_PATH' option.
2. modify read logger setting process.
    - read default setting file after read LOGBACK_CONFIG_PATH file.


### Use '--logback-config' option example

#### 1. create logback.xml

```xml
<!-- Output to './plugin.error.log', only XxxPlugin's Error message. -->
<configuration>
<appender name="ERROR" class="ch.qos.logback.core.FileAppender">
    <file>./app.error.log</file>
    <encoder>
        <charset>UTF-8</charset>
        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss'Z'} - %m%n</pattern>
    </encoder>
</appender>
<logger name="org.embulk.input.xxx.XxxPlugin">
    <level value="ERROR" />
    <appender-ref ref="ERROR" />
</logger>
</configuration>
```


#### 2. set path to '--logback-config' option

```sh
./embulk run --logback-config /PATH/TO/logback.xml ./config.yml
```

Is there any problem?
or have more effective idea?
