### PR TITLE
Copy default checkstyle config in new command

### DIFF
--- a/lib/embulk/command/embulk_new_plugin.rb
+++ b/lib/embulk/command/embulk_new_plugin.rb
@@ -88,6 +88,7 @@ module Embulk
         pkg.cp("java/gradlew", "gradlew")
         pkg.set_executable("gradlew")
         pkg.cp("java/config/checkstyle/checkstyle.xml","config/checkstyle/checkstyle.xml")
+        pkg.cp("java/config/checkstyle/default.xml","config/checkstyle/default.xml")
         pkg.cp_erb("java/build.gradle.erb", "build.gradle")
         pkg.cp_erb("java/plugin_loader.rb.erb", plugin_path)
         pkg.cp_erb("java/#{category}.java.erb", "src/main/java/#{java_package_name.gsub(/\./, '/')}/#{java_class_name}.java")


### PR DESCRIPTION
Copy missing default.xml in new command. 

```
./gradlew check
:compileJava
:processResources UP-TO-DATE
:classes
:checkstyleMain FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':checkstyleMain'.
> Unable to create a Checker: configLocation {/private/tmp/embulk-parser-hoge/config/checkstyle/default.xml}, classpath {/private/tmp/embulk-parser-hoge/build/classes/main:/private/tmp/embulk-parser-hoge/build/resources/main}.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 4.036 secs
```