### PR TITLE
CSV Parser: Do not always convert empty string to null

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -233,7 +233,6 @@ public class CsvParserPlugin
         final TimestampParser[] timestampParsers = Timestamps.newTimestampColumnParsers(task, task.getSchemaConfig());
         final JsonParser jsonParser = new JsonParser();
         final CsvTokenizer tokenizer = new CsvTokenizer(new LineDecoder(input, task), task);
-        final String nullStringOrNull = task.getNullString().orNull();
         final boolean allowOptionalColumns = task.getAllowOptionalColumns();
         final boolean allowExtraColumns = task.getAllowExtraColumns();
         final boolean stopOnInvalidRecord = task.getStopOnInvalidRecord();
@@ -261,7 +260,7 @@ public class CsvParserPlugin
                             public void booleanColumn(Column column)
                             {
                                 String v = nextColumn();
-                                if (v == null) {
+                                if (v == null || v.isEmpty()) {
                                     pageBuilder.setNull(column);
                                 } else {
                                     pageBuilder.setBoolean(column, TRUE_STRINGS.contains(v));
@@ -271,7 +270,7 @@ public class CsvParserPlugin
                             public void longColumn(Column column)
                             {
                                 String v = nextColumn();
-                                if (v == null) {
+                                if (v == null || v.isEmpty()) {
                                     pageBuilder.setNull(column);
                                 } else {
                                     try {
@@ -286,7 +285,7 @@ public class CsvParserPlugin
                             public void doubleColumn(Column column)
                             {
                                 String v = nextColumn();
-                                if (v == null) {
+                                if (v == null || v.isEmpty()) {
                                     pageBuilder.setNull(column);
                                 } else {
                                     try {
@@ -311,7 +310,7 @@ public class CsvParserPlugin
                             public void timestampColumn(Column column)
                             {
                                 String v = nextColumn();
-                                if (v == null) {
+                                if (v == null || v.isEmpty()) {
                                     pageBuilder.setNull(column);
                                 } else {
                                     try {
@@ -326,7 +325,7 @@ public class CsvParserPlugin
                             public void jsonColumn(Column column)
                             {
                                 String v = nextColumn();
-                                if (v == null) {
+                                if (v == null || v.isEmpty()) {
                                     pageBuilder.setNull(column);
                                 } else {
                                     try {
@@ -344,17 +343,7 @@ public class CsvParserPlugin
                                     //TODO warning
                                     return null;
                                 }
-                                String v = tokenizer.nextColumn();
-                                if (!v.isEmpty()) {
-                                    if (v.equals(nullStringOrNull)) {
-                                        return null;
-                                    }
-                                    return v;
-                                } else if (tokenizer.wasQuotedColumn()) {
-                                    return "";
-                                } else {
-                                    return null;
-                                }
+                                return tokenizer.nextColumnOrNull();
                             }
                         });
 

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -32,6 +32,7 @@ public class CsvTokenizer
     private final long maxQuotedSizeLimit;
     private final String commentLineMarker;
     private final LineDecoder input;
+    private final String nullStringOrNull;
 
     private RecordState recordState = RecordState.END;  // initial state is end of a record. nextRecord() must be called first
     private long lineNumber = 0;
@@ -51,6 +52,7 @@ public class CsvTokenizer
         trimIfNotQuoted = task.getTrimIfNotQuoted();
         maxQuotedSizeLimit = task.getMaxQuotedSizeLimit();
         commentLineMarker = task.getCommentLineMarker().orNull();
+        nullStringOrNull = task.getNullString().orNull();
         this.input = input;
     }
 
@@ -321,6 +323,17 @@ public class CsvTokenizer
                 default:
                     assert false;
             }
+        }
+    }
+
+    public String nextColumnOrNull()
+    {
+        String v = nextColumn();
+        if (v == null || v.equals(nullStringOrNull)) {
+            return null;
+        }
+        else {
+            return v;
         }
     }
 


### PR DESCRIPTION
Currently, empty string is always converted into null even if I do not specify `null_string` option, or I specify `null_string: NULL`.

I prefer csv parser converts an empty string only if I specify its option as `null_string: ""`, and I believe it is the correct specification of csv parser which this document http://www.embulk.org/docs/built-in.html#csv-parser-plugin describes.