### PR TITLE
Fix #450 undefined method `jar_path' for Gem:Module

### DIFF
--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -341,7 +341,9 @@ examples:
     if m && m[1] != "org.jruby.Main"
       # Main-Class is not jruby
       Gem.define_singleton_method(:ruby) do
-        "java -cp #{jar_path(jar_uri)} org.jruby.Main"
+        path = jar_uri.sub(/^file:/, "").sub(/!.*/, "")
+        path = path.sub(/^\//, "") if win_platform? && path =~ /^\/[A-Za-z]:/
+        "java -cp #{path} org.jruby.Main"
       end
     end
   end


### PR DESCRIPTION
Fix #450 

I read source code again.
The ``jar_path`` method was used ``fix_gem_ruby_path`` method in
``lib/embulk/command/embulk_run.rb``  only. 

So I simply copy code from original jar_path method.
