### PR TITLE
fixes 'IllegalArgumentException: Self-suppression not permitted' when output plugin throws a runtime exception

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
@@ -552,6 +552,7 @@ public class LocalExecutorPlugin
                     catch (InterruptedException ex) {
                         error = ex;
                     }
+                    outputWorkers[i] = null;
                     if (error != null) {
                         throw Throwables.propagate(error);
                     }


### PR DESCRIPTION
Fixes #438.