### PR TITLE
[Trivial] Use strict mode when rendering liquid templates.

### DIFF
--- a/lib/embulk/runner.rb
+++ b/lib/embulk/runner.rb
@@ -132,7 +132,7 @@ module Embulk
 
     def run_liquid(source, params, template_include_path)
       require 'liquid'
-      template = Liquid::Template.parse(source)
+      template = Liquid::Template.parse(source, :error_mode => :strict)
       template.registers[:file_system] = Liquid::LocalFileSystem.new(template_include_path, "_%s.yml.liquid") if template_include_path
 
       data = {


### PR DESCRIPTION
Liquid by default is lax (silent) when syntax errors are encountered while parsing a template. It should be configured so they are fatal. For example if you accidentally wrote:
`path_prefix: {{ env.MY_VAR || 'input.csv' }}` instead of
`path_prefix: {{ env.MY_VAR | default: 'input.csv' }}`

Current error message (cryptic and unhelpful): 
`com.fasterxml.jackson.databind.JsonMappingException: Setting null to a task field is not allowed. Use Optional<T> (com.google.common.base.Optional) to represent null.`

With this patch (sane):
`Liquid syntax error: Expected id but found pipe in "{{ env.MY_VAR || 'file' }}"`