### PR TITLE
Fix bug of trimming in CsvTokenizer 

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -252,7 +252,7 @@ public class CsvTokenizer
 
                     } else {
                         // this spaces are not trailing spaces. go back to VALUE state
-                        columnState = ColumnState.BEGIN;
+                        columnState = ColumnState.VALUE;
                     }
                     break;
 


### PR DESCRIPTION
When `trim_if_not_quoted` is true, `AB C` will be parsed as "".