### PR TITLE
[Propose] Add bundler URL in help.

### DIFF
--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -422,7 +422,7 @@ examples:
     STDERR.puts "usage: <command> [--options]"
     STDERR.puts "commands:"
     STDERR.puts "   mkbundle   <directory>                             # create a new plugin bundle environment."
-    STDERR.puts "   bundle     [directory]                             # update a plugin bundle environment."
+    STDERR.puts "   bundle     [directory]                             # update a plugin bundle environment. (usage: http://bundler.io)"
     STDERR.puts "   run        <config.yml>                            # run a bulk load transaction."
     STDERR.puts "   preview    <config.yml>                            # dry-run the bulk load without output and show preview."
     STDERR.puts "   guess      <partial-config.yml> -o <output.yml>    # guess missing parameters to create a complete configuration file."


### PR DESCRIPTION
Related #334 

```
./embulk-0.7.8.jar bundle -h 
2015-11-10 13:12:52.282 +0900: Embulk v0.7.8
/path/to/embulk/pkg/embulk-0.7.8.jar!/bundler/man/bundle: No such file or directory
No manual entry for /pat/to/embulk/pkg/embulk-0.7.8.jar!/bundler/man/bundle
```

Add http://bundler.io URL in usage.
