### PR TITLE
Ignore IOException when embulk closes input stream in `reopen`

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/util/ResumableInputStream.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/ResumableInputStream.java
@@ -32,7 +32,10 @@ public class ResumableInputStream
     private void reopen(Exception closedCause) throws IOException
     {
         if (in != null) {
-            in.close();
+            try {
+                in.close();
+            } catch (IOException ignored) {
+            }
             in = null;
         }
         in = reopener.reopen(offset, closedCause);


### PR DESCRIPTION
Because if input stream is already closed, `in.close()` may raise IOException.
In such a situation, Reopener cannot reopen even if input stream is resumable.

ex. SSL connection of embulk-input-gcs is sometimes closed by server side.