### PR TITLE
Add csv_all_strings guess plugin

### DIFF
--- a/lib/embulk/guess/csv.rb
+++ b/lib/embulk/guess/csv.rb
@@ -142,16 +142,20 @@ module Embulk
         schema = []
         column_names.zip(other_types).each do |name,type|
           if name && type
-            if type.is_a?(SchemaGuess::TimestampTypeMatch)
-              schema << {"name" => name, "type" => type, "format" => type.format}
-            else
-              schema << {"name" => name, "type" => type}
-            end
+            schema << new_column(name, type)
           end
         end
         parser_guessed["columns"] = schema
 
         return {"parser" => parser_guessed}
+      end
+
+      def new_column(name, type)
+        if type.is_a?(SchemaGuess::TimestampTypeMatch)
+          {"name" => name, "type" => type, "format" => type.format}
+        else
+          {"name" => name, "type" => type}
+        end
       end
 
       private

--- a/lib/embulk/guess/csv_all_strings.rb
+++ b/lib/embulk/guess/csv_all_strings.rb
@@ -1,0 +1,13 @@
+module Embulk
+  module Guess
+    require 'embulk/guess/csv'
+
+    class CsvAllStringsGuessPlugin < CsvGuessPlugin
+      Plugin.register_guess("csv_all_strings", self)
+
+      def new_column(name, type)
+        {"name" => name, "type" => "string"}
+      end
+    end
+  end
+end

--- a/test/guess/test_csv_all_strings.rb
+++ b/test/guess/test_csv_all_strings.rb
@@ -1,0 +1,43 @@
+require 'helper'
+require 'time'
+require 'embulk/guess/csv_all_strings'
+
+class CsvAllStringsGuessTest < ::Test::Unit::TestCase
+  class TestAllStrings < self
+    def test_columns_without_header
+      actual = guess([
+        "1\tfoo\t2000-01-01T00:00:00+0900",
+        "2\tbar\t2000-01-01T00:00:00+0900",
+      ])
+      expected = [
+        {"name" => "c0", "type" => "string"},
+        {"name" => "c1", "type" => "string"},
+        {"name" => "c2", "type" => "string"},
+      ]
+      assert_equal expected, actual["parser"]["columns"]
+    end
+
+    def test_columns_with_header
+      actual = guess([
+        "num\tstr\ttime",
+        "1\tfoo\t2000-01-01T00:00:00+0900",
+        "2\tbar\t2000-01-01T00:00:00+0900",
+      ])
+      expected = [
+        {"name" => "num", "type" => "string"},
+        {"name" => "str", "type" => "string"},
+        {"name" => "time", "type" => "string"},
+      ]
+      assert_equal expected, actual["parser"]["columns"]
+    end
+  end
+
+  def guess(texts)
+    conf = Embulk::DataSource.new({
+      parser: {
+        type: "csv"
+      }
+    })
+    Embulk::Guess::CsvAllStringsGuessPlugin.new.guess_lines(conf, Array(texts))
+  end
+end


### PR DESCRIPTION
This guess plugin suggests column types within Csv files as string types. The default Csv guess plugin suggests column types unexpected by users. To execute Embulk correctly, users sometimes need to edit Embulk config manually and fix column types that users expect. But, some users don't want to edit Embulk config so much. 

This plugin is not included in the list of default guess plugins. And to use this plugin, users explicitly need to exclude default csv guess plugin from the list of default guess plugins like:

```
exec:
  exclude_guess_plugins: ['csv']
  guess_plugins: ['csv_all_strings']
in:
  type: file
  path_prefix: path/to/csvfile
```

