### PR TITLE
Fix typos in Java-based plugin's templates

### DIFF
--- a/lib/embulk/data/new/java/decoder.java.erb
+++ b/lib/embulk/data/new/java/decoder.java.erb
@@ -26,12 +26,12 @@ public class <%= java_class_name %>
         public int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
-        @Config("optoin2")
+        @Config("option2")
         @ConfigDefault("\"myvalue\"")
         public String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
-        @Config("optoin3")
+        @Config("option3")
         @ConfigDefault("null")
         public Optional<String> getOption3();
 

--- a/lib/embulk/data/new/java/encoder.java.erb
+++ b/lib/embulk/data/new/java/encoder.java.erb
@@ -26,12 +26,12 @@ public class <%= java_class_name %>
         public int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
-        @Config("optoin2")
+        @Config("option2")
         @ConfigDefault("\"myvalue\"")
         public String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
-        @Config("optoin3")
+        @Config("option3")
         @ConfigDefault("null")
         public Optional<String> getOption3();
 

--- a/lib/embulk/data/new/java/file_input.java.erb
+++ b/lib/embulk/data/new/java/file_input.java.erb
@@ -29,12 +29,12 @@ public class <%= java_class_name %>
         public int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
-        @Config("optoin2")
+        @Config("option2")
         @ConfigDefault("\"myvalue\"")
         public String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
-        @Config("optoin3")
+        @Config("option3")
         @ConfigDefault("null")
         public Optional<String> getOption3();
 

--- a/lib/embulk/data/new/java/file_output.java.erb
+++ b/lib/embulk/data/new/java/file_output.java.erb
@@ -24,12 +24,12 @@ public class <%= java_class_name %>
         public int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
-        @Config("optoin2")
+        @Config("option2")
         @ConfigDefault("\"myvalue\"")
         public String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
-        @Config("optoin3")
+        @Config("option3")
         @ConfigDefault("null")
         public Optional<String> getOption3();
 

--- a/lib/embulk/data/new/java/filter.java.erb
+++ b/lib/embulk/data/new/java/filter.java.erb
@@ -23,12 +23,12 @@ public class <%= java_class_name %>
         public int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
-        @Config("optoin2")
+        @Config("option2")
         @ConfigDefault("\"myvalue\"")
         public String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
-        @Config("optoin3")
+        @Config("option3")
         @ConfigDefault("null")
         public Optional<String> getOption3();
     }

--- a/lib/embulk/data/new/java/formatter.java.erb
+++ b/lib/embulk/data/new/java/formatter.java.erb
@@ -23,12 +23,12 @@ public class <%= java_class_name %>
         public int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
-        @Config("optoin2")
+        @Config("option2")
         @ConfigDefault("\"myvalue\"")
         public String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
-        @Config("optoin3")
+        @Config("option3")
         @ConfigDefault("null")
         public Optional<String> getOption3();
     }

--- a/lib/embulk/data/new/java/input.java.erb
+++ b/lib/embulk/data/new/java/input.java.erb
@@ -26,12 +26,12 @@ public class <%= java_class_name %>
         public int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
-        @Config("optoin2")
+        @Config("option2")
         @ConfigDefault("\"myvalue\"")
         public String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
-        @Config("optoin3")
+        @Config("option3")
         @ConfigDefault("null")
         public Optional<String> getOption3();
 

--- a/lib/embulk/data/new/java/output.java.erb
+++ b/lib/embulk/data/new/java/output.java.erb
@@ -26,12 +26,12 @@ public class <%= java_class_name %>
         public int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
-        @Config("optoin2")
+        @Config("option2")
         @ConfigDefault("\"myvalue\"")
         public String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
-        @Config("optoin3")
+        @Config("option3")
         @ConfigDefault("null")
         public Optional<String> getOption3();
     }

--- a/lib/embulk/data/new/java/parser.java.erb
+++ b/lib/embulk/data/new/java/parser.java.erb
@@ -24,12 +24,12 @@ public class <%= java_class_name %>
         public int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
-        @Config("optoin2")
+        @Config("option2")
         @ConfigDefault("\"myvalue\"")
         public String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
-        @Config("optoin3")
+        @Config("option3")
         @ConfigDefault("null")
         public Optional<String> getOption3();
 


### PR DESCRIPTION
I found some typos in Java-based plugin's templates and fixed it.