### PR TITLE
PageBuilder#close doesn't close underlaying output

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
@@ -252,6 +252,7 @@ public class PageBuilder
             buffer = null;
             bufferSlice = null;
         }
+        output.close();
     }
 
     /* TODO for variable-length types


### PR DESCRIPTION
Fixes https://github.com/sonots/embulk-filter-column/issues/8