### PR TITLE
Avoid /0 when no input task

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
@@ -60,7 +60,7 @@ public class LocalExecutorPlugin
         Logger log = Exec.getLogger(LocalExecutorPlugin.class);
         int maxThreads = config.get(Integer.class, "max_threads", defaultMaxThreads);
         int minThreads = config.get(Integer.class, "min_output_tasks", defaultMinThreads);
-        if (inputTaskCount < minThreads) {
+        if (inputTaskCount > 0 && inputTaskCount < minThreads) {
             int scatterCount = (minThreads + inputTaskCount - 1) / inputTaskCount;
             log.info("Using local thread executor with max_threads={} / output tasks {} = input tasks {} * {}",
                     maxThreads, inputTaskCount * scatterCount, inputTaskCount, scatterCount);


### PR DESCRIPTION
When input task count is 0 (ex. input file for file input plugin is empty), following exception will be thrown.

<pre>
Caused by: java.lang.ArithmeticException: / by zero
	at org.embulk.exec.LocalExecutorPlugin.newExecutor(LocalExecutorPlugin.java:64)
	at org.embulk.exec.LocalExecutorPlugin.transaction(LocalExecutorPlugin.java:53)
</pre>