### PR TITLE
customize Yaml tag resolver to be more strict

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/ConfigLoader.java
+++ b/embulk-core/src/main/java/org/embulk/config/ConfigLoader.java
@@ -15,6 +15,9 @@ import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.representer.Representer;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 public class ConfigLoader
 {
@@ -60,7 +63,7 @@ public class ConfigLoader
 
     public ConfigSource fromYamlString(String string)
     {
-        JsonNode node = objectToJson(new Yaml().load(string));
+        JsonNode node = objectToJson(newYaml().load(string));
         validateJsonNode(node);
         return new DataSourceImpl(model, (ObjectNode) node);
     }
@@ -74,7 +77,7 @@ public class ConfigLoader
 
     public ConfigSource fromYaml(InputStream stream) throws IOException
     {
-        JsonNode node = objectToJson(new Yaml().load(stream));
+        JsonNode node = objectToJson(newYaml().load(stream));
         validateJsonNode(node);
         return new DataSourceImpl(model, (ObjectNode) node);
     }
@@ -107,7 +110,7 @@ public class ConfigLoader
     {
         ObjectNode source = new ObjectNode(JsonNodeFactory.instance);
         DataSource ds = new DataSourceImpl(model, source);
-        Yaml yaml = new Yaml();
+        Yaml yaml = newYaml();
         for (Map.Entry<String, String> pair : props.entrySet()) {
             if (!pair.getKey().startsWith(keyPrefix)) {
                 continue;
@@ -137,5 +140,10 @@ public class ConfigLoader
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
+    }
+
+    private Yaml newYaml()
+    {
+        return new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), new YamlTagResolver());
     }
 }

--- a/embulk-core/src/main/java/org/embulk/config/YamlTagResolver.java
+++ b/embulk-core/src/main/java/org/embulk/config/YamlTagResolver.java
@@ -1,0 +1,53 @@
+package org.embulk.config;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import org.yaml.snakeyaml.resolver.Resolver;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.nodes.NodeId;
+
+public class YamlTagResolver
+    extends Resolver
+{
+    // Resolver converts a node (scalar, sequence, map, or !!tag with them)
+    // to a tag (INT, FLOAT, STR, SEQ, MAP, ...). For example, converting
+    // "123" (scalar) to 123 (INT), or "true" (scalar) to true (BOOL).
+    // This is called by snakeyaml Composer which converts parser events
+    // into an object.
+    //
+    // jackson-dataformat-yaml doesn't use this because it traverses parser
+    // events without using Composer.
+
+    public static final Pattern FLOAT_EXCEPTING_ZERO_START = Pattern
+        .compile("^([-+]?(\\.[0-9]+|[1-9][0-9_]*(\\.[0-9_]*)?)([eE][-+]?[0-9]+)?|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+
+    @Override
+    public void addImplicitResolver(Tag tag, Pattern regexp, String first)
+    {
+        // This method is called by constructor through addImplicitResolvers
+        // to setup default implicit resolvers.
+
+        if (tag.equals(Tag.FLOAT)) {
+            super.addImplicitResolver(Tag.FLOAT, FLOAT_EXCEPTING_ZERO_START, "-+0123456789.");
+        }
+        else if (tag.equals(Tag.BOOL)) {
+            // use stricter rule (reject 'On', 'Off', 'Yes', 'No')
+            super.addImplicitResolver(Tag.BOOL, Pattern.compile("^(?:[Tt]rue|[Ff]alse)$"), "TtFf");
+        }
+        else if (tag.equals(Tag.TIMESTAMP)) {
+            // This solves some unexpected behavior that snakeyaml
+            // deserializes "2015-01-01 00:00:00" to java.util.Date
+            // but jackson serializes java.util.Date to an integer.
+            return;
+        }
+        else {
+            super.addImplicitResolver(tag, regexp, first);
+        }
+    }
+
+    @Override
+    public Tag resolve(NodeId kind, String value, boolean implicit)
+    {
+        return super.resolve(kind, value, implicit);  // checks implicit resolvers
+    }
+}


### PR DESCRIPTION
This change includes following restrictions:

* Strings starting with 0 such as 019 will be string instead of float.
  This is changed to be compatible with YAML 1.1 generators.
  This is a workaround for https://bugs.ruby-lang.org/issues/11988
* Dates like 2015-01-01 00:00:00 will be string instead of java.util.Date.
  This is changed because jackson uses UNIX timestamp numbers
  unexpectedly when it converts from Date to String.
* 'on', 'off', 'yes' or 'no' (case insensitive) will be string instead
  of boolean. Only 'True', 'true', 'False' and 'false' (case sensitive)
  are accepted as boolean.