### PR TITLE
CSV Parser: CSV Tokenizer should set lineNumber to 0

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -105,7 +105,11 @@ public class CsvTokenizer
 
     public boolean nextFile()
     {
-        return input.nextFile();
+        boolean next = input.nextFile();
+        if (next) {
+            lineNumber = 0;
+        }
+        return next;
     }
 
     // used by guess-csv


### PR DESCRIPTION
CSV Tokenizer should set lineNumber to 0 when CSV Parser's nextFile method is called.