### PR TITLE
Fix embulk run config.yml -c diff.yml fail.

### DIFF
--- a/lib/embulk/runner.rb
+++ b/lib/embulk/runner.rb
@@ -61,7 +61,7 @@ module Embulk
       check_file_writable(config_diff_path)
       check_file_writable(resume_state_path)
 
-      if config_diff_path
+      if config_diff_path && File.size(config_diff_path) > 0
         lastConfigDiff = read_config(config_diff_path, options)
         configSource = configSource.merge(lastConfigDiff)
       end


### PR DESCRIPTION
``embulk run config.yml -c diff.yml`` command fail if ``diff.yml``  not exists.

[test code](https://gist.github.com/hiroyuki-sato/64792328449d6099953a)

This code create empty file. 
https://github.com/embulk/embulk/blob/master/lib/embulk/runner.rb#L61

So I ignore if file size == 0