### PR TITLE
Fix an example in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ Embulk bundles some built-in plugins such as `embulk-encoder-gzip` or `embulk-fo
 
 ```yaml
 in:
-  type: file
-  path_prefix: "./try1/csv/sample_"
+  ...snip (see the previous configuration file)...
 out:
   type: command
   command: "cat - > task.$INDEX.$SEQID.csv.gz"


### PR DESCRIPTION
Can not be executed with the configuration file of the document.
like below: 

> Field 'parser' is required but not set
> 
> ```
> $ embulk run ./config.yml
> 2016-09-24 11:44:03.959 +0900: Embulk v0.8.13
> 2016-09-24 11:44:06.954 +0900 [INFO] (0001:transaction): Loaded plugin embulk-output-command (0.1.4)
> org.embulk.exec.PartialExecutionException: org.embulk.config.ConfigException: com.fasterxml.jackson.databind.JsonMappingException: Field 'parser' is required but not set
>  at [Source: N/A; line: -1, column: -1]
>     at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(org/embulk/exec/BulkLoader.java:363)
>     at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:572)
>     at org.embulk.exec.BulkLoader.access$000(org/embulk/exec/BulkLoader.java:33)
>     at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:374)
>     at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:370)
>     at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:25)
> ```
