### PR TITLE
Check the empty string as a null string

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -345,7 +345,7 @@ public class CsvParserPlugin
                                     return null;
                                 }
                                 String v = tokenizer.nextColumn();
-                                if (!v.isEmpty()) {
+                                if (v != null) {
                                     if (v.equals(nullStringOrNull)) {
                                         return null;
                                     }


### PR DESCRIPTION
Currently, empty string (without QuotedString) is always treated as a null regardless of the setting of the null_string. Empty string should be treated as `""` if null_string is `NULL` or `\N` or something. 