### PR TITLE
Rename methods that Embulk generates to avoid name conflict with JRuby

### DIFF
--- a/lib/embulk/file_input_plugin.rb
+++ b/lib/embulk/file_input_plugin.rb
@@ -13,7 +13,7 @@ module Embulk
     module RubyAdapter
       module ClassMethods
         def new_java
-          Java::FileInputRunner.new(Java.injector.getInstance(java_class))
+          Java::FileInputRunner.new(Java.injector.getInstance(plugin_java_class))
         end
         # TODO transaction, resume, cleanup
       end

--- a/lib/embulk/file_output_plugin.rb
+++ b/lib/embulk/file_output_plugin.rb
@@ -13,7 +13,7 @@ module Embulk
     module RubyAdapter
       module ClassMethods
         def new_java
-          Java::FileOutputRunner.new(Java.injector.getInstance(java_class))
+          Java::FileOutputRunner.new(Java.injector.getInstance(plugin_java_class))
         end
         # TODO transaction, resume, cleanup
       end

--- a/lib/embulk/guess_plugin.rb
+++ b/lib/embulk/guess_plugin.rb
@@ -37,7 +37,7 @@ module Embulk
       def guess(config, sample)
         java_config = config.to_java
         java_sample = sample.to_java
-        java_config_diff = java_object.guess(java_config, java_sample)
+        java_config_diff = plugin_java_object.guess(java_config, java_sample)
         return DataSource.from_java(java_config_diff)
       end
     end

--- a/lib/embulk/java_plugin.rb
+++ b/lib/embulk/java_plugin.rb
@@ -57,20 +57,20 @@ module Embulk
 
     def self.ruby_adapter_class(java_class, ruby_base_class, ruby_module)
       Class.new(ruby_base_class) do
-        const_set(:JAVA_CLASS, java_class)
+        const_set(:PLUGIN_JAVA_CLASS, java_class)
 
         include ruby_module
         extend ruby_module::ClassMethods
 
-        unless method_defined?(:java_object)
-          def java_object
-            @java_object ||= self.class.new_java
+        unless method_defined?(:plugin_java_object)
+          def plugin_java_object
+            @plugin_java_object ||= self.class.new_java
           end
         end
 
-        unless (class<<self;self;end).method_defined?(:java_class)
-          def self.java_class
-            self::JAVA_CLASS
+        unless (class<<self;self;end).method_defined?(:plugin_java_class)
+          def self.plugin_java_class
+            self::PLUGIN_JAVA_CLASS
           end
         end
 
@@ -81,7 +81,7 @@ module Embulk
         #      ruby_module::ClassMethods includes other modules.
         unless ruby_module::ClassMethods.method_defined?(:new_java)
           def self.new_java
-            Java.injector.getInstance(java_class)
+            Java.injector.getInstance(plugin_java_class)
           end
         end
       end


### PR DESCRIPTION
Since the names of methods that Embulk genetes are simple like `java_class`, `java_object`, etc, there might be name conflict with code generation libraries in the future. To avoid the issues, it's better to rename such methods in advance. 