### PR TITLE
Close GzipFileDecoder/GZIPInputStream and GzipFileEncoder/GZIPOutputStream

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/GzipFileDecoderPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/GzipFileDecoderPlugin.java
@@ -38,17 +38,21 @@ public class GzipFileDecoderPlugin
         return new InputStreamFileInput(
                 task.getBufferAllocator(),
                 new InputStreamFileInput.Provider() {
+                    private GZIPInputStream gzis;
+
                     public InputStream openNext() throws IOException
                     {
                         if (!files.nextFile()) {
                             return null;
                         }
-                        return new GZIPInputStream(files, 8*1024);
+                        gzis = new GZIPInputStream(files, 8*1024);
+                        return gzis;
                     }
 
                     public void close() throws IOException
                     {
                         files.close();
+                        gzis.close();
                     }
                 });
     }

--- a/embulk-standards/src/main/java/org/embulk/standards/GzipFileEncoderPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/GzipFileEncoderPlugin.java
@@ -47,14 +47,17 @@ public class GzipFileEncoderPlugin
         final FileOutputOutputStream output = new FileOutputOutputStream(fileOutput, task.getBufferAllocator(), FileOutputOutputStream.CloseMode.FLUSH);
 
         return new OutputStreamFileOutput(new OutputStreamFileOutput.Provider() {
+            private GZIPOutputStream gzos;
+
             public OutputStream openNext() throws IOException
             {
                 output.nextFile();
-                return new GZIPOutputStream(output) {
+                gzos = new GZIPOutputStream(output) {
                     {
                         this.def.setLevel(task.getLevel());
                     }
                 };
+                return gzos;
             }
 
             public void finish() throws IOException
@@ -65,6 +68,7 @@ public class GzipFileEncoderPlugin
             public void close() throws IOException
             {
                 fileOutput.close();
+                gzos.close();
             }
         });
     }


### PR DESCRIPTION
It seems that GZIPInputStream and GZIPOutputStream is not closed at both of GzipFileDecoder and GzipFileEncoder plugins.
I fixed it.