### PR TITLE
[WIP] Enhance JsonParserPlugin

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/json/JsonParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/json/JsonParser.java
@@ -1,18 +1,13 @@
 package org.embulk.spi.json;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
 import java.io.InputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import org.msgpack.value.Value;
-import org.msgpack.value.ValueFactory;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser.Feature;
-import com.fasterxml.jackson.core.JsonToken;
 
+@Deprecated
 public class JsonParser
 {
     public interface Stream
@@ -143,90 +138,7 @@ public class JsonParser
 
         public Value next() throws IOException
         {
-            try {
-                JsonToken token = parser.nextToken();
-                if (token == null) {
-                    return null;
-                }
-                return jsonTokenToValue(token);
-            }
-            catch (com.fasterxml.jackson.core.JsonParseException ex) {
-                throw new JsonParseException("Failed to parse JSON: "+sampleJsonString(), ex);
-            }
-            catch (IOException ex) {
-                throw ex;
-            }
-            catch (JsonParseException ex) {
-                throw ex;
-            }
-            catch (RuntimeException ex) {
-                throw new JsonParseException("Failed to parse JSON: "+sampleJsonString(), ex);
-            }
-        }
-
-        private Value jsonTokenToValue(JsonToken token)
-            throws IOException
-        {
-            switch(token) {
-            case VALUE_NULL:
-                return ValueFactory.newNil();
-            case VALUE_TRUE:
-                return ValueFactory.newBoolean(true);
-            case VALUE_FALSE:
-                return ValueFactory.newBoolean(false);
-            case VALUE_NUMBER_FLOAT:
-                return ValueFactory.newFloat(parser.getDoubleValue());
-            case VALUE_NUMBER_INT:
-                try {
-                    return ValueFactory.newInteger(parser.getLongValue());
-                }
-                catch (JsonParseException ex) {
-                    return ValueFactory.newInteger(parser.getBigIntegerValue());
-                }
-            case VALUE_STRING:
-                return ValueFactory.newString(parser.getText());
-            case START_ARRAY: {
-                List<Value> list = new ArrayList<>();
-                while (true) {
-                    token = parser.nextToken();
-                    if (token == JsonToken.END_ARRAY) {
-                        return ValueFactory.newArray(list);
-                    }
-                    else if (token == null) {
-                        throw new JsonParseException("Unexpected end of JSON at "+parser.getTokenLocation() + " while expecting an element of an array: " + sampleJsonString());
-                    }
-                    list.add(jsonTokenToValue(token));
-                }
-            }
-            case START_OBJECT:
-                Map<Value, Value> map = new HashMap<>();
-                while (true) {
-                    token = parser.nextToken();
-                    if (token == JsonToken.END_OBJECT) {
-                        return ValueFactory.newMap(map);
-                    }
-                    else if (token == null) {
-                        throw new JsonParseException("Unexpected end of JSON at "+parser.getTokenLocation() + " while expecting a key of object: " + sampleJsonString());
-                    }
-                    String key = parser.getCurrentName();
-                    if (key == null) {
-                        throw new JsonParseException("Unexpected token "+token+" at "+parser.getTokenLocation() + ": " + sampleJsonString());
-                    }
-                    token = parser.nextToken();
-                    if (token == null) {
-                        throw new JsonParseException("Unexpected end of JSON at "+parser.getTokenLocation() + " while expecting a value of object: " + sampleJsonString());
-                    }
-                    Value value = jsonTokenToValue(token);
-                    map.put(ValueFactory.newString(key), value);
-                }
-            case VALUE_EMBEDDED_OBJECT:
-            case FIELD_NAME:
-            case END_ARRAY:
-            case END_OBJECT:
-            case NOT_AVAILABLE:
-            default:
-                throw new JsonParseException("Unexpected token "+token+" at "+parser.getTokenLocation() + ": " + sampleJsonString());
-            }
+            return JsonUtil.readJson(parser);
         }
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/json/JsonUtil.java
+++ b/embulk-core/src/main/java/org/embulk/spi/json/JsonUtil.java
@@ -1,0 +1,104 @@
+package org.embulk.spi.json;
+
+import com.fasterxml.jackson.core.JsonToken;
+import org.msgpack.value.Value;
+import org.msgpack.value.ValueFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JsonUtil
+{
+    // This class should be ported to msgpack-java in the future.
+
+    public static Value readJson(com.fasterxml.jackson.core.JsonParser parser)
+            throws IOException
+    {
+        try {
+            JsonToken token = parser.nextToken();
+            if (token == null) {
+                return null;
+            }
+            return jsonTokenToValue(parser, token);
+        }
+        catch (com.fasterxml.jackson.core.JsonParseException e) {
+            throw new JsonParseException("Failed to parse JSON", e);
+        }
+        catch (IOException e) {
+            throw e;
+        }
+        catch (JsonParseException e) {
+            throw e;
+        }
+        catch (RuntimeException e) {
+            throw new JsonParseException("Failed to parse JSON", e);
+        }
+    }
+
+    public static Value jsonTokenToValue(com.fasterxml.jackson.core.JsonParser parser, JsonToken token)
+            throws IOException
+    {
+        switch(token) {
+        case VALUE_NULL:
+            return ValueFactory.newNil();
+        case VALUE_TRUE:
+            return ValueFactory.newBoolean(true);
+        case VALUE_FALSE:
+            return ValueFactory.newBoolean(false);
+        case VALUE_NUMBER_FLOAT:
+            return ValueFactory.newFloat(parser.getDoubleValue());
+        case VALUE_NUMBER_INT:
+            try {
+                return ValueFactory.newInteger(parser.getLongValue());
+            }
+            catch (JsonParseException ex) {
+                return ValueFactory.newInteger(parser.getBigIntegerValue());
+            }
+        case VALUE_STRING:
+            return ValueFactory.newString(parser.getText());
+        case START_ARRAY:
+            List<Value> list = new ArrayList<>();
+            while (true) {
+                token = parser.nextToken();
+                if (token == JsonToken.END_ARRAY) {
+                    return ValueFactory.newArray(list);
+                }
+                else if (token == null) {
+                    throw new JsonParseException("Unexpected end of JSON at " + parser.getTokenLocation());
+                }
+                list.add(jsonTokenToValue(parser, token));
+            }
+        case START_OBJECT:
+            Map<Value, Value> map = new HashMap<>();
+            while (true) {
+                token = parser.nextToken();
+                if (token == JsonToken.END_OBJECT) {
+                    return ValueFactory.newMap(map);
+                }
+                else if (token == null) {
+                    throw new JsonParseException("Unexpected end of JSON at " + parser.getTokenLocation());
+                }
+                String key = parser.getCurrentName();
+                if (key == null) {
+                    throw new JsonParseException("Unexpected token " + token + " at " + parser.getTokenLocation());
+                }
+                token = parser.nextToken();
+                if (token == null) {
+                    throw new JsonParseException("Unexpected end of JSON at " + parser.getTokenLocation());
+                }
+                Value value = jsonTokenToValue(parser, token);
+                map.put(ValueFactory.newString(key), value);
+            }
+        case VALUE_EMBEDDED_OBJECT:
+        case FIELD_NAME:
+        case END_ARRAY:
+        case END_OBJECT:
+        case NOT_AVAILABLE:
+        default:
+            throw new JsonParseException("Unexpected token " + token + " at " + parser.getTokenLocation());
+        }
+    }
+}

--- a/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
@@ -1,8 +1,17 @@
 package org.embulk.standards;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonParser.Feature;
+import com.fasterxml.jackson.core.JsonToken;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
+import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
@@ -15,9 +24,10 @@ import org.embulk.spi.PageOutput;
 import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.Schema;
 import org.embulk.spi.json.JsonParseException;
-import org.embulk.spi.json.JsonParser;
+import org.embulk.spi.json.JsonUtil;
 import org.embulk.spi.type.Types;
 import org.embulk.spi.util.FileInputInputStream;
+import org.embulk.spi.util.LineDecoder;
 import org.msgpack.value.Value;
 import org.slf4j.Logger;
 
@@ -27,24 +37,69 @@ public class JsonParserPlugin
         implements ParserPlugin
 {
     public interface PluginTask
-            extends Task
+            extends Task, LineDecoder.DecoderTask
     {
+        @Config("file_type")
+        @ConfigDefault("\"sequence\"")
+        FileType getFileType();
+
+        @Config("object_field")
+        @ConfigDefault("null")
+        Optional<String> getObjectField();
+
         @Config("stop_on_invalid_record")
         @ConfigDefault("false")
         boolean getStopOnInvalidRecord();
     }
 
+    public enum FileType
+    {
+        SEQUENCE("sequence"), OBJECT("object"), ARRAY("array"), LINES("lines");
+
+        private final String name;
+
+        FileType(String name)
+        {
+            this.name = name;
+        }
+
+        @JsonValue
+        @Override
+        public String toString()
+        {
+            return name;
+        }
+
+        @JsonCreator
+        public static FileType of(String name)
+        {
+            for (FileType type : FileType.values()) {
+                if (type.toString().equals(name)) {
+                    return type;
+                }
+            }
+            throw new ConfigException(String.format("Unknown FileType '%s'. Available options are [sequence, object, array, lines]", name));
+        }
+    }
+
     private final Logger log;
+    private final JsonFactory factory;
 
     public JsonParserPlugin()
     {
         this.log = Exec.getLogger(JsonParserPlugin.class);
+        this.factory = new JsonFactory().enable(Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
     }
 
     @Override
     public void transaction(ConfigSource configSource, Control control)
     {
         PluginTask task = configSource.loadConfig(PluginTask.class);
+
+        if (task.getFileType().equals(FileType.OBJECT) && !task.getObjectField().isPresent()) {
+            throw new ConfigException("Must specify 'object_field' option if 'object' is used as file_type");
+        }
+
         control.run(task.dump(), newSchema());
     }
 
@@ -59,16 +114,23 @@ public class JsonParserPlugin
     {
         PluginTask task = taskSource.loadTask(PluginTask.class);
 
+        final FileType fileType = task.getFileType();
         final boolean stopOnInvalidRecord = task.getStopOnInvalidRecord();
         final Column column = schema.getColumn(0); // record column
 
         try (PageBuilder pageBuilder = newPageBuilder(schema, output);
-                FileInputInputStream in = new FileInputInputStream(input)) {
+                JsonFileInput in = newJsonFileInput(task, fileType, input)) {
             while (in.nextFile()) {
-                try (JsonParser.Stream stream = newJsonStream(in)) {
+                try {
+                    JsonFileParser parser = newJsonFileParser(factory, task, fileType, in);
+
+                    // read json text before records
+                    parser.skipFirst();
+
                     Value value;
-                    while ((value = stream.next()) != null) {
+                    while ((value = parser.readJson()) != null) {
                         try {
+                            // make sure that it's map value
                             if (!value.isMapValue()) {
                                 throw new JsonRecordValidateException(
                                         String.format("A Json record must not represent map value but it's %s", value.getValueType().name()));
@@ -84,33 +146,330 @@ public class JsonParserPlugin
                             log.warn(String.format("Skipped record (%s): %s", e.getMessage(), value.toJson()));
                         }
                     }
+
+                    // read json text after records
+                    parser.skipLast();
                 }
-                catch (IOException | JsonParseException e) {
+                catch (IOException | JsonParseException e) { // catch JsonFileValidate
                     throw new DataException(e);
                 }
             }
-
             pageBuilder.finish();
         }
     }
 
-    private PageBuilder newPageBuilder(Schema schema, PageOutput output)
+    static PageBuilder newPageBuilder(Schema schema, PageOutput output)
     {
         return new PageBuilder(Exec.getBufferAllocator(), schema, output);
     }
 
-    private JsonParser.Stream newJsonStream(FileInputInputStream in)
+    static JsonFileInput newJsonFileInput(PluginTask task, FileType fileType, FileInput in)
+    {
+        if (fileType.equals(FileType.LINES)) {
+            return new JsonLineDecoder(in, task);
+        }
+        else {
+            return new JsonFileInputInputStream(in);
+        }
+    }
+
+    static JsonFileParser newJsonFileParser(JsonFactory factory, PluginTask task, FileType fileType, JsonFileInput in)
             throws IOException
     {
-        return new JsonParser().open(in);
+        if (fileType.equals(FileType.LINES)) {
+            return new LinesParser(factory, (JsonLineDecoder)in);
+        }
+
+        JsonParser parser = newJsonParser(factory, (JsonFileInputInputStream)in);
+        switch (fileType) {
+        case SEQUENCE:
+            return new SequenceParser(parser);
+        case OBJECT:
+            return new ObjectParser(parser, task.getObjectField().get());
+        case ARRAY:
+            return new ArrayParser(parser);
+        }
+
+        throw new IllegalArgumentException(String.format("Unexpected file type: %s", fileType.name));
+    }
+
+    static JsonParser newJsonParser(JsonFactory factory, JsonFileInputInputStream in)
+            throws IOException
+    {
+        try {
+            return factory.createParser(in);
+        }
+        catch (com.fasterxml.jackson.core.JsonParseException e) {
+            throw new JsonParseException("Failed JsonParser object creation", e);
+        }
+    }
+
+    static Value readJsonObject(JsonParser parser)
+            throws IOException
+    {
+        JsonToken token = parser.nextToken();
+        if (token == null || !token.equals(JsonToken.START_OBJECT)) {
+            return null;
+        }
+        else {
+            return JsonUtil.jsonTokenToValue(parser, token);
+        }
     }
 
     static class JsonRecordValidateException
-            extends DataException
+            extends JsonParseException
     {
         JsonRecordValidateException(String message)
         {
             super(message);
+        }
+    }
+
+    static class JsonFileValidateException
+            extends JsonParseException
+    {
+        JsonFileValidateException(String message)
+        {
+            super(message);
+        }
+    }
+
+    interface JsonFileInput
+            extends AutoCloseable
+    {
+        boolean nextFile();
+        void close();
+    }
+
+    static class JsonFileInputInputStream
+            extends FileInputInputStream
+            implements JsonFileInput
+    {
+        public JsonFileInputInputStream(FileInput in)
+        {
+            super(in);
+        }
+    }
+
+    static class JsonLineDecoder
+            extends LineDecoder
+            implements JsonFileInput
+    {
+
+        public JsonLineDecoder(FileInput in, DecoderTask task)
+        {
+            super(in, task);
+        }
+    }
+
+    interface JsonFileParser
+    {
+        Value readJson() throws IOException;
+        void skipFirst() throws IOException;
+        void skipLast() throws IOException;
+    }
+
+    static abstract class AbstractJsonFileParser
+            implements JsonFileParser
+    {
+        protected final FileType fileType;
+        protected final JsonParser parser;
+
+        protected AbstractJsonFileParser(FileType fileType, JsonParser parser)
+                throws IOException
+        {
+            this.fileType = fileType;
+            this.parser = parser;
+        }
+
+        @Override
+        public Value readJson()
+                throws IOException
+        {
+            return readJsonObject(this.parser);
+        }
+
+        protected void throwJsonFileValidateException(String message)
+        {
+            throw new JsonFileValidateException(newMessage(message));
+        }
+
+        private String newMessage(String message)
+        {
+            return String.format("%s by %s parser at %s", message, fileType, parser.getTokenLocation());
+        }
+
+    }
+
+    static class SequenceParser
+            extends AbstractJsonFileParser
+    {
+        // {"col":"val1"}{"col":"val2"}
+        public SequenceParser(JsonParser parser)
+                throws IOException
+        {
+            super(FileType.SEQUENCE, parser);
+        }
+
+        @Override
+        public void skipFirst()
+                throws IOException
+        {
+        }
+
+        @Override
+        public void skipLast()
+                throws IOException
+        {
+        }
+    }
+
+    static class ObjectParser
+            extends AbstractJsonFileParser
+    {
+        private final String fieldName;
+
+        // {"records":[{"col":"val1"},{"col":"val2"},...],...}
+        public ObjectParser(JsonParser parser, String fieldName)
+                throws IOException
+        {
+            super(FileType.OBJECT, parser);
+            this.fieldName = fieldName;
+        }
+
+        @Override
+        public void skipFirst()
+                throws IOException
+        {
+            JsonToken token;
+
+            if ((token = parser.nextToken()) == null || !token.equals(JsonToken.START_OBJECT)) {
+                throwJsonFileValidateException(String.format("Unexpected head of file: %s is not '{'", token));
+            }
+
+            while (true) {
+                token = parser.nextToken();
+                if (token == null) {
+                    throwJsonFileValidateException("Unexpected head of file");
+                }
+                String key = parser.getCurrentName();
+                if (key == null) {
+                    throwJsonFileValidateException("Unexpected token " + token);
+                }
+                else if (key.equals(fieldName)) {
+                    break;
+                }
+                token = parser.nextToken();
+                if (token == null) {
+                    throwJsonFileValidateException("Unexpected head of file");
+                }
+            }
+
+            if ((token = parser.nextToken()) == null || !token.equals(JsonToken.START_ARRAY)) {
+                throwJsonFileValidateException(String.format("Unexpected head of file: %s is not '['", token));
+            }
+        }
+
+        @Override
+        public void skipLast()
+                throws IOException
+        {
+            JsonToken token;
+
+            // it should not use nextToken method first. Because the token is already read before.
+            if ((token = parser.getCurrentToken()) == null || !token.equals(JsonToken.END_ARRAY)) {
+                throwJsonFileValidateException(String.format("Unexpected end of file: %s is not ']'", token));
+            }
+
+            while (true) {
+                token = parser.nextToken();
+                if (token == JsonToken.END_OBJECT) {
+                    return;
+                }
+                else if (token == null) {
+                    throwJsonFileValidateException(String.format("Unexpected end of file: %s is not '}'", token));
+                }
+                String key = parser.getCurrentName();
+                if (key == null) {
+                    throwJsonFileValidateException("Unexpected token " + token);
+                }
+                token = parser.nextToken();
+                if (token == null) {
+                    throwJsonFileValidateException("Unexpected end of file");
+                }
+            }
+        }
+    }
+
+    static class ArrayParser
+            extends AbstractJsonFileParser
+    {
+        // [{"col":"val1"},{"col":"val2"},...]
+        public ArrayParser(JsonParser parser)
+                throws IOException
+        {
+            super(FileType.ARRAY, parser);
+        }
+
+        @Override
+        public void skipFirst()
+                throws IOException
+        {
+            JsonToken token = parser.nextToken();
+            if (token == null || !token.equals(JsonToken.START_ARRAY)) {
+                throwJsonFileValidateException(String.format("Unexpected head of file: % is not '['", token));
+            }
+        }
+
+        @Override
+        public void skipLast()
+                throws IOException
+        {
+            // it should not use nextToken method first. Because the token is already read before.
+            JsonToken token = parser.getCurrentToken();
+            if (token == null || !token.equals(JsonToken.END_ARRAY)) {
+                throwJsonFileValidateException(String.format("Unexpected end of file: %s is not ']'", token));
+            }
+        }
+    }
+
+    static class LinesParser
+            implements JsonFileParser
+    {
+        private final JsonFactory factory;
+        private final LineDecoder input;
+
+        LinesParser(JsonFactory factory, JsonLineDecoder input)
+        {
+            this.factory = factory;
+            this.input = input;
+        }
+
+        @Override
+        public Value readJson()
+                throws IOException
+        {
+            // TODO error handling
+
+            String line = input.poll();
+            if (!Strings.isNullOrEmpty(line)) {
+                return readJsonObject(factory.createParser(line));
+            }
+            else {
+                return null;
+            }
+        }
+
+        @Override
+        public void skipFirst()
+                throws IOException
+        {
+        }
+
+        @Override
+        public void skipLast()
+                throws IOException
+        {
         }
     }
 }


### PR DESCRIPTION
Add file_type and object_field options

The plugin can parse several types of JSON files. Currently it supports [sequence, object, array, lines] as file types. sequence is by default.

If `field_type: sequence` specified, the plugin can parse the sequence of JSON objects as records:

```
{"col1":"val1","col2":"val2"}{"col1":"val3","col2":"val4"}{"col1":"val1","col5":"val6"}{"col1":"val7","col2":"val8"}
```
and
```
{
  "col1":"val1",
  "col2":"val2"
}
{
  "col1":"val3",
  "col2":"val4"
}
{
  "col1":"val1",
  "col5":"val6"
}
{
  "col1":"val7",
  "col2":"val8"
}
```

By `field_type: object`, it can extract and parse the value in a big JSON object in the file as records:

```
{"records":[
  {"col1":"val1","col2":"val2"},
  {"col1":"val3","col2":"val4"},
  {"col1":"val1","col5":"val6"},
  {"col1":"val7","col2":"val8"}
]}
```

The extracted key is `records` by default. Users can specify the key name as object_field option.

`field_type: array` can parse the following a big JSON array in the file.

```
[
  {"col1":"val1","col2":"val2"},
  {"col1":"val3","col2":"val4"},
  {"col1":"val1","col5":"val6"},
  {"col1":"val7","col2":"val8"}
]
```

`field_type: lines` can parse a JSON file in line-json format.

TODO: 
* enhance `lines` typed parser. We can handle JsonParseException by each line
* implement guess command