### PR TITLE
Fix: NameError exception.

### DIFF
--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -130,7 +130,7 @@ module Embulk
         elsif File.exists?('Gemfile')
           bundle_path = '.'
         else
-          system_exit "'#{path}' already exists. You already ran 'embulk bundle new'. Please remove it, or run \"cd #{path}\" and \"embulk bundle\" instead"
+          system_exit "'#{gemfile_path}' already exists. You already ran 'embulk bundle new'. Please remove it, or run \"cd #{gemfile_path}\" and \"embulk bundle\" instead"
         end
 
         run_bundler(argv)


### PR DESCRIPTION
Please review this patch.

Fix following exception.

```
embulk bundle /tmp/hoge2
2015-09-17 19:21:53.252 +0900: Embulk v0.7.4
NameError: undefined local variable or method `path' for Embulk:Module
      run at /path/to/.embulk/bin/embulk!/embulk/command/embulk_run.rb:133
    <top> at /path/to/.embulk/bin/embulk!/embulk/command/embulk_main.rb:2
  require at org/jruby/RubyKernel.java:940
   (root) at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
    <top> at file:/path/to/.embulk/bin/embulk!/embulk/command/embulk_bundle.rb:55
```
