### PR TITLE
embulk-test: Make output configurable and add MemoryOutputPlugin

### DIFF
--- a/embulk-test/src/main/java/org/embulk/test/MemoryOutputPlugin.java
+++ b/embulk-test/src/main/java/org/embulk/test/MemoryOutputPlugin.java
@@ -1,0 +1,133 @@
+package org.embulk.test;
+
+import com.google.common.collect.ImmutableList;
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.Task;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Column;
+import org.embulk.spi.Exec;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.Page;
+import org.embulk.spi.PageReader;
+import org.embulk.spi.Schema;
+import org.embulk.spi.TransactionalPageOutput;
+import org.embulk.spi.util.Pages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MemoryOutputPlugin implements OutputPlugin
+{
+    public interface PluginTask extends Task { }
+
+    @Override
+    public ConfigDiff transaction(ConfigSource config,
+                                  Schema schema, int taskCount,
+                                  OutputPlugin.Control control)
+    {
+        final PluginTask task = config.loadConfig(PluginTask.class);
+        return resume(task.dump(), schema, taskCount, control);
+    }
+
+    @Override
+    public ConfigDiff resume(TaskSource taskSource,
+                             Schema schema, int taskCount,
+                             OutputPlugin.Control control)
+    {
+        control.run(taskSource);
+        return Exec.newConfigDiff();
+    }
+
+    @Override
+    public void cleanup(TaskSource taskSource,
+                        Schema schema, int taskCount,
+                        List<TaskReport> successTaskReports)
+    { }
+
+    @Override
+    public TransactionalPageOutput open(final TaskSource taskSource, final Schema schema, final int taskIndex)
+    {
+        return new TransactionalPageOutput()
+        {
+            private final PageReader reader = new PageReader(schema);
+
+            public void add(Page page)
+            {
+                reader.setPage(page);
+                while (reader.nextRecord())
+                {
+                    Recorder.addRecord(reader);
+                }
+            }
+
+            public void finish() { }
+
+            public void close()
+            {
+                reader.close();
+            }
+
+            public void abort() { }
+
+            public TaskReport commit()
+            {
+                return Exec.newTaskReport();
+            }
+        };
+    }
+
+    public static List<Record> getRecords()
+    {
+        return Recorder.getRecords();
+    }
+
+    private static class Recorder
+    {
+        private static final List<Record> records = new ArrayList<>();
+
+        private Recorder() { }
+
+        private synchronized static void addRecord(PageReader reader)
+        {
+            final ImmutableList.Builder<Object> values = ImmutableList.builder();
+            final ImmutableList.Builder<Column> columns = ImmutableList.builder();
+            reader.getSchema().visitColumns(new Pages.ObjectColumnVisitor(reader) {
+                @Override
+                public void visit(org.embulk.spi.Column column, Object value) {
+                    values.add(value);
+                    columns.add(column);
+                }
+            });
+            records.add(new Record(values.build(), columns.build()));
+        }
+
+        synchronized static List<Record> getRecords()
+        {
+            return records;
+        }
+    }
+
+    public static class Record
+    {
+        private final List<Object> values;
+        private final List<Column> columns;
+
+        Record(List<Object> values, List<Column> columns)
+        {
+            this.values = values;
+            this.columns = columns;
+        }
+
+        public List<Object> getValues()
+        {
+            return values;
+        }
+
+        public List<Column> getColumns()
+        {
+            return columns;
+        }
+    }
+}

--- a/embulk-test/src/main/java/org/embulk/test/TestingEmbulk.java
+++ b/embulk-test/src/main/java/org/embulk/test/TestingEmbulk.java
@@ -175,6 +175,7 @@ public class TestingEmbulk
     {
         private ConfigSource inConfig = null;
         private ConfigSource execConfig = null;
+        private ConfigSource outConfig = null;
         private Path outputPath = null;
 
         public InputBuilder in(ConfigSource inConfig)
@@ -191,6 +192,13 @@ public class TestingEmbulk
             return this;
         }
 
