### PR TITLE
Update msgpack-ruby 0.7.4 -> 1.0.3

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     compile 'com.ibm.icu:icu4j:54.1.1'
 
     gems 'rubygems:bundler:1.10.6'
-    gems 'rubygems:msgpack:0.7.4'
+    gems 'rubygems:msgpack:1.0.3'
     gems 'rubygems:liquid:3.0.6'
 }
 


### PR DESCRIPTION
Update msgpack-ruby for prepare ruby 2.4.

https://github.com/msgpack/msgpack-ruby/blob/master/ChangeLog

2017-01-24 version 1.0.3:

* Support Ruby 2.4

2016-10-17 version 1.0.2:

* Bump version up to release newer version to fix broken gem release for JRuby

2016-10-17 version 1.0.1:

* Fix a bug to crash at packer when ext type is registered for superclass of packed object
* Fix JRuby implementation about inconsistent API of Unpacker constructor

2016-07-08 version 1.0.0:

* Fix to be able to pack Symbol with ext types
* Fix for MRI 2.4 (Integer unification)

2016-05-10 version 0.7.6:

* Fix bug to raise IndexOutOfBoundsException for Bignum value with small int in JRuby

2016-04-06 version 0.7.5:

* Improved support for i386/armel/armhf environments
* Fix bug for negative ext type id and some architectures (arm*)
