### PR TITLE
Purge setCompatVersion code

### DIFF
--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
@@ -62,7 +62,6 @@ public class JRubyScriptingModule
         {
             LocalContextScope scope = (useGlobalRubyRuntime ? LocalContextScope.SINGLETON : LocalContextScope.SINGLETHREAD);
             ScriptingContainer jruby = new ScriptingContainer(scope);
-            jruby.setCompatVersion(CompatVersion.RUBY1_9);
 
             // Search embulk/java/bootstrap.rb from a $LOAD_PATH.
             // $LOAD_PATH is set by lib/embulk/command/embulk_run.rb if Embulk starts


### PR DESCRIPTION
Because this deprecated function has no effect in JRuby 9.0.0.0 or later.

see:
https://github.com/jruby/jruby/blob/e10ec96f39d236e947d969877d138123a8af5344/core/src/main/java/org/jruby/embed/ScriptingContainer.java#L508