### PR TITLE
Add unit.TimestampParam class for plugins

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -21,7 +21,6 @@ import org.embulk.plugin.PluginManager;
 import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.time.TimestampFormatter.FormatterTask;
-import org.embulk.spi.unit.TimestampParam;
 
 public class ExecSession
 {
@@ -42,7 +41,7 @@ public class ExecSession
     {
         @Config("transaction_time")
         @ConfigDefault("null")
-        Optional<TimestampParam> getTransactionTime();
+        Optional<Timestamp> getTransactionTime();
     }
 
     public static class Builder
@@ -93,8 +92,8 @@ public class ExecSession
     {
         this(injector,
                 configSource.loadConfig(SessionTask.class).getTransactionTime().or(
-                    TimestampParam.of(Timestamp.ofEpochMilli(System.currentTimeMillis()))
-                    ).getTimestamp(), // TODO get nanoseconds for default
+                    Timestamp.ofEpochMilli(System.currentTimeMillis())
+                    ), // TODO get nanoseconds for default
                 null);
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -21,6 +21,7 @@ import org.embulk.plugin.PluginManager;
 import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.time.TimestampFormatter.FormatterTask;
+import org.embulk.spi.unit.TimestampParam;
 
 public class ExecSession
 {
@@ -41,7 +42,7 @@ public class ExecSession
     {
         @Config("transaction_time")
         @ConfigDefault("null")
-        Optional<Timestamp> getTransactionTime();
+        Optional<TimestampParam> getTransactionTime();
     }
 
     public static class Builder
@@ -92,8 +93,8 @@ public class ExecSession
     {
         this(injector,
                 configSource.loadConfig(SessionTask.class).getTransactionTime().or(
-                    Timestamp.ofEpochMilli(System.currentTimeMillis())
-                    ), // TODO get nanoseconds for default
+                    TimestampParam.of(Timestamp.ofEpochMilli(System.currentTimeMillis()))
+                    ).getTimestamp(), // TODO get nanoseconds for default
                 null);
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/unit/TimestampParam.java
+++ b/embulk-core/src/main/java/org/embulk/spi/unit/TimestampParam.java
@@ -1,0 +1,115 @@
+package org.embulk.spi.unit;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Date;
+import java.util.TimeZone;
+import java.text.SimpleDateFormat;
+import java.text.ParseException;
+import org.embulk.spi.time.Timestamp;
+
+public class TimestampParam
+{
+    private final Timestamp timestamp;
+
+    private TimestampParam(Timestamp timestamp)
+    {
+        this.timestamp = timestamp;
+    }
+
+    public Timestamp getTimestamp()
+    {
+        return timestamp;
+    }
+
+    @JsonCreator
+    public static TimestampParam fromJson(JsonNode node)
+        throws JsonMappingException
+    {
+        String url;
+        if (node.canConvertToLong()) {
+            return of(Timestamp.ofEpochSecond(node.asLong()));
+        }
+        else if (node.isTextual()) {
+            try {
+                return fromString(node.asText());
+            }
+            catch (IllegalArgumentException ex) {
+                throw new JsonMappingException(ex.getMessage());
+            }
+        }
+        else {
+            throw new JsonMappingException("Can not deserialize instance of TimestampParam out of malformed object: " + node);
+
+        }
+    }
+
+    public static TimestampParam fromString(String timestamp)
+    {
+        Date date;
+        try {
+            if (timestamp.contains("UTC")) {
+                if (timestamp.indexOf('.') >= 0) {
+                    // with fractional seconds
+                    date = pattern("yyyy-MM-dd HH:mm:ss.SSS 'UTC'").parse(timestamp);
+                }
+                else {
+                    date = pattern("yyyy-MM-dd HH:mm:ss 'UTC'").parse(timestamp);
+                }
+            }
+            else if (timestamp.indexOf('T') >= 0) {
+                // ISO 8601 & RFC 3339 format
+                if (timestamp.indexOf(' ') >= 0) {
+                    throw new IllegalArgumentException("Invalid timestamp format: " + timestamp);
+                }
+                if (timestamp.indexOf('.') >= 0) {
+                    // with fractional seconds
+                    date = pattern("yyyy-MM-dd'T'HH:mm:ss.SSSX").parse(timestamp);
+                }
+                else {
+                    date = pattern("yyyy-MM-dd'T'HH:mm:ssX").parse(timestamp);
+                }
+            }
+            else {
+                if (timestamp.indexOf('.') >= 0) {
+                    // with fractional seconds
+                    date = pattern("yyyy-MM-dd HH:mm:ss.SSS X").parse(timestamp);
+                }
+                else {
+                    date = pattern("yyyy-MM-dd HH:mm:ss X").parse(timestamp);
+                }
+            }
+        }
+        catch (ParseException ex) {
+            throw new IllegalArgumentException("Invalid timestamp format: " + timestamp + " (" + ex.getMessage() + ")", ex);
+        }
+        return of(Timestamp.ofEpochMilli(date.getTime()));
+    }
+
+    public static TimestampParam of(Timestamp timestamp)
+    {
+        return new TimestampParam(timestamp);
+    }
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        long millis = timestamp.toEpochMilli();
+        if (millis % 1000 == 0) {
+            return pattern("yyyy-MM-dd'T'HH:mm:ssX").format(new Date(millis));
+        }
+        else {
+            return pattern("yyyy-MM-dd'T'HH:mm:ss.SSSX").format(new Date(millis));
+        }
+    }
+
+    private static SimpleDateFormat pattern(String pattern)
+    {
+        SimpleDateFormat format = new SimpleDateFormat(pattern);
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return format;
+    }
+}

--- a/embulk-core/src/test/java/org/embulk/spi/unit/TestTimestampParam.java
+++ b/embulk-core/src/test/java/org/embulk/spi/unit/TestTimestampParam.java
@@ -1,0 +1,121 @@
+package org.embulk.spi.unit;
+
+import org.embulk.spi.time.Timestamp;
+
+import org.junit.Test;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class TestTimestampParam
+{
+    @Test
+    public void testUnitPatterns()
+        throws Exception
+    {
+        assertTimestamp(1471384563000L, "2016-08-16T14:56:03-07:00");
+        assertTimestamp(1471384563000L, "2016-08-16T14:56:03-0700");
+        assertTimestamp(1471384563000L, "2016-08-16 14:56:03 -07:00");
+        assertTimestamp(1471384563000L, "2016-08-16 14:56:03 -0700");
+
+        assertTimestamp(1471359363000L, "2016-08-16T14:56:03+00:00");
+        assertTimestamp(1471359363000L, "2016-08-16T14:56:03+0000");
+        assertTimestamp(1471359363000L, "2016-08-16T14:56:03Z");
+        assertTimestamp(1471359363000L, "2016-08-16 14:56:03 +00:00");
+        assertTimestamp(1471359363000L, "2016-08-16 14:56:03 +0000");
+        assertTimestamp(1471359363000L, "2016-08-16 14:56:03 Z");
+        assertTimestamp(1471359363000L, "2016-08-16 14:56:03 UTC");
+
+        assertInvalid("2016-08-16T14:56:03 -07:00");
+        assertInvalid("2016-08-16T14:56:03 -0700");
+        assertInvalid("2016-08-16 14:56:03-07:00");
+        assertInvalid("2016-08-16 14:56:03-0700");
+
+        assertInvalid("2016-08-16T14:56:03 +00:00");
+        assertInvalid("2016-08-16T14:56:03 +0000");
+        assertInvalid("2016-08-16T14:56:03 Z");
+        assertInvalid("2016-08-16T14:56:03 UTC");
+        assertInvalid("2016-08-16 14:56:03+00:00");
+        assertInvalid("2016-08-16 14:56:03+0000");
+        assertInvalid("2016-08-16 14:56:03Z");
+        assertInvalid("2016-08-16 14:56:03UTC");
+    }
+
+    @Test
+    public void testUnitPatternsWithFracSeconds()
+        throws Exception
+    {
+        assertTimestamp(1471384563031L, "2016-08-16T14:56:03.031-07:00");
+        assertTimestamp(1471384563031L, "2016-08-16T14:56:03.031-0700");
+        assertTimestamp(1471384563031L, "2016-08-16 14:56:03.031 -07:00");
+        assertTimestamp(1471384563031L, "2016-08-16 14:56:03.031 -0700");
+
+        assertTimestamp(1471359363031L, "2016-08-16T14:56:03.031+00:00");
+        assertTimestamp(1471359363031L, "2016-08-16T14:56:03.031+0000");
+        assertTimestamp(1471359363031L, "2016-08-16T14:56:03.031Z");
+        assertTimestamp(1471359363031L, "2016-08-16 14:56:03.031 +00:00");
+        assertTimestamp(1471359363031L, "2016-08-16 14:56:03.031 +0000");
+        assertTimestamp(1471359363031L, "2016-08-16 14:56:03.031 Z");
+        assertTimestamp(1471359363031L, "2016-08-16 14:56:03.031 UTC");
+
+        assertInvalid("2016-08-16T14:56:03.031 -07:00");
+        assertInvalid("2016-08-16T14:56:03.031 -0700");
+        assertInvalid("2016-08-16 14:56:03.031-07:00");
+        assertInvalid("2016-08-16 14:56:03.031-0700");
+
+        assertInvalid("2016-08-16T14:56:03.031 +00:00");
+        assertInvalid("2016-08-16T14:56:03.031 +0000");
+        assertInvalid("2016-08-16T14:56:03.031 Z");
+        assertInvalid("2016-08-16T14:56:03.031 UTC");
+        assertInvalid("2016-08-16 14:56:03.031+00:00");
+        assertInvalid("2016-08-16 14:56:03.031+0000");
+        assertInvalid("2016-08-16 14:56:03.031Z");
+        assertInvalid("2016-08-16 14:56:03.031UTC");
+
+        assertInvalid("2016-08-16 14:56:03.0315");
+        assertInvalid("2016-08-16 14:56:03.03156");
+        assertInvalid("2016-08-16 14:56:03.031567");
+        assertInvalid("2016-08-16 14:56:03.03156799321");
+    }
+
+    @Test
+    public void testUnix()
+        throws Exception
+    {
+        assertTimestamp(1471359363000L, 1471359363L);
+    }
+
+    @Test
+    public void testFormats()
+        throws Exception
+    {
+        assertEquals("2016-08-16T14:56:03Z", TimestampParam.of(Timestamp.ofEpochMilli(1471359363000L)).toString());
+        assertEquals("2016-08-16T14:56:03.031Z", TimestampParam.of(Timestamp.ofEpochMilli(1471359363031L)).toString());
+    }
+
+    private static void assertInvalid(String string)
+    {
+        try {
+            TimestampParam.fromJson(JsonNodeFactory.instance.textNode(string)).getTimestamp();
+            fail();
+        }
+        catch (Exception ex) {
+        }
+    }
+
+    private static void assertTimestamp(long millis, String string)
+        throws Exception
+    {
+        assertEquals(
+                Timestamp.ofEpochMilli(millis),
+                TimestampParam.fromJson(JsonNodeFactory.instance.textNode(string)).getTimestamp());
+    }
+
+    private static void assertTimestamp(long millis, long num)
+        throws Exception
+    {
+        assertEquals(
+                Timestamp.ofEpochMilli(millis),
+                TimestampParam.fromJson(JsonNodeFactory.instance.numberNode(num)).getTimestamp());
+    }
+}


### PR DESCRIPTION
This unit class is useful to get a timestamp value as a config
parameter. It accepts intersection of ISO 8601 & RFC 3339 and UNIX
timestamp in seconds.