### PR TITLE
Allow type coalesce from timestamp to long at guess

### DIFF
--- a/lib/embulk/guess/schema_guess.rb
+++ b/lib/embulk/guess/schema_guess.rb
@@ -111,6 +111,7 @@ module Embulk::Guess
       TYPE_COALESCE = Hash[{
         long: :double,
         boolean: :long,
+        timestamp: :long,  # TimeFormatGuess matches with digits without delimiters
       }.map {|k,v|
         [[k.to_s, v.to_s].sort, v.to_s]
       }]

--- a/test/guess/test_schema_guess.rb
+++ b/test/guess/test_schema_guess.rb
@@ -4,8 +4,26 @@ require 'embulk/guess/schema_guess'
 
 class SchemaGuessTest < ::Test::Unit::TestCase
   G = Embulk::Guess::SchemaGuess
+  C = Embulk::Column
 
   def test_guess
     G.from_hash_records([{"int" => "1", "str" => "a"}])
+  end
+
+  def test_coalesce
+    assert_equal(
+      [C.new(0, "a", :timestamp, "%Y%m%d")],
+      G.from_hash_records([
+        {"a" => "20160101"},
+        {"a" => "20160101"},
+      ]))
+
+    assert_equal(
+      [C.new(0, "a", :long)],
+      G.from_hash_records([
+        {"a" => "20160101"},
+        {"a" => "20160101"},
+        {"a" => "12345678"},
+      ]))
   end
 end


### PR DESCRIPTION
This fixes unexpected guess results of integer types.
Gussing `[1456012800, 1456014800]` is expected to be long but it becomes
string because `1456012800` is guessed as timestamp with `%Y%m%d%H`
format, `1456014800` is guessed as long, and type coalescing from timestamp
to long was not allowed. This adds coalescing from timestamp to long to
fix this issue.