### PR TITLE
embulk-test: Add helpers to get config YAML

### DIFF
--- a/embulk-test/src/main/java/org/embulk/test/EmbulkTests.java
+++ b/embulk-test/src/main/java/org/embulk/test/EmbulkTests.java
@@ -35,6 +35,17 @@ public class EmbulkTests
         }
     }
 
+    public static ConfigSource configFromString(String yaml)
+    {
+        assumeThat(isNullOrEmpty(yaml), is(false));
+        return EmbulkEmbed.newSystemConfigLoader().fromYamlString(yaml);
+    }
+
+    public static ConfigSource configFromResource(String name)
+    {
+        return configFromString(readResource(name));
+    }
+
     public static String readResource(String name)
     {
         try (InputStream in = Resources.getResource(name).openStream()) {


### PR DESCRIPTION
Examples of usage

EmbulkTests#configFromResource
```java
ConfigSource config = EmbulkTests.configFromResource("yaml/test01.yml");
```

EmbulkTests#configFromString
```java
final String yaml = new StringBuilder()
        .append("type: file\n")
        .append("path_prefix: /some/path/to/file_\n"))
        .append("parser\n")
        .append("  type: csv\n")
        .append("  columns: \n")
        .append("  - {name: id, type: long}\n")
        .append("  - {name: name, type: string}\n")
        .toString();
ConfigSource config = EmbulkTests.configFromString(yaml);
```