### PR TITLE
new and migrate add sourceCompatibility = 1.7 and targetCompatibility = 1.7 to build.gradle

### DIFF
--- a/lib/embulk/data/new/java/build.gradle.erb
+++ b/lib/embulk/data/new/java/build.gradle.erb
@@ -15,6 +15,9 @@ configurations {
 
 version = "0.1.0"
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 dependencies {
     compile  "org.embulk:embulk-core:<%= Embulk::VERSION %>"
     provided "org.embulk:embulk-core:<%= Embulk::VERSION %>"


### PR DESCRIPTION
this migrate should be updated once embulk is build with JDK 8.