### PR TITLE
Revert "changed default sequence_format of output-file to include dot…

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -405,12 +405,12 @@ Options
 +====================+==========+===================================================+============================+
 | path\_prefix       | string   | Path prefix of the output files                   | required                   |
 +--------------------+----------+---------------------------------------------------+----------------------------+
-| sequence\_format   | string   | Format of the sequence number of the output files | ``%03d.%02d.`` by default  |
+| sequence\_format   | string   | Format of the sequence number of the output files | ``.%03d.%02d`` by default  |
 +--------------------+----------+---------------------------------------------------+----------------------------+
-| file\_ext          | string   | Path suffix of the output files (e.g. ``"csv"``)  | required                   |
+| file\_ext          | string   | Path suffix of the output files                   | required                   |
 +--------------------+----------+---------------------------------------------------+----------------------------+
 
-For example, if you set ``path_prefix: /path/to/output/sample_``, ``sequence_format: "%03d.%02d."``, and ``file_ext: csv``, name of the output files will be as following:
+For example, if you set ``path_prefix: /path/to/output``, ``sequence_format: ".%03d.%02d"``, and ``file_ext: .csv``, name of the output files will be as following:
 
 ::
 
@@ -418,10 +418,10 @@ For example, if you set ``path_prefix: /path/to/output/sample_``, ``sequence_for
     `-- path
         `-- to
             `-- output
-                |-- sample_01.000.csv
-                |-- sample_02.000.csv
-                |-- sample_03.000.csv
-                |-- sample_04.000.csv
+                |-- sample.01.000.csv
+                |-- sample.02.000.csv
+                |-- sample.03.000.csv
+                |-- sample.04.000.csv
 
 ``sequence_format`` formats task index and sequence number in a task.
 
@@ -432,8 +432,8 @@ Example
 
     out:
       type: file
-      path_prefix: /path/to/output/sample_
-      file_ext: csv
+      path_prefix: /path/to/output/sample
+      file_ext: .csv
       formatter:
         ...
 

--- a/embulk-standards/src/main/java/org/embulk/standards/LocalFileOutputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/LocalFileOutputPlugin.java
@@ -35,8 +35,8 @@ public class LocalFileOutputPlugin
         String getFileNameExtension();
 
         @Config("sequence_format")
-        @ConfigDefault("\"%03d.%02d.\"")
-        String getSequenceFormat();
+        @ConfigDefault("\".%03d.%02d\"")
+        public String getSequenceFormat();
     }
 
     private final Logger log = Exec.getLogger(getClass());


### PR DESCRIPTION
… at the end so that file_ext doesn't have to include dot"

This reverts commit 0c1f7ee51e4ef215b30999181ed689a763c8a5de.