### PR TITLE
selfrun.sh: Added argument ERRORLEVEL to exit/b after java command

### DIFF
--- a/embulk-cli/src/main/sh/selfrun.sh
+++ b/embulk-cli/src/main/sh/selfrun.sh
@@ -42,7 +42,7 @@ java %java_args% -jar %this% %jruby_args% %args%
 
 endlocal
 
-exit /b
+exit /b %ERRORLEVEL%
 
 :check_arg
 set arg=%*


### PR DESCRIPTION
For execute on Cygwin, return java command exit code.