### PR TITLE
add migrate for checkstyle

### DIFF
--- a/lib/embulk/data/new/java/build.gradle.erb
+++ b/lib/embulk/data/new/java/build.gradle.erb
@@ -29,6 +29,23 @@ task classpath(type: Copy, dependsOn: ["jar"]) {
 }
 clean { delete "classpath" }
 
+checkstyle {
+    configFile = file("${project.rootDir}/config/checkstyle/checkstyle.xml")
+    toolVersion = '6.14.1'
+}
+checkstyleMain {
+    configFile = file("${project.rootDir}/config/checkstyle/default.xml")
+    ignoreFailures = true
+}
+checkstyleTest {
+    configFile = file("${project.rootDir}/config/checkstyle/default.xml")
+    ignoreFailures = true
+}
+task checkstyle(type: Checkstyle) {
+    classpath = sourceSets.main.output + sourceSets.test.output
+    source = sourceSets.main.allJava + sourceSets.test.allJava
+}
+
 task gem(type: JRubyExec, dependsOn: ["gemspec", "classpath"]) {
     jrubyArgs "-rrubygems/gem_runner", "-eGem::GemRunner.new.run(ARGV)", "build"
     script "${project.name}.gemspec"
@@ -72,10 +89,3 @@ end
     }
 }
 clean { delete "${project.name}.gemspec" }
-
-checkstyle {
-  // source config
-  // https://github.com/facebook/presto/blob/master/src/checkstyle/checks.xml
-  configFile = file("${project.rootDir}/config/checkstyle/checkstyle.xml")
-  toolVersion = '6.7'
-}

--- a/lib/embulk/data/new/java/config/checkstyle/default.xml
+++ b/lib/embulk/data/new/java/config/checkstyle/default.xml
@@ -2,8 +2,10 @@
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
         "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<!--
+     This is a subset of ./checkstyle.xml which allows some loose styles
+-->
 <module name="Checker">
-    <!-- https://github.com/facebook/presto/blob/master/src/checkstyle/checks.xml -->
     <module name="FileTabCharacter"/>
     <module name="NewlineAtEndOfFile">
         <property name="lineSeparator" value="lf"/>
@@ -17,24 +19,12 @@
         <property name="message" value="Line has trailing whitespace"/>
     </module>
     <module name="RegexpMultiline">
-        <property name="format" value="\{\n\n"/>
-        <property name="message" value="Blank line after opening brace"/>
-    </module>
-    <module name="RegexpMultiline">
-        <property name="format" value="\n\n\s*\}"/>
-        <property name="message" value="Blank line before closing brace"/>
-    </module>
-    <module name="RegexpMultiline">
         <property name="format" value="\n\n\n"/>
         <property name="message" value="Multiple consecutive blank lines"/>
     </module>
     <module name="RegexpMultiline">
         <property name="format" value="\n\n\Z"/>
         <property name="message" value="Blank line before end of file"/>
-    </module>
-    <module name="RegexpMultiline">
-        <property name="format" value="Preconditions\.checkNotNull"/>
-        <property name="message" value="Use of checkNotNull"/>
     </module>
 
     <module name="TreeWalker">
@@ -98,16 +88,6 @@
         </module>
         <module name="MethodTypeParameterName">
             <property name="format" value="^[A-Z][0-9]?$"/>
-        </module>
-
-        <module name="AvoidStarImport"/>
-        <module name="RedundantImport"/>
-        <module name="UnusedImports"/>
-        <module name="ImportOrder">
-            <property name="groups" value="*,javax,java"/>
-            <property name="separated" value="true"/>
-            <property name="option" value="bottom"/>
-            <property name="sortStaticImportsAlphabetically" value="true"/>
         </module>
 
         <module name="WhitespaceAround">


### PR DESCRIPTION
Follow-up pull-request of #361.
Running strict checkstyle every time is annoying. I want to avoid it. This pull-request solves this issue as following:

* defines 2 types of checkstyles: looser (default.xml) and stricter (checkstyle.xml).
* "check" task uses looser rule.
* "check" task doesn't fail even if checkstyle fails. Checkstyle should be warning.
* "checkstyle" task uses stricter rule. developers can run it optionally at the end of CI.
