### PR TITLE
Change internal buffer size of GzipFileDecoderPlugin for a guess executor

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/GzipFileDecoderPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/GzipFileDecoderPlugin.java
@@ -43,7 +43,7 @@ public class GzipFileDecoderPlugin
                         if (!files.nextFile()) {
                             return null;
                         }
-                        return new GZIPInputStream(files);
+                        return new GZIPInputStream(files, 8*1024);
                     }
 
                     public void close() throws IOException


### PR DESCRIPTION
When a guess executor tries to read a gzipped file, it sometimes cannot read an enough sized sample buffer to guess effectively. In my case, it read about 800 bytes only from the file as a sample buffer and cannot suggest column names and types by the sample buffer.

I changed the internal buffer size in GZIPInputStream to 8*1024 bytes. I think that 4096 bytes are also fine. But default 512 bytes are too small for my case.
