### PR TITLE
Prevent exceptions at close() from overwriting essential exception

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/AbortTransactionResource.java
+++ b/embulk-core/src/main/java/org/embulk/spi/AbortTransactionResource.java
@@ -1,0 +1,36 @@
+package org.embulk.spi;
+
+public class AbortTransactionResource
+        implements AutoCloseable
+{
+    private Transactional tran;
+
+    public AbortTransactionResource()
+    {
+        this(null);
+    }
+
+    public AbortTransactionResource(Transactional tran)
+    {
+        this.tran = tran;
+    }
+
+    public void abortThis(Transactional tran)
+    {
+        this.tran = tran;
+    }
+
+    public void dontAbort()
+    {
+        this.tran = null;
+    }
+
+    @Override
+    public void close()
+    {
+        if (tran != null) {
+            tran.abort();
+        }
+    }
+}
+

--- a/embulk-core/src/main/java/org/embulk/spi/CloseResource.java
+++ b/embulk-core/src/main/java/org/embulk/spi/CloseResource.java
@@ -1,0 +1,42 @@
+package org.embulk.spi;
+
+import com.google.common.base.Throwables;
+
+public class CloseResource
+        implements AutoCloseable
+{
+    private AutoCloseable resource;
+
+    public CloseResource()
+    {
+        this(null);
+    }
+
+    public CloseResource(AutoCloseable resource)
+    {
+        this.resource = resource;
+    }
+
+    public void closeThis(AutoCloseable resource)
+    {
+        this.resource = resource;
+    }
+
+    public void dontClose()
+    {
+        this.resource = null;
+    }
+
+    public void close()
+    {
+        if (resource != null) {
+            try {
+                resource.close();
+            }
+            catch (Exception ex) {
+                throw Throwables.propagate(ex);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
If an exception happens both in `try` block and `finally` block,
exception by `finally` block overwrites exception by `try` block. Thus
the ssential exception information will be lost if `close()` call at
`finally` block throws an exception.

But with try-with-resource, exception happend at `close()` will be added
to suppressed exception of the exception at `try` block.