### PR TITLE
Fix incorrect line number in warning messages.

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -244,6 +244,7 @@ public class CsvParserPlugin
                     if (lineDecoder.poll() == null) {
                         break;
                     }
+                    tokenizer.skipHeaderLine();
                 }
 
                 if (!tokenizer.nextRecord()) {

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -56,8 +56,12 @@ public class CsvTokenizer
 
     public long getCurrentLineNumber()
     {
-        // returns actual line number. Internally, lineNumber starts at 0.
-        return lineNumber + 1;
+        return lineNumber;
+    }
+
+    public void skipHeaderLine()
+    {
+        lineNumber++;
     }
 
     // returns skipped line


### PR DESCRIPTION
Fix incorrect line number in warning messages.
9e70f55403e9ce3e8836cdafe8db66a43af265e1 is not the right change.
It doesn't work if files have headers. My fault.