+        public InputBuilder out(ConfigSource execConfig)
+        {
+            checkNotNull(execConfig, "outConfig");
+            this.outConfig = execConfig.deepCopy();
+            return this;
+        }
+
         public InputBuilder outputPath(Path outputPath)
         {
             checkNotNull(outputPath, "outputPath");
@@ -202,29 +210,32 @@ public class TestingEmbulk
                 throws IOException
         {
             checkState(inConfig != null, "in config must be set");
-            checkState(outputPath != null, "outputPath must be set");
             if (execConfig == null) {
                 execConfig = embulk.newConfig();
             }
 
-            String fileName = outputPath.getFileName().toString();
-            checkArgument(fileName.endsWith(".csv"), "outputPath must end with .csv");
-            Path dir = outputPath.getParent().resolve(fileName.substring(0, fileName.length() - 4));
+            Path dir = null;
+            if (outConfig == null) {
+                checkState(outputPath != null, "outputPath must be set");
+                String fileName = outputPath.getFileName().toString();
+                checkArgument(fileName.endsWith(".csv"), "outputPath must end with .csv");
+                dir = outputPath.getParent().resolve(fileName.substring(0, fileName.length() - 4));
 
-            Files.createDirectories(dir);
+                Files.createDirectories(dir);
 
-            // exec: config
-            execConfig.set("min_output_tasks", 1);
+                // exec: config
+                execConfig.set("min_output_tasks", 1);
 
-            // out: config
-            ConfigSource outConfig = embulk.newConfig()
-                    .set("type", "file")
-                    .set("path_prefix", dir.resolve("fragments_").toString())
-                    .set("file_ext", "csv")
-                    .set("formatter", embulk.newConfig()
-                            .set("type", "csv")
-                            .set("header_line", false)
-                            .set("newline", "LF"));
+                // out: config
+                outConfig = embulk.newConfig()
+                        .set("type", "file")
+                        .set("path_prefix", dir.resolve("fragments_").toString())
+                        .set("file_ext", "csv")
+                        .set("formatter", embulk.newConfig()
+                                .set("type", "csv")
+                                .set("header_line", false)
+                                .set("newline", "LF"));
+            }
 
             // combine exec:, out: and in:
             ConfigSource config = embulk.newConfig()
@@ -235,17 +246,19 @@ public class TestingEmbulk
             // embed.run returns TestingBulkLoader.TestingExecutionResult because
             RunResult result = (RunResult) embulk.embed.run(config);
 
-            try (OutputStream out = Files.newOutputStream(outputPath)) {
-                List<Path> fragments = new ArrayList<Path>();
-                try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir, "fragments_*.csv")) {
-                    for (Path fragment : stream) {
-                        fragments.add(fragment);
+            if (outputPath != null && dir != null) {
+                try (OutputStream out = Files.newOutputStream(outputPath)) {
+                    List<Path> fragments = new ArrayList<Path>();
+                    try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir, "fragments_*.csv")) {
+                        for (Path fragment : stream) {
+                            fragments.add(fragment);
+                        }
                     }
-                }
-                Collections.sort(fragments);
-                for (Path fragment : fragments) {
-                    try (InputStream in = Files.newInputStream(fragment)) {
-                        ByteStreams.copy(in, out);
+                    Collections.sort(fragments);
+                    for (Path fragment : fragments) {
+                        try (InputStream in = Files.newInputStream(fragment)) {
+                            ByteStreams.copy(in, out);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR makes assertions for `TestingEmbulk` easy, I think.

`MemoryOutputPlugin` dumps input records to memory (JVM heap) as `Object` lists, so we can easily get them by using the helper `MemoryOutputPlugin#getRecords` such as the following.

Please review the specs, thanks!

```java
public class FileInputPluginTest
{
    @Rule
    public TestingEmbulk embulk = TestingEmbulk
            .builder()
            .registerPlugin(OutputPlugin.class, "memory", MemoryOutputPlugin.class)
            .build();

    @Test
    public void testReadFile() throws Exception
    {
        TestingEmbulk.inputBuilder()
                .in(EmbulkTests.config("FILE_INPUT_CONFIG"))
                .out(EmbulkTests.config("MEMORY_OUTPUT_CONFIG"))
                .run(embulk);
        List<MemoryOutputPlugin.Record> records = MemoryOutputPlugin.getRecords();
        assertThat(records.size(), is(2));
        assertThat(records.get(0).getValues(), is(Arrays.<Object>asList(1L, "kamatama41")));
        assertThat(records.get(1).getValues(), is(Arrays.<Object>asList(2L, "kamatama42")));
    }
}
```

FILE_INPUT_CONFIG
```yaml
type: file
path_prefix: /some/path/to/sample_01.csv
parser:
  type: csv
  columns:
  - {name: id, type: long}
  - {name: username, type: string}
```

MEMORY_OUTPUT_CONFIG
```yaml
type: memory
```

sample_01.csv
```
1,kamatama41
2,kamatama42
```
