### PR TITLE
Thread name should be always unique for debug purpose

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/SetCurrentThreadName.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SetCurrentThreadName.java
@@ -1,5 +1,7 @@
 package org.embulk.exec;
 
+import static java.util.Locale.ENGLISH;
+
 public class SetCurrentThreadName
         implements AutoCloseable
 {
@@ -8,7 +10,8 @@ public class SetCurrentThreadName
     public SetCurrentThreadName(String name)
     {
         this.original = Thread.currentThread().getName();
-        Thread.currentThread().setName(name);
+        Thread thread = Thread.currentThread();
+        thread.setName(String.format(ENGLISH, "%04d:", thread.getId()) + name);
     }
 
     @Override


### PR DESCRIPTION
SetCurrentThreadName can set same names to multiple threads such as
"preview", "guess", or "task-1". It makes it hard to debug problems such
as deadlock because Java stacktrace includes these names.