### PR TITLE
Support "mkbundle --path" option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    embulk (0.7.4)
+    embulk (0.7.7)
       jruby-jars (= 9.0.0.0)
 
 GEM

--- a/bin/embulk
+++ b/bin/embulk
@@ -1,12 +1,14 @@
 #!/usr/bin/env ruby
 
 if RUBY_PLATFORM =~ /java/i
-  # Enable embulk_bundle if run by CRuby.
-  # Disable embulk_bundle if run by JRuby.
   if ENV['EMBULK_BIN_ENABLE_BUNDLE'] == File.expand_path(__FILE__)
+    # bin/embulk is run by CRuby (embulk gem for CRuby is installed). enable embulk_bundle.
     ENV.delete('EMBULK_BIN_ENABLE_BUNDLE')
+    # include -cp CLASSPATH to LOAD_PATH so that embulk_bundle.rb can load bundler included in embulk-core.jar
+    $LOAD_PATH << "uri:classloader:/"
     require_relative '../lib/embulk/command/embulk_bundle'
   else
+    # bin/embulk is run by JRuby (embulk gem for JRuby is installed). disable embulk_bundle not to bother the JRuby's bundler
     $LOAD_PATH << File.expand_path('../lib', File.dirname(__FILE__))
     require 'embulk/command/embulk_main'
   end
@@ -93,11 +95,13 @@ rescue LoadError => e
   raise e
 end
 jruby_cp = "#{File.dirname(JRubyJars.core_jar_path)}/*"
+embulk_cp = "#{File.expand_path('../../classpath', __FILE__)}/*"  # bundler is included in embulk-core.jar
 
 # java ... -jar ruby-complete.jar bin/embulk "$@"
 cmdline = [java_cmd]
 cmdline.concat java_args
-cmdline << '-cp' << jruby_cp << 'org.jruby.Main'
+cmdline << '-cp' << [jruby_cp, embulk_cp].join(File::PATH_SEPARATOR)
+cmdline << 'org.jruby.Main'
 cmdline.concat jruby_args
 cmdline << __FILE__
 cmdline.concat ARGV

--- a/embulk-cli/src/main/java/org/embulk/cli/Main.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/Main.java
@@ -30,7 +30,7 @@ public class Main
             resourcePath = Main.class.getProtectionDomain().getCodeSource().getLocation().toURI().toString() + "!/";
         }
         catch (URISyntaxException ex) {
-            resourcePath = "classpath:";
+            resourcePath = "uri:classloader:/";
         }
         return resourcePath + "embulk/command/embulk_bundle.rb";
     }

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     // For embulk/guess/charset.rb. See also embulk.gemspec
     compile 'com.ibm.icu:icu4j:54.1.1'
 
+    gems 'rubygems:bundler:1.10.6'
     gems 'rubygems:liquid:3.0.6'
 }
 

--- a/embulk.gemspec
+++ b/embulk.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.has_rdoc      = false
 
   if RUBY_PLATFORM =~ /java/i
+    gem.add_dependency "bundler", '~> 1.10.6'
     gem.add_dependency "liquid", '~> 3.0.6'
 
     # For embulk/guess/charset.rb. See also embulk-core/build.gradle
@@ -31,7 +32,6 @@ Gem::Specification.new do |gem|
     gem.add_dependency "jruby-jars", '= 9.0.0.0'
   end
 
-  gem.add_development_dependency "bundler", [">= 1.0"]
   gem.add_development_dependency "rake", [">= 0.10.0"]
   gem.add_development_dependency "test-unit", ["~> 3.0.9"]
   gem.add_development_dependency "yard", ["~> 0.8.7"]

--- a/lib/embulk.rb
+++ b/lib/embulk.rb
@@ -8,7 +8,7 @@ module Embulk
     if resource
       lib = resource.split("/")[0..-2].join("/")
       "#{jar}!#{lib}/#{path}"
-    elsif __FILE__ =~ /^classpath:/
+    elsif __FILE__ =~ /^(?:classpath|uri:classloader):/
       lib = __FILE__.split("/")[0..-2].join("/")
       "#{lib}/#{path}"
     else
@@ -22,7 +22,7 @@ module Embulk
       # single jar. __FILE__ should point path/to/embulk.jar!/embulk.rb
       # which means that embulk.jar is already loaded in this JVM.
 
-    elsif __FILE__ =~ /^classpath:/
+    elsif __FILE__ =~ /^(?:classpath|uri:classloader):/
       # already in classpath
 
     else

--- a/lib/embulk/command/embulk_bundle.rb
+++ b/lib/embulk/command/embulk_bundle.rb
@@ -9,19 +9,15 @@ if bundle_path_index
 end
 
 if bundle_path
-  # use bundler installed at bundle_path
   ENV['EMBULK_BUNDLE_PATH'] = bundle_path
-  ENV['GEM_HOME'] = File.expand_path File.join(bundle_path, Gem.ruby_engine, RbConfig::CONFIG['ruby_version'])
-  ENV['GEM_PATH'] = ''
-  Gem.clear_paths  # force rubygems to reload GEM_HOME
-
   ENV['BUNDLE_GEMFILE'] = File.expand_path File.join(bundle_path, "Gemfile")
 
-  begin
-    require 'bundler'
-  rescue LoadError => e
-    raise "#{e}\nBundler is not installed. Did you run \`$ embulk bundle #{bundle_path}\` ?"
-  end
+  # bundler is included in embulk-core.jar
+  ENV.delete('GEM_HOME')
+  ENV.delete('GEM_PATH')
+  Gem.clear_paths
+  require 'bundler'
+
   Bundler.load.setup_environment
   require 'bundler/setup'
   # since here, `require` may load files of different (newer) embulk versions

--- a/lib/embulk/command/embulk_generate_bin.rb
+++ b/lib/embulk/command/embulk_generate_bin.rb
@@ -1,7 +1,7 @@
 module Embulk
   def self.generate_bin(options={})
     jruby_jar_path = org.jruby.Main.java_class.protection_domain.code_source.location.to_s
-    if __FILE__ =~ /^classpath:/ || __FILE__.include?('!/')
+    if __FILE__ =~ /^(?:classpath|uri:classloader):/ || __FILE__.include?('!/')
       resource_class = org.embulk.command.Runner.java_class
       ruby_script_path = resource_class.resource("/embulk/command/embulk.rb").to_s
     else


### PR DESCRIPTION
When we deploy embulk to a production environment using chef or
capistrano, gems should be installed to a shared directory
(shared/bundler) but Gemfile.lock should be isolated. --path optoin
works for that case.

This change includes bundler itself to embulk-core.jar so that
embulk_run doesn't have to install bundler. Thus initialization of
bundler becomes less magical.

Following-up of #334.