### PR TITLE
Support timestamp format "%Q"

### DIFF
--- a/lib/embulk/java/time_helper.rb
+++ b/lib/embulk/java/time_helper.rb
@@ -35,7 +35,7 @@ module Embulk
             return seconds * 1_000_000 + usec.to_i
           else # ex) %Q return Rational object.
             t = Time.at(seconds,0)
-            return t.to_i * 1_000_000 + t.usec
+            return (seconds * 1_000_000).to_i
           end
         else
           year = hash[:year]

--- a/lib/embulk/java/time_helper.rb
+++ b/lib/embulk/java/time_helper.rb
@@ -30,10 +30,13 @@ module Embulk
         end
 
         if seconds = hash[:seconds]
-          sec_fraction = hash[:sec_fraction]  # Rational
-          usec = sec_fraction * 1_000_000 if sec_fraction
-          return seconds * 1_000_000 + usec.to_i
-
+          if sec_fraction = hash[:sec_fraction]  # Rational
+            usec = sec_fraction * 1_000_000 if sec_fraction
+            return seconds * 1_000_000 + usec.to_i
+          else # ex) %Q return Rational object.
+            t = Time.at(seconds,0)
+            return t.to_i * 1_000_000 + t.usec
+          end
         else
           year = hash[:year]
           mon = hash[:mon]


### PR DESCRIPTION
The current timestamp format does not work properly when format string is "%Q".
This is because [Date#_strptime](https://github.com/embulk/embulk/blob/3b149ad3cd6481ddc146911dd679eaab9a6a3479/lib/embulk/java/time_helper.rb#L27) return Rational object and it does not have sec_fraction data.

I copied source from the following codes.
https://github.com/ruby/ruby/blob/trunk/lib/time.rb#L430-L437

ref: [strftime](http://apidock.com/ruby/DateTime/strftime)
## Ruby test code.

```
puts Time.strptime("1470148959542","%Q").utc.strftime("%Y-%m-%d %H:%M:%S.%L")
2016-08-02 14:42:39.542
```
## Configuration and data.

```
in:
  type: file
  path_prefix: csv/sample_
  parser:
    charset: UTF-8
    newline: CRLF
    type: csv
    delimiter: ','
    quote: '"'
    escape: '"'
    trim_if_not_quoted: false
    skip_header_lines: 1
    allow_extra_columns: false
    allow_optional_columns: false
    columns:
    - {name: id, type: long}
    - {name: time, type: timestamp, format: "%Q"}
#out: {type: stdout}
```

```
id,time
1,1470148959542
2,1470148959542
3,1470148959542
4,1470148959542
```
## Current

```
+---------+-------------------------+
| id:long |          time:timestamp |
+---------+-------------------------+
|       1 | 1970-01-01 00:00:00 UTC |
|       2 | 1970-01-01 00:00:00 UTC |
|       3 | 1970-01-01 00:00:00 UTC |
|       4 | 1970-01-01 00:00:00 UTC |
+---------+-------------------------+
```
## After fix.

```
+---------+-----------------------------+
| id:long |              time:timestamp |
+---------+-----------------------------+
|       1 | 2016-08-02 14:42:39.542 UTC |
|       2 | 2016-08-02 14:42:39.542 UTC |
|       3 | 2016-08-02 14:42:39.542 UTC |
|       4 | 2016-08-02 14:42:39.542 UTC |
+---------+-----------------------------+
```
