### PR TITLE
Introduce SkipTransactionException to stop Embulk before the transaction starts

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/ExecutionResult.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecutionResult.java
@@ -6,17 +6,24 @@ import org.embulk.config.ConfigDiff;
 public class ExecutionResult
 {
     private final ConfigDiff configDiff;
+    private final boolean skipped;
     private final List<Throwable> ignoredExceptions;
 
-    public ExecutionResult(ConfigDiff configDiff, List<Throwable> ignoredExceptions)
+    public ExecutionResult(ConfigDiff configDiff, boolean skipped, List<Throwable> ignoredExceptions)
     {
         this.configDiff = configDiff;
+        this.skipped = skipped;
         this.ignoredExceptions = ignoredExceptions;
     }
 
     public ConfigDiff getConfigDiff()
     {
         return configDiff;
+    }
+
+    public boolean isSkipped()
+    {
+        return skipped;
     }
 
     public List<Throwable> getIgnoredExceptions()

--- a/embulk-core/src/main/java/org/embulk/exec/SkipTransactionException.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SkipTransactionException.java
@@ -1,0 +1,23 @@
+package org.embulk.exec;
+
+import org.embulk.config.ConfigDiff;
+
+// Input/output plugins might need to stop Embulk before the transaction starts by depending
+// on the conditions of input/output data sources/destinations. They can throw this exception
+// if they want to do that. Embulk handles it and then stops the transaction.
+public class SkipTransactionException
+        extends RuntimeException
+{
+    private final ConfigDiff configDiff;
+
+    public SkipTransactionException(ConfigDiff configDiff)
+    {
+        super();
+        this.configDiff = configDiff;
+    }
+
+    public ConfigDiff getConfigDiff()
+    {
+        return configDiff;
+    }
+}


### PR DESCRIPTION
Input/output plugins might need to stop Embulk before the transaction starts by depending
on the conditions of input/output data sources/destinations. They can throw this exception
if they want to do that. Embulk handles it and then stops the transaction.

Currently Embulk hits NPE when input/output plugins return an empty ConfigDiff before the transaction starts to stop Embulk.

```
org.embulk.exec.PartialExecutionException: java.lang.NullPointerException
       at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:363)
       at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:572)
       at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:33)
       at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:374)
       at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:370)
       at org.embulk.spi.Exec.doWith(Exec.java:25)
       at org.embulk.exec.BulkLoader.run(BulkLoader.java:370)
... ...
  Caused by: java.lang.NullPointerException
       at org.embulk.exec.BulkLoader$LoaderState.getAllInputTaskReports(BulkLoader.java:266)
       at org.embulk.exec.BulkLoader$4.run(BulkLoader.java:557)
       at org.embulk.input.jdbc.AbstractJdbcInputPlugin.transaction(AbstractJdbcInputPlugin.java:193)
       at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:513)
       ... 15 more
```
