### PR TITLE
Make "embulk bundle" command less confusing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    embulk (0.7.4)
+    embulk (0.7.7)
       jruby-jars (= 9.0.0.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -104,15 +104,15 @@ embulk cleanup config.yml -r resume-state.yml
 
 ### Using plugin bundle
 
-`embulk bundle new` subcommand creates (or updates if already exists) a private (isolated) bundle of a plugins.
-You can use the bundle using `-b <bundle_dir>` option. `embulk bundle` also generates some example plugins to \<bundle_dir>/embulk/\*.rb directory.
+`embulk mkbundle` subcommand creates a isolated bundle of plugins. You can install plugins (gems) to the bundle directory instead of ~/.embulk directory. This makes it easy to manage versions of plugins.
+To use the bundle, add `-b <bundle_dir>` option to `guess`, `preview`, or `run` subcommand. `embulk mkbundle` also generates some example plugins to \<bundle_dir>/embulk/\*.rb directory.
 
 See the generated \<bundle_dir>/Gemfile file how to plugin bundles work.
 
 ```
-embulk bundle new ./embulk_bundle
-embulk guess  -b ./embulk_bundle ...
-embulk run    -b ./embulk_bundle ...
+embulk mkbundle ./embulk_bundle
+embulk guess -b ./embulk_bundle ...
+embulk run   -b ./embulk_bundle ...
 ```
 
 ## Use cases

--- a/bin/embulk
+++ b/bin/embulk
@@ -1,12 +1,14 @@
 #!/usr/bin/env ruby
 
 if RUBY_PLATFORM =~ /java/i
-  # Enable embulk_bundle if run by CRuby.
-  # Disable embulk_bundle if run by JRuby.
   if ENV['EMBULK_BIN_ENABLE_BUNDLE'] == File.expand_path(__FILE__)
+    # bin/embulk is run by CRuby (embulk gem for CRuby is installed). enable embulk_bundle.
     ENV.delete('EMBULK_BIN_ENABLE_BUNDLE')
+    # include -cp CLASSPATH to LOAD_PATH so that embulk_bundle.rb can load bundler included in embulk-core.jar
+    $LOAD_PATH << "uri:classloader:/"
     require_relative '../lib/embulk/command/embulk_bundle'
   else
+    # bin/embulk is run by JRuby (embulk gem for JRuby is installed). disable embulk_bundle not to bother the JRuby's bundler
     $LOAD_PATH << File.expand_path('../lib', File.dirname(__FILE__))
     require 'embulk/command/embulk_main'
   end
@@ -93,11 +95,13 @@ rescue LoadError => e
   raise e
 end
 jruby_cp = "#{File.dirname(JRubyJars.core_jar_path)}/*"
+embulk_cp = "#{File.expand_path('../../classpath', __FILE__)}/*"  # bundler is included in embulk-core.jar
 
 # java ... -jar ruby-complete.jar bin/embulk "$@"
 cmdline = [java_cmd]
 cmdline.concat java_args
-cmdline << '-cp' << jruby_cp << 'org.jruby.Main'
+cmdline << '-cp' << [jruby_cp, embulk_cp].join(File::PATH_SEPARATOR)
+cmdline << 'org.jruby.Main'
 cmdline.concat jruby_args
 cmdline << __FILE__
 cmdline.concat ARGV

--- a/embulk-cli/src/main/java/org/embulk/cli/Main.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/Main.java
@@ -30,7 +30,7 @@ public class Main
             resourcePath = Main.class.getProtectionDomain().getCodeSource().getLocation().toURI().toString() + "!/";
         }
         catch (URISyntaxException ex) {
-            resourcePath = "classpath:";
+            resourcePath = "uri:classloader:/";
         }
         return resourcePath + "embulk/command/embulk_bundle.rb";
     }

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     // For embulk/guess/charset.rb. See also embulk.gemspec
     compile 'com.ibm.icu:icu4j:54.1.1'
 
+    gems 'rubygems:bundler:1.10.6'
     gems 'rubygems:liquid:3.0.6'
 }
 

--- a/embulk.gemspec
+++ b/embulk.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.has_rdoc      = false
 
   if RUBY_PLATFORM =~ /java/i
+    gem.add_dependency "bundler", '~> 1.10.6'
     gem.add_dependency "liquid", '~> 3.0.6'
 
     # For embulk/guess/charset.rb. See also embulk-core/build.gradle
