### PR TITLE
Add dontAbort() after commit() to skip abort()

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
@@ -301,6 +301,7 @@ public class LocalExecutorPlugin
 
                     // outputCommitted
                     tran.commit();
+                    aborter.dontAbort();
                 }
             }
             finally {


### PR DESCRIPTION
I think dontAbort() should be called after commit() call
when using AbortTransactionResource.
AbortTransactionResource is used in try-with-resource block.
When leaving the block, tran.abort() is called. When commit()
is finished without failure, the abort() call is not required.
From other usage of AbortTransactionResource in embulk,
dontAbort() is called after commit() or just before leaving
try-with-resource block. I think runInputTask() should call
dontAbort() at the end of the block.

Note:
This change doesn't affect actual behavior because
ScatterTransactionalPageOutput.commit()
set null to trans field. So, abort doesn't affect to transactions
except a little bit of cpu time.