### PR TITLE
Add updateJRuby task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -346,3 +346,35 @@ task setVersion {
         println "add 'release/release-${to}' line to embulk-docs/src/release.rst"
     }
 }
+
+task updateJRuby {
+    doLast {
+        if (!project.hasProperty("to")) {
+            throw new GradleException("Usage: ./gradlew updateJRuby -Pto=VERSION")
+        }
+
+        File gradle_ver = file('build.gradle')
+        gradle_ver.write(gradle_ver.getText().replaceFirst("jrubyVersion = '(\\d+)(\\.\\d+){3}'", "jrubyVersion = '${to}'"))
+
+        File gemspec_ver  = file('embulk.gemspec')
+        gemspec_ver.write(gemspec_ver.getText().replaceFirst("gem.add_dependency \"jruby-jars\", '= (\\d+)(\\.\\d+){3}'", "gem.add_dependency \"jruby-jars\", '= ${to}'"))
+
+        File migrate_plugin_ver  = file('lib/embulk/command/embulk_migrate_plugin.rb')
+        migrate_plugin_ver.write(migrate_plugin_ver.getText().replaceFirst("\".ruby-version\", \"jruby-(\\d+)(\\.\\d+){3}\"", "\".ruby-version\", \"jruby-${to}\""))
+
+        File gemfile_lock_ver  = file('Gemfile.lock')
+        gemfile_lock_ver.write(gemfile_lock_ver.getText().replaceFirst("jruby-jars \\(= (\\d+)(\\.\\d+){3}\\)", "jruby-jars (= ${to})"))
+
+        gemfile_lock_ver.write(gemfile_lock_ver.getText().replaceFirst("jruby-jars \\((\\d+)(\\.\\d+){3}\\)", "jruby-jars (${to})"))
+
+        List<String> dot_ruby_vers = [
+            'lib/embulk/data/bundle/.ruby-version',
+            'lib/embulk/data/new/ruby/.ruby-version'
+        ]
+        dot_ruby_vers.each() { path ->
+            File dot_ruby_ver = file(path)
+            dot_ruby_ver.write(dot_ruby_ver.getText().replaceAll('jruby-(\\d+)(\\.\\d+){3}', "jruby-${to}"))
+        }
+
+    }
+}


### PR DESCRIPTION
JRuby 9.1.7.0 released at 11/Jan/2017. 
http://jruby.org/2017/01/11/jruby-9-1-7-0.html

I made the `updateJRuby` task. 
If the command `./gradlew updateJRuby -Pto=9.1.7.0` execute,
The following change will generate. 

If those feature already implemented, please ignore this PR. 


```diff
a/Gemfile.lock b/Gemfile.lock
index cf7cb56..7099ad1 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     embulk (0.8.13)
-      jruby-jars (= 9.1.5.0)
+      jruby-jars (= 9.1.7.0)

 GEM
   remote: https://rubygems.org/
   specs:
-    jruby-jars (9.1.5.0)
+    jruby-jars (9.1.7.0)
     kramdown (1.5.0)
     power_assert (0.2.2)
     rake (10.4.2)
diff --git a/build.gradle b/build.gradle
index af261105..b56f237 100644
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ allprojects {
     version = '0.8.15'

     ext {
-        jrubyVersion = '9.1.5.0'
+        jrubyVersion = '9.1.7.0'
     }

     apply plugin: 'java'
diff --git a/embulk.gemspec b/embulk.gemspec
index cd18f3e..ebdc55e 100644
--- a/embulk.gemspec
+++ b/embulk.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
     gem.platform = 'java'

   else
-    gem.add_dependency "jruby-jars", '= 9.1.5.0'
+    gem.add_dependency "jruby-jars", '= 9.1.7.0'
   end

   gem.add_development_dependency "rake", [">= 0.10.0"]
diff --git a/lib/embulk/command/embulk_migrate_plugin.rb b/lib/embulk/command/embulk_migrate_plugin.rb
index 1c5e55b..ec75bb7 100644
--- a/lib/embulk/command/embulk_migrate_plugin.rb
+++ b/lib/embulk/command/embulk_migrate_plugin.rb
@@ -122,7 +122,7 @@ EOF
     # add rules...
     ##

-    migrator.write(".ruby-version", "jruby-9.1.5.0")
+    migrator.write(".ruby-version", "jruby-9.1.7.0")

     # update version at the end
     if from_ver <= version("0.1.0")
diff --git a/lib/embulk/data/bundle/.ruby-version b/lib/embulk/data/bundle/.ruby-version
index cd53e88..4f1a588 100644
--- a/lib/embulk/data/bundle/.ruby-version
+++ b/lib/embulk/data/bundle/.ruby-version
@@ -1 +1 @@
-jruby-9.1.5.0
+jruby-9.1.7.0
diff --git a/lib/embulk/data/new/ruby/.ruby-version b/lib/embulk/data/new/ruby/.ruby-version
index cd53e88..4f1a588 100644
--- a/lib/embulk/data/new/ruby/.ruby-version
+++ b/lib/embulk/data/new/ruby/.ruby-version
@@ -1 +1 @@
-jruby-9.1.5.0
+jruby-9.1.7.0
```