### PR TITLE
Add usage cleanup command

### DIFF
--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -88,7 +88,7 @@ module Embulk
     when :cleanup
       op.banner = "Usage: cleanup <config.yml>"
       op.separator "  Options:"
-      op.on('-r', '--resume-state PATH', 'Path to a file to write or read resume state') do |path|
+      op.on('-r', '--resume-state PATH', 'Path to a file to cleanup resume state') do |path|
         options[:resume_state_path] = path
       end
       plugin_load_ops.call
@@ -434,6 +434,7 @@ examples:
     STDERR.puts "   mkbundle   <directory>                             # create a new plugin bundle environment."
     STDERR.puts "   bundle     [directory]                             # update a plugin bundle environment."
     STDERR.puts "   run        <config.yml>                            # run a bulk load transaction."
+    STDERR.puts "   cleanup    <config.yml>                            # cleanup resume state."
     STDERR.puts "   preview    <config.yml>                            # dry-run the bulk load without output and show preview."
     STDERR.puts "   guess      <partial-config.yml> -o <output.yml>    # guess missing parameters to create a complete configuration file."
     STDERR.puts "   gem        <install | list | help>                 # install a plugin or show installed plugins."


### PR DESCRIPTION
no ``cleanup`` command help

```
Embulk v0.7.10
usage: <command> [--options]
commands:
   mkbundle   <directory>                             # create a new plugin bundle environment.
   bundle     [directory]                             # update a plugin bundle environment.
   run        <config.yml>                            # run a bulk load transaction.
   preview    <config.yml>                            # dry-run the bulk load without output and show preview.
   guess      <partial-config.yml> -o <output.yml>    # guess missing parameters to create a complete configuration file.
   gem        <install | list | help>                 # install a plugin or show installed plugins.
                                                      # plugin path is /Users/hsato/.embulk/jruby/2.2.0
   new        <category> <name>                       # generates new plugin template
   migrate    <path>                                  # modify plugin code to use the latest Embulk plugin API
   example    [path]                                  # creates an example config file and csv file to try embulk.
   selfupdate [version]                               # upgrades embulk to the latest released version or to the specified version.

Use `<command> --help` to see description of the commands.
```