### PR TITLE
CSV parser supports delimiter longer than 1 character

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -57,7 +57,7 @@ public class CsvParserPlugin
 
         @Config("delimiter")
         @ConfigDefault("\",\"")
-        char getDelimiterChar();
+        String getDelimiter();
 
         @Config("quote")
         @ConfigDefault("\"\\\"\"")

--- a/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
@@ -33,7 +33,7 @@ public class TestCsvParserPlugin
         assertEquals(Charset.forName("utf-8"), task.getCharset());
         assertEquals(Newline.CRLF, task.getNewline());
         assertEquals(false, task.getHeaderLine().or(false));
-        assertEquals(',', task.getDelimiterChar());
+        assertEquals(",", task.getDelimiter());
         assertEquals(Optional.of(new CsvParserPlugin.QuoteCharacter('\"')), task.getQuoteChar());
         assertEquals(false, task.getAllowOptionalColumns());
         assertEquals(DateTimeZone.UTC, task.getDefaultTimeZone());
@@ -68,7 +68,7 @@ public class TestCsvParserPlugin
         assertEquals(Charset.forName("utf-16"), task.getCharset());
         assertEquals(Newline.LF, task.getNewline());
         assertEquals(true, task.getHeaderLine().or(false));
-        assertEquals('\t', task.getDelimiterChar());
+        assertEquals("\t", task.getDelimiter());
         assertEquals(Optional.of(new CsvParserPlugin.QuoteCharacter('\\')), task.getQuoteChar());
         assertEquals(true, task.getAllowOptionalColumns());
     }


### PR DESCRIPTION
For example,

```
id::name::comment
1::foo::bar
2::bar::baz
```
