### PR TITLE
Revert "remove unused public wasQuotedColumn()"

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvTokenizer.java
@@ -400,6 +400,11 @@ public class CsvTokenizer
         }
     }
 
+    public boolean wasQuotedColumn()
+    {
+        return wasQuotedColumn;
+    }
+
     private char nextChar()
     {
         Preconditions.checkState(line != null, "nextColumn is called after end of file");


### PR DESCRIPTION
since guess uses `CsvTokenizer.wasQuotedColumn()`

Fix https://github.com/embulk/embulk/issues/439

cc: @muga 
