### PR TITLE
Avoid NPE is thrown by PageBuilder#set{String,Timestamp,Json}

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
@@ -123,6 +123,11 @@ public class PageBuilder
 
     public void setString(int columnIndex, String value)
     {
+        if (value == null) {
+            setNull(columnIndex);
+            return;
+        }
+
         Integer reuseIndex = stringReferences.get(value);
         if (reuseIndex != null) {
             bufferSlice.setInt(getOffset(columnIndex), reuseIndex);
@@ -143,6 +148,11 @@ public class PageBuilder
 
     public void setJson(int columnIndex, Value value)
     {
+        if (value == null) {
+            setNull(columnIndex);
+            return;
+        }
+
         int index = valueReferences.size();
         valueReferences.add(value.immutableValue());
         bufferSlice.setInt(getOffset(columnIndex), index);
@@ -158,6 +168,11 @@ public class PageBuilder
 
     public void setTimestamp(int columnIndex, Timestamp value)
     {
+        if (value == null) {
+            setNull(columnIndex);
+            return;
+        }
+
         int offset = getOffset(columnIndex);
         bufferSlice.setLong(offset, value.getEpochSecond());
         bufferSlice.setInt(offset + 8, value.getNano());


### PR DESCRIPTION
The problem is that PageBuilder#set{String,Timestamp,Json} throw NPE if null object is given.
Basically plugins should handle null object appropriately. But, I think that the #set{String,Timestamp,Json} should take one of the following:

a. Accept null object and call #setNull. 
b. Throw an appropriate exception instead of NPE.

This PR takes a. 

```
2017-01-23 11:51:23.083 +0000 [WARN] (main): null 
org.embulk.exec.PartialExecutionException: java.lang.NullPointerException 
at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:373) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:591) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:33) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:389) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:385) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.spi.Exec.doWith(Exec.java:25) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.exec.BulkLoader.run(BulkLoader.java:385) ~[embulk-core-0.8.15.jar:na] 
... ...
Caused by: java.lang.NullPointerException: null 
at org.embulk.spi.PageBuilder.setString(PageBuilder.java:133) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.spi.PageBuilder.setString(PageBuilder.java:121) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.input.jdbc.getter.StringColumnGetter.stringColumn(StringColumnGetter.java:81) ~[na:na] 
at org.embulk.spi.Column.visit(Column.java:58) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.input.jdbc.getter.AbstractColumnGetter.getAndSet(AbstractColumnGetter.java:36) ~[na:na] 
at org.embulk.input.jdbc.AbstractJdbcInputPlugin.fetch(AbstractJdbcInputPlugin.java:534) ~[na:na] 
at org.embulk.input.jdbc.AbstractJdbcInputPlugin.run(AbstractJdbcInputPlugin.java:432) ~[na:na] 
at org.embulk.spi.util.Executors.process(Executors.java:67) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.spi.util.Executors.process(Executors.java:42) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184) ~[embulk-core-0.8.15.jar:na] 
at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180) ~[embulk-core-0.8.15.jar:na] 
at java.util.concurrent.FutureTask.run(FutureTask.java:262) ~[na:1.7.0_80] 
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) ~[na:1.7.0_80] 
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) ~[na:1.7.0_80] 
at java.lang.Thread.run(Thread.java:745) ~[na:1.7.0_80]
```