### PR TITLE
Human readable ruby plugin error report.

### DIFF
--- a/lib/embulk/data_source.rb
+++ b/lib/embulk/data_source.rb
@@ -138,9 +138,9 @@ module Embulk
 
     def param(key, type, options={})
       if self.has_key?('type')
-        type = self['type'].to_s.dump
+        plugin_name = self['type'].to_s.dump
       else
-        type = "Unkown"
+        plugin_name = "Unknown".dump
       end
       if self.has_key?(key)
         v = self[key]
@@ -150,40 +150,40 @@ module Embulk
             begin
               Integer(v)
             rescue => e
-              raise ConfigError.new e
+              raise ConfigError.new "Plugin(#{plugin_name}) " + e
             end
           when :float
             begin
               Float(v)
             rescue => e
-              raise ConfigError.new e
+              raise ConfigError.new "Plugin(#{plugin_name}) " + e
             end
           when :string
             begin
               String(v).dup
             rescue => e
-              raise ConfigError.new e
+              raise ConfigError.new "Plugin(#{plugin_name}) " + e
             end
           when :bool
             begin
               !!v  # TODO validation
             rescue => e
-              raise ConfigError.new e
+              raise ConfigError.new "Plugin(#{plugin_name}) " + e
             end
           when :hash
-            raise ConfigError.new "Invalid value for :hash" unless v.is_a?(Hash)
+            raise ConfigError.new "Plugin(#{plugin_name}) Config #{key.dump} has invalid value for :hash" unless v.is_a?(Hash)
             DataSource.new.merge!(v)
           when :array
-            raise ConfigError.new "Invalid value for :array" unless v.is_a?(Array)
+            raise ConfigError.new "Plugin(#{plugin_name}) Config #{key.dump} has invalid value for :array" unless v.is_a?(Array)
             v.dup
           else
             unless type.respond_to?(:load)
-              raise ArgumentError, "Unknown type #{type.to_s.dump}"
+              raise ArgumentError, "Plugin(#{plugin_name}) Config #{key.dump} has unknown type #{type.to_s.dump}"
             end
             begin
               type.load(v)
             rescue => e
-              raise ConfigError.new e
+              raise ConfigError.new "Plugin(#{plugin_name}) " + e
             end
           end
 
@@ -191,7 +191,7 @@ module Embulk
         value = options[:default]
 
       else
-        raise ConfigError.new "Plugin: #{type} required field #{key.to_s.dump} is not set"
+        raise ConfigError.new "Plugin(#{plugin_name}) Required field #{key.to_s.dump} is not set"
       end
 
       return value

--- a/lib/embulk/data_source.rb
+++ b/lib/embulk/data_source.rb
@@ -150,25 +150,25 @@ module Embulk
             begin
               Integer(v)
             rescue => e
-              raise ConfigError.new "Plugin(#{plugin_name}) " + e
+              raise ConfigError.new "Plugin(#{plugin_name}) Config #{key.dump} has invalid value for Integer"
             end
           when :float
             begin
               Float(v)
             rescue => e
-              raise ConfigError.new "Plugin(#{plugin_name}) " + e
+              raise ConfigError.new "Plugin(#{plugin_name}) Config #{key.dump} has invalid value for Float"
             end
           when :string
             begin
               String(v).dup
             rescue => e
-              raise ConfigError.new "Plugin(#{plugin_name}) " + e
+              raise ConfigError.new "Plugin(#{plugin_name}) Config #{key.dump} has invalid value for String"
             end
           when :bool
             begin
               !!v  # TODO validation
             rescue => e
-              raise ConfigError.new "Plugin(#{plugin_name}) " + e
+              raise ConfigError.new "Plugin(#{plugin_name}) Config #{key.dump} has invalid value for Boolean"
             end
           when :hash
             raise ConfigError.new "Plugin(#{plugin_name}) Config #{key.dump} has invalid value for :hash" unless v.is_a?(Hash)
@@ -183,7 +183,7 @@ module Embulk
             begin
               type.load(v)
             rescue => e
-              raise ConfigError.new "Plugin(#{plugin_name}) " + e
+              raise ConfigError.new "Plugin(#{plugin_name}) " + e.to_s
             end
           end
 

--- a/lib/embulk/data_source.rb
+++ b/lib/embulk/data_source.rb
@@ -137,6 +137,11 @@ module Embulk
     end
 
     def param(key, type, options={})
+      if self.has_key?('type')
+        type = self['type'].to_s.dump
+      else
+        type = "Unkown"
+      end
       if self.has_key?(key)
         v = self[key]
         value =
@@ -186,7 +191,7 @@ module Embulk
         value = options[:default]
 
       else
-        raise ConfigError.new "Required field #{key.to_s.dump} is not set"
+        raise ConfigError.new "Plugin: #{type} required field #{key.to_s.dump} is not set"
       end
 
       return value


### PR DESCRIPTION
Current error message is not human readable.

This PR write human readable error report.

ex. 

```
Error: Plugin("hoge") Config "option1" has invalid value for Integer
```

```
Error: Plugin("hoge") Required field "option1" is not set
```
