### PR TITLE
Fix uninitialized constant MessagePack

### DIFF
--- a/lib/embulk/schema.rb
+++ b/lib/embulk/schema.rb
@@ -1,6 +1,7 @@
 module Embulk
 
   require 'embulk/column'
+  require 'msgpack'
 
   class Schema < Array
     def initialize(columns)


### PR DESCRIPTION
Using json type with jruby plugin, I got `Fix uninitialized constant MessagePack` as https://gist.github.com/sonots/617c7cf246a0c522651c. 

I am not sure a correct way to fix, but this patch fixed the issue anyway. 