### PR TITLE
Added 'date' option to timestamp type field

### DIFF
--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatterParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatterParser.java
@@ -60,4 +60,16 @@ public class TestTimestampFormatterParser
         TimestampParser parser = new TimestampParser(ptask);
         assertEquals(Timestamp.ofEpochSecond(1416365189), parser.parse("1416365189"));
     }
+
+    @Test
+    public void testDefaultDate() throws Exception
+    {
+        ConfigSource config = Exec.newConfigSource()
+            .set("default_timestamp_format", "%H:%M:%S %Z")
+            .set("default_date", "2016-02-03");
+
+        ParserTestTask ptask = config.loadConfig(ParserTestTask.class);
+        TimestampParser parser = new TimestampParser(ptask);
+        assertEquals(Timestamp.ofEpochSecond(1454467589, 0), parser.parse("02:46:29 +0000"));
+    }
 }


### PR DESCRIPTION
This option is useful when a timestamp string doesn't include date and
user wants to set date in a config file. For example, a CSV file
includes "02:46:29" and a config file includes "date: 2016-02-03".