### PR TITLE
allow String in type value

### DIFF
--- a/lib/embulk/column.rb
+++ b/lib/embulk/column.rb
@@ -5,7 +5,7 @@ module Embulk
       if args.length == 1 && args[0].is_a?(Hash)
         # initialize(hash)
         hash = args.first
-        super(hash[:index], hash[:name], hash[:type], hash[:format])
+        super(hash[:index], hash[:name], hash[:type].to_sym, hash[:format])
       else
         # initialize(index, name, type, format)
         super(*args)


### PR DESCRIPTION
This patch is allow following code.

``` ruby
Embulk::Schema.new([Embulk::Column.new({name: 'col1', type: 'string'})])
```

Now, this code is raise RuntimeError, because type value is String Class.

``` sh
RuntimeError: Unknown type "string"
/Users/takkanm/.rbenv/versions/jruby-9.0.0.0/lib/ruby/gems/shared/gems/embulk-0.7.9-java/lib/embulk/schema.rb:37:in `block in initialize'
org/jruby/RubyArray.java:1560:in `each'
/Users/takkanm/.rbenv/versions/jruby-9.0.0.0/lib/ruby/gems/shared/gems/embulk-0.7.9-java/lib/embulk/schema.rb:19:in `initialize'
```