@@ -31,7 +32,6 @@ Gem::Specification.new do |gem|
     gem.add_dependency "jruby-jars", '= 9.0.0.0'
   end
 
-  gem.add_development_dependency "bundler", [">= 1.0"]
   gem.add_development_dependency "rake", [">= 0.10.0"]
   gem.add_development_dependency "test-unit", ["~> 3.0.9"]
   gem.add_development_dependency "yard", ["~> 0.8.7"]

--- a/lib/embulk.rb
+++ b/lib/embulk.rb
@@ -8,7 +8,7 @@ module Embulk
     if resource
       lib = resource.split("/")[0..-2].join("/")
       "#{jar}!#{lib}/#{path}"
-    elsif __FILE__ =~ /^classpath:/
+    elsif __FILE__ =~ /^(?:classpath|uri:classloader):/
       lib = __FILE__.split("/")[0..-2].join("/")
       "#{lib}/#{path}"
     else
@@ -22,7 +22,7 @@ module Embulk
       # single jar. __FILE__ should point path/to/embulk.jar!/embulk.rb
       # which means that embulk.jar is already loaded in this JVM.
 
-    elsif __FILE__ =~ /^classpath:/
+    elsif __FILE__ =~ /^(?:classpath|uri:classloader):/
       # already in classpath
 
     else

--- a/lib/embulk/command/embulk_bundle.rb
+++ b/lib/embulk/command/embulk_bundle.rb
@@ -9,19 +9,15 @@ if bundle_path_index
 end
 
 if bundle_path
-  # use bundler installed at bundle_path
   ENV['EMBULK_BUNDLE_PATH'] = bundle_path
-  ENV['GEM_HOME'] = File.expand_path File.join(bundle_path, Gem.ruby_engine, RbConfig::CONFIG['ruby_version'])
-  ENV['GEM_PATH'] = ''
-  Gem.clear_paths  # force rubygems to reload GEM_HOME
-
   ENV['BUNDLE_GEMFILE'] = File.expand_path File.join(bundle_path, "Gemfile")
 
-  begin
-    require 'bundler'
-  rescue LoadError => e
-    raise "#{e}\nBundler is not installed. Did you run \`$ embulk bundle #{bundle_path}\` ?"
-  end
+  # bundler is included in embulk-core.jar
+  ENV.delete('GEM_HOME')
+  ENV.delete('GEM_PATH')
+  Gem.clear_paths
+  require 'bundler'
+
   Bundler.load.setup_environment
   require 'bundler/setup'
   # since here, `require` may load files of different (newer) embulk versions

--- a/lib/embulk/command/embulk_generate_bin.rb
+++ b/lib/embulk/command/embulk_generate_bin.rb
@@ -1,7 +1,7 @@
 module Embulk
   def self.generate_bin(options={})
     jruby_jar_path = org.jruby.Main.java_class.protection_domain.code_source.location.to_s
-    if __FILE__ =~ /^classpath:/ || __FILE__.include?('!/')
+    if __FILE__ =~ /^(?:classpath|uri:classloader):/ || __FILE__.include?('!/')
       resource_class = org.embulk.command.Runner.java_class
       ruby_script_path = resource_class.resource("/embulk/command/embulk.rb").to_s
     else

--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -66,7 +66,7 @@ module Embulk
       op.on('-C', '--classpath PATH', "Add java classpath separated by #{classpath_separator} (CLASSPATH)") do |classpath|
         classpaths.concat classpath.split(classpath_separator)
       end
-      op.on('-b', '--bundle BUNDLE_DIR', 'Path to a Gemfile directory (create one using "embulk bundle new" command)') do |path|
+      op.on('-b', '--bundle BUNDLE_DIR', 'Path to a Gemfile directory (create one using "embulk mkbundle" command)') do |path|
         # only for help message. implemented at lib/embulk/command/embulk_bundle.rb
       end
     end
@@ -118,21 +118,30 @@ module Embulk
       java_embed_ops.call
       args = 1..1
 
+    when :mkbundle
+      op.banner = "Usage: mkbundle <directory>"
+      op.separator <<-EOF
+
+  "mkbundle" creates a new a plugin bundle directory. You can install
+  plugins (gems) to the directory instead of ~/.embulk.
+
+  See generated <directory>/Gemfile to install plugins to the directory.
+  Use -b, --bundle BUNDLE_DIR option to use it:
+
+    $ embulk mkbundle ./dir                # create bundle directory
+    $ (cd dir && vi Gemfile && embulk bundle)   # update plugin list
+    $ embulk guess -b ./dir ...            # guess using bundled plugins
+    $ embulk run   -b ./dir ...            # run using bundled plugins
+
+      EOF
+      args = 1..1
+
     when :bundle
       if argv[0] == 'new'
         usage nil if argv.length != 2
         new_bundle(argv[1])
