### PR TITLE
state.isAllTasksCommitted() should be check to throw an exception

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
+++ b/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
@@ -175,6 +175,36 @@ public class BulkLoader
             return true;
         }
 
+        public int countUncommittedInputTasks()
+        {
+            if (inputTaskStates == null) {
+                // not initialized
+                return 0;
+            }
+            int count = 0;
+            for (TaskState inputTaskState : inputTaskStates) {
+                if (!inputTaskState.isCommitted()) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        public int countUncommittedOutputTasks()
+        {
+            if (outputTaskStates == null) {
+                // not initialized
+                return 0;
+            }
+            int count = 0;
+            for (TaskState outputTaskState : outputTaskStates) {
+                if (!outputTaskState.isCommitted()) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
         public boolean isAllTransactionsCommitted()
         {
             return inputConfigDiff != null && outputConfigDiff != null;
@@ -498,6 +528,11 @@ public class BulkLoader
                                                 execute(task, executor, state);
                                             }
 
+                                            if (!state.isAllTasksCommitted()) {
+                                                throw new RuntimeException(String.format("%d input tasks and %d output tasks failed",
+                                                            state.countUncommittedInputTasks(), state.countUncommittedOutputTasks()));
+                                            }
+
                                             return state.getAllOutputTaskReports();
                                         }
                                     });
@@ -561,6 +596,11 @@ public class BulkLoader
                                             restoreResumedTaskReports(resume, state);
                                             if (!state.isAllTasksCommitted()) {
                                                 execute(task, executor, state);
+                                            }
+
+                                            if (!state.isAllTasksCommitted()) {
+                                                throw new RuntimeException(String.format("%d input tasks and %d output tasks failed",
+                                                            state.countUncommittedInputTasks(), state.countUncommittedOutputTasks()));
                                             }
 
                                             return state.getAllOutputTaskReports();


### PR DESCRIPTION
This commit fixes this error happens when an executor finishes without
throwing exceptions but some tasks failed:

```
2015-10-28_20:18:29.04862 Caused by: org.embulk.exec.PartialExecutionException: java.lang.IllegalStateException: Optional.get() cannot be called on an absent value
2015-10-28_20:18:29.04864     at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:333)
2015-10-28_20:18:29.04875     at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:531)
2015-10-28_20:18:29.04878     at org.embulk.exec.BulkLoader.access$100(BulkLoader.java:33)
2015-10-28_20:18:29.04882     at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:344)
2015-10-28_20:18:29.04887     at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:340)
2015-10-28_20:18:29.04896     at org.embulk.spi.Exec.doWith(Exec.java:25)
2015-10-28_20:18:29.04898     at org.embulk.exec.BulkLoader.run(BulkLoader.java:340)
2015-10-28_20:18:29.04953     ... 7 more
2015-10-28_20:18:29.04958 Caused by: java.lang.IllegalStateException: Optional.get() cannot be called on an absent value
2015-10-28_20:18:29.04962     at com.google.common.base.Absent.get(Absent.java:47)
2015-10-28_20:18:29.04966     at org.embulk.exec.BulkLoader$LoaderState.getAllInputTaskReports(BulkLoader.java:240)
2015-10-28_20:18:29.04971     at org.embulk.exec.BulkLoader$4.run(BulkLoader.java:514)
2015-10-28_20:18:29.04975     at org.embulk.spi.FileInputRunner$RunnerControl$1$1.run(FileInputRunner.java:124)
2015-10-28_20:18:29.04978     at org.embulk.standards.CsvParserPlugin.transaction(CsvParserPlugin.java:223)
2015-10-28_20:18:29.04983     at org.embulk.spi.FileInputRunner$RunnerControl$1.run(FileInputRunner.java:118)
2015-10-28_20:18:29.04987     at org.embulk.spi.util.Decoders$RecursiveControl.transaction(Decoders.java:77)
2015-10-28_20:18:29.04991     at org.embulk.spi.util.Decoders.transaction(Decoders.java:33)
2015-10-28_20:18:29.04995     at org.embulk.spi.FileInputRunner$RunnerControl.run(FileInputRunner.java:115)
2015-10-28_20:18:29.05000     at org.embulk.input.s3.AbstractS3FileInputPlugin.resume(AbstractS3FileInputPlugin.java:106)
2015-10-28_20:18:29.05004     at org.embulk.input.s3.AbstractS3FileInputPlugin.transaction(AbstractS3FileInputPlugin.java:93)
2015-10-28_20:18:29.05009     at org.embulk.spi.FileInputRunner.transaction(FileInputRunner.java:65)
2015-10-28_20:18:29.05013     at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:482)
2015-10-28_20:18:29.05018     ... 21 more
```