### PR TITLE
[Proposal] [Temporary] Print embulk bundle usage

### DIFF
--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -119,7 +119,9 @@ module Embulk
       args = 1..1
 
     when :bundle
-      if argv[0] == 'new'
+      if argv.size == 0
+        system_exit "Usage: bundle new <directory>"
+      elsif argv[0] == 'new'
         usage nil if argv.length != 2
         new_bundle(argv[1])
       else


### PR DESCRIPTION
#317 Temporary fix.


```
java -jar ./pkg/embulk-0.7.5.jar bundle 
2015-10-05 12:58:32.555 +0900: Embulk v0.7.5
Usage: bundle new <directory>
```

Note

Should fix following usage.

```
java -jar ./pkg/embulk-0.7.5.jar bundle new
2015-10-05 12:59:22.963 +0900: Embulk v0.7.5
Embulk v0.7.5
usage: <command> [--options]
commands:
   bundle     [directory]                             # create or update plugin environment.
```