+        STDERR.puts "'embulk bundle new' is deprecated. This will be removed in future release. Please use 'embulk mkbundle' instead."
       else
-        gemfile_path = ENV['BUNDLE_GEMFILE'].to_s
-
-        if !gemfile_path.empty?
-          bundle_path = File.dirname(gemfile_path)
-        elsif File.exists?('Gemfile')
-          bundle_path = '.'
-        else
-          system_exit "'#{gemfile_path}' already exists. You already ran 'embulk bundle new'. Please remove it, or run \"cd #{gemfile_path}\" and \"embulk bundle\" instead"
-        end
-
         run_bundler(argv)
       end
       system_exit_success
@@ -259,6 +268,9 @@ examples:
       options[:version] = ARGV[0]
       Embulk.selfupdate(options)
 
+    when :mkbundle
+      new_bundle(argv[0])
+
     else
       require 'json'
 
@@ -360,7 +372,7 @@ examples:
     require 'rubygems/gem_runner'
 
     if File.exists?(path)
-      error = "'#{path}' already exists. You already ran 'embulk bundle new'. Please remove it, or run \"cd #{path}\" and \"embulk bundle\" instead"
+      error = "'#{path}' already exists."
       STDERR.puts error
       raise SystemExit.new(1, error)
     end
@@ -432,7 +444,8 @@ examples:
     STDERR.puts "Embulk v#{Embulk::VERSION}"
     STDERR.puts "usage: <command> [--options]"
     STDERR.puts "commands:"
-    STDERR.puts "   bundle     [directory]                             # create or update plugin environment."
+    STDERR.puts "   mkbundle   <directory>                             # create a new plugin bundle environment."
+    STDERR.puts "   bundle     [directory]                             # update a plugin bundle environment."
     STDERR.puts "   run        <config.yml>                            # run a bulk load transaction."
     STDERR.puts "   preview    <config.yml>                            # dry-run the bulk load without output and show preview."
     STDERR.puts "   guess      <partial-config.yml> -o <output.yml>    # guess missing parameters to create a complete configuration file."

--- a/lib/embulk/data/bundle/Gemfile
+++ b/lib/embulk/data/bundle/Gemfile
@@ -2,25 +2,30 @@ source 'https://rubygems.org/'
 gem 'embulk', '~> 0.7.0'
 
 #
-# Note: After updating this file, run this command to update Gemfile.lock:
+# 1. Use following syntax to specify versions of plugins
+#    to install this bundle directory:
 #
-#       cd this_directory
-#       embulk bundle
+#gem 'embulk-output-mysql'                     # the latest version
+#gem 'embulk-input-baz', '= 0.2.0'             # specific version
+#gem 'embulk-input-xyz', '~> 0.3.0'            # latest major version
+#gem 'embulk-output-postgresql', '>= 0.1.0'    # newer than specific version
 #
-
-#
-# RubyGems Plugins
-#
-#gem 'embulk-output-mysql'
-#gem 'embulk-output-postgresql', '>= 0.1.0'
-#gem 'embulk-input-baz', '= 0.2.0'
-#gem 'embulk-input-xyz', '~> 0.3.0'
-#
-
-#
-# Private plugins
-#
-#gem 'embulk-inupt-awesome', path: '/path/to/your/embulk-input-awesome'
 #gem 'embulk-output-awesome', git: 'https://github.com/you/embulk-output-awesome.git', branch: 'master'
+#
+
+#
+# 2. When you modify this file, run following command to
+#    install plugins:
+#
+#   $ cd this_directory
+#   $ embulk bundle
+#
+
+#
+# 3. Then you can use plugins with -b, --bundle BUNDLE_PATH command:
+#
+#   $ embulk guess -b path/to/this/directory  ...
+#   $ embulk run -b path/to/this/directory  ...
+#   $ embulk preview -b path/to/this/directory  ...
 #
 


### PR DESCRIPTION
`embulk bundle -h` shows help message of bundler. So there are little
chance to know how to use plugin bundles.

This change adds `embulk mkbundle` subcommand that creates new bundle,
and `embulk mkbundle -h` shows usage of plugin bundle.

Mitigates #320.