### PR TITLE
Throw ConfigException instead of AssertionError when task validation failed

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/ModelManager.java
+++ b/embulk-core/src/main/java/org/embulk/config/ModelManager.java
@@ -89,7 +89,12 @@ public class ModelManager
 
     public void validate(Object object)
     {
-        taskValidator.validateModel(object);
+        try {
+            taskValidator.validateModel(object);
+        }
+        catch (AssertionError ex) {
+            throw new ConfigException(ex);
+        }
     }
 
     // visible for DataSource.set


### PR DESCRIPTION
When BVal validation for Task instantiation failed, ModelManager throws AssertionError. It's ok but, I think better to throw ConfigException instead because such validation error is not recoverable. 