### PR TITLE
Add document for the new "rules" option in the built-in rename filter plugin.

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -580,12 +580,13 @@ Options
 +---------+----------+----------------------------------------------------------------------+--------------------+
 | name    | type     | description                                                          | required?          |
 +=========+==========+======================================================================+====================+
-| columns | hash     | A map whose keys are existing column names. values are new names.    | ``{}`` by default  |
-+---------+----------+----------------------------------------------------------------------+--------------------+
 | rules   | array    | An array of rule-based renaming operations. (See below for rules.)   | ``[]`` by default  |
 +---------+----------+----------------------------------------------------------------------+--------------------+
+| columns | hash     | A map whose keys are existing column names. values are new names.    | ``{}`` by default  |
++---------+----------+----------------------------------------------------------------------+--------------------+
 
-Renaming by ``columns`` are done before ``rules``.
+Renaming rules
+~~~~~~~~~~~~~~~
 
 The ``rules`` is an array of rules as below applied top-down for all the columns.
 
@@ -607,7 +608,7 @@ The ``rules`` is an array of rules as below applied top-down for all the columns
 | unique\_number\_suffix  | Make column names unique in the schema.                                                |
 +-------------------------+----------------------------------------------------------------------------------------+
 
-Renaming Rule: character\_types
+Renaming rule: character\_types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The rule ``character_types`` replaces restricted characters.
@@ -637,7 +638,7 @@ Example
           pass_types: [ "a-z", "0-9" ]
 
 
-Renaming Rule: first\_character\_types
+Renaming rule: first\_character\_types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The rule ``first_character_types`` prefixes or replaces a restricted character at the beginning.
@@ -669,7 +670,7 @@ Example
           pass_types: [ "a-z" ]
           prefix: "_"
 
-Renaming Rule: lower\_to\_upper
+Renaming rule: lower\_to\_upper
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The rule ``lower_to_upper`` converts lower-case alphabets to upper-case.
@@ -687,7 +688,7 @@ Example
         - rule: lower_to_upper
 
 
-Renaming Rule: regex\_replace
+Renaming rule: regex\_replace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The rule ``regex_replace`` replaces column names based on a regular expression.
@@ -715,7 +716,7 @@ Example
           replace: "USD$1"
 
 
-Renaming Rule: truncate
+Renaming rule: truncate
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 The rule ``truncate`` truncates column names.
@@ -739,7 +740,7 @@ Example
         - rule: truncate
           max_length: 20
 
-Renaming Rule: upper\_to\_lower
+Renaming rule: upper\_to\_lower
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The rule ``upper_to_lower`` converts upper-case alphabets to lower-case.
@@ -756,7 +757,7 @@ Example
         rules:
         - rule: upper_to_lower
 
-Renaming Rule: unique\_number\_suffix
+Renaming rule: unique\_number\_suffix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The rule ``unique_number_suffix`` makes column names unique in the schema by suffixing numbers.
@@ -802,9 +803,25 @@ Example
         rules:
         - rule: unique_number_suffix
 
+Example of renaming rules
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Example
-~~~~~~~~
+.. code-block:: yaml
+
+    filters:
+      ...
+      - type: rename
+        rules:
+        - rule: upper_to_lower        # All upper-case are converted to lower-case.
+        - rule: character_types       # Only lower-case, digits and "_" are allowed. (No upper-case by the rule ahove.)
+          pass_types: [ "a-z", "0-9" ]
+          pass_characters: "_"
+        - rule: unique_number_suffix  # Ensure all column names are unique.
+
+Columns: not recommended
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``columns`` is not recommended to use anymore. Consider using ``rules`` instead.
 
 .. code-block:: yaml
 
@@ -814,12 +831,9 @@ Example
         columns:
           my_existing_column1: new_column1
           my_existing_column2: new_column2
-        rules:
-        - rule: upper_to_lower
-        - rule: character_types
-          pass_types: [ "a-z", "A-Z", "0-9" ]
-          pass_characters: "_"
-        - rule: unique_number_suffix
+
+.. hint::
+   ``columns`` are applied before ``rules`` if ``columns`` and ``rules`` are specified together. (It is discouraged to specify them together, though.)
 
 Local executor plugin
 ----------------------

--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -582,6 +582,226 @@ Options
 +=========+==========+======================================================================+====================+
 | columns | hash     | A map whose keys are existing column names. values are new names.    | ``{}`` by default  |
 +---------+----------+----------------------------------------------------------------------+--------------------+
+| rules   | array    | An array of rule-based renaming operations. (See below for rules.)   | ``[]`` by default  |
++---------+----------+----------------------------------------------------------------------+--------------------+
+
+Renaming by ``columns`` are done before ``rules``.
+
+The ``rules`` is an array of rules as below applied top-down for all the columns.
+
++-------------------------+----------------------------------------------------------------------------------------+
+| rule                    | description                                                                            |
++=========================+========================================================================================+
+| character\_types        | Restrict characters by types. Replace restricted characteres.                          |
++-------------------------+----------------------------------------------------------------------------------------+
+| first\_character\_types | Restrict the first character by types. Prefix or replace first restricted characters.  |
++-------------------------+----------------------------------------------------------------------------------------+
+| lower\_to\_upper        | Convert lower-case alphabets to upper-case.                                            |
++-------------------------+----------------------------------------------------------------------------------------+
+| regex\_replace          | Replace with a regular expressions.                                                    |
++-------------------------+----------------------------------------------------------------------------------------+
+| truncate                | Truncate.                                                                              |
++-------------------------+----------------------------------------------------------------------------------------+
+| upper\_to\_lower        | Convert upper-case alphabets to lower-case                                             |
++-------------------------+----------------------------------------------------------------------------------------+
+| unique\_number\_suffix  | Make column names unique in the schema.                                                |
++-------------------------+----------------------------------------------------------------------------------------+
+
+Renaming Rule: character\_types
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The rule ``character_types`` replaces restricted characters.
+
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
+| option            | description                                                                                                                                | required?          |
++===================+============================================================================================================================================+====================+
+| pass\_characteres | Characters to be allowed.                                                                                                                  | ``""`` by default  |
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
+| pass\_types       | Sets of characters to be allowed. The array must consist of "a-z" (lower-case alphabets), "A-Z" (upper-case alphabets), or "0-9" (digits). | ``[]`` by default  |
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
+| replace           | A character that disallowed characters are replaced with. It must consist of just 1 character.                                             | ``"_"`` by default |
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------+
+
+Example
+""""""""
+
+.. code-block:: yaml
+
+    # This configuration replaces characters into "_" except for "_", lower-case alphabets, and digits.
+    filters:
+      ...
+      - type: rename
+        rules:
+        - rule: character_types
+          pass_characters: "_"
+          pass_types: [ "a-z", "0-9" ]
+
+
+Renaming Rule: first\_character\_types
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The rule ``first_character_types`` prefixes or replaces a restricted character at the beginning.
+
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------+
+| option            | description                                                                                                                                | required?                                    |
++===================+============================================================================================================================================+==============================================+
+| pass\_characteres | Characters to be allowed.                                                                                                                  | ``""`` by default                            |
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------+
+| pass\_types       | Sets of characters to be allowed. The array must consist of "a-z" (lower-case alphabets), "A-Z" (upper-case alphabets), or "0-9" (digits). | ``[]`` by default                            |
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------+
+| prefix            | A character that a disallowed first character is replaced with.                                                                            | one of ``prefix`` or ``replace`` is required |
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------+
+| replace           | A character that a disallowed first character is prefixed with.                                                                            | one of ``prefix`` or ``replace`` is required |
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------+
+
+Example
+""""""""
+
+.. code-block:: yaml
+
+    # This configuration prefixes a column name with "_" unless the name starts from "_" or a lower-case alphabet.
+    filters:
+      ...
+      - type: rename
+        rules:
+        - rule: first_character_types
+          pass_characters: "_"
+          pass_types: [ "a-z" ]
+          prefix: "_"
+
+Renaming Rule: lower\_to\_upper
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The rule ``lower_to_upper`` converts lower-case alphabets to upper-case.
+
+Example
+""""""""
+
+.. code-block:: yaml
+
+    # This configuration converts all lower-case alphabets to upper-case.
+    filters:
+      ...
+      - type: rename
+        rules:
+        - rule: lower_to_upper
+
+
+Renaming Rule: regex\_replace
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The rule ``regex_replace`` replaces column names based on a regular expression.
+
++---------+--------------------------------------------------------------------------------------------------------------------------------------+-----------+
+| option  | description                                                                                                                          | required? |
++=========+======================================================================================================================================+===========+
+| match   | A `Java-style regular expression <https://docs.oracle.com/javase/tutorial/essential/regex/>`_ to which this string is to be matched. | required  |
++---------+--------------------------------------------------------------------------------------------------------------------------------------+-----------+
+| replace | A string to be substibuted for each match in Java-style.                                                                             | required  |
++---------+--------------------------------------------------------------------------------------------------------------------------------------+-----------+
+
+Example
+""""""""
+
+.. code-block:: yaml
+
+    # This configuration replaces all patterns
+    filters:
+      ...
+      - type: rename
+        rules:
+        - rule: regex_replace
+          match: "([0-9]+)_dollars"
+          replace: "USD$1"
+
+
+Renaming Rule: truncate
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The rule ``truncate`` truncates column names.
+
++------------+-----------------------------------------------------+--------------------+
+| option     | description                                         | required?          |
++============+=====================================================+====================+
+| max_length | The length to which the column names are truncated. | ``128`` by default |
++------------+-----------------------------------------------------+--------------------+
+
+Example
+""""""""
+
+.. code-block:: yaml
+
+    # This configuration drops all characters after the 20th character.
+    filters:
+      ...
+      - type: rename
+        rules:
+        - rule: truncate
+          max_length: 20
+
+Renaming Rule: upper\_to\_lower
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The rule ``upper_to_lower`` converts upper-case alphabets to lower-case.
+
+Example
+""""""""
+
+.. code-block:: yaml
+
+    # This configuration converts all upper-case alphabets to lower-case.
+    filters:
+      ...
+      - type: rename
+        rules:
+        - rule: upper_to_lower
+
+Renaming Rule: unique\_number\_suffix
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The rule ``unique_number_suffix`` makes column names unique in the schema by suffixing numbers.
+
++------------+-----------------------------------------------------------------------------------------------------------------------------+--------------------+
+| option     | description                                                                                                                 | required?          |
++============+=============================================================================================================================+====================+
+| delimiter  | A delimiter character inserted before a suffix number. It must be just 1 non-digit character.                               | ``"_"`` by default |
++------------+-----------------------------------------------------------------------------------------------------------------------------+--------------------+
+| digits     | An integer that specifies the number of zero-filled digits of a suffix number. The suffix number zero-filled to the digits. | optional           |
++------------+-----------------------------------------------------------------------------------------------------------------------------+--------------------+
+| max_length | The length to which the column names are truncated. The column name is truncated before the suffix number.                  | optional           |
++------------+-----------------------------------------------------------------------------------------------------------------------------+--------------------+
+| offset     | An integer where the suffix number starts. The first duplicative column name is suffixed by (```offset``` + 1).             | ``1`` by default   |
++------------+-----------------------------------------------------------------------------------------------------------------------------+--------------------+
+
+.. hint::
+   The procedure to make column names unique is not very trivial. There are many feasible ways. This renaming rule works as follows:
+
+   Basic policies:
+
+   * Suffix numbers are counted per original column name.
+   * Column names are fixed from the first column to the last column.
+
+   Actual procedure applied from the first (leftmost) column to the last (rightmost) column:
+
+   1. Fix the column name as-is with truncating if the truncated name is not duplicated with left columns.
+   2. Suffix the column name otherwise.
+
+      a. Try to append the suffix number for the original column name with truncating.
+      b. Fix it if the suffixed name is not duplicated with left columns nor original columns.
+      c. Retry (a) with the suffix number increased otherwise.
+
+Example
+""""""""
+
+.. code-block:: yaml
+
+    # This configuration suffixes numbers to duplicative column names. (Ex. ["column", "column", "column"] goes to ["column", "column_2", "column_3"].)
+    filters:
+      ...
+      - type: rename
+        rules:
+        - rule: unique_number_suffix
+
 
 Example
 ~~~~~~~~
@@ -594,6 +814,12 @@ Example
         columns:
           my_existing_column1: new_column1
           my_existing_column2: new_column2
+        rules:
+        - rule: upper_to_lower
+        - rule: character_types
+          pass_types: [ "a-z", "A-Z", "0-9" ]
+          pass_characters: "_"
+        - rule: unique_number_suffix
 
 Local executor plugin
 ----------------------


### PR DESCRIPTION
@muga The descriptions of all renaming rules are nested, and may be so long. I'd separate them out if it's not good.