### PR TITLE
JsonParser: Fix how to change Java type for mapping Json numbers

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/json/JsonParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/json/JsonParser.java
@@ -180,7 +180,7 @@ public class JsonParser
                 try {
                     return ValueFactory.newInteger(parser.getLongValue());
                 }
-                catch (JsonParseException ex) {
+                catch (com.fasterxml.jackson.core.JsonParseException ex) {
                     return ValueFactory.newInteger(parser.getBigIntegerValue());
                 }
             case VALUE_STRING:


### PR DESCRIPTION
I got the following exception and the JsonParser could not change Java type for mapping Json numbers from long type to BigInteger type. 
```
Caused by: com.fasterxml.jackson.core.JsonParseException: Numeric value (12246234245276851497) out of range of long (-9223372036854775808 - 9223372036854775807)
 at [Source: org.embulk.spi.util.FileInputInputStream@6533629; line: 3073, column: 264]
        at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1487)
        at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:518)
        at com.fasterxml.jackson.core.base.ParserBase.reportOverflowLong(ParserBase.java:1003)
        at com.fasterxml.jackson.core.base.ParserBase.convertNumberToLong(ParserBase.java:894)
        at com.fasterxml.jackson.core.base.ParserBase.getLongValue(ParserBase.java:674)
        at org.embulk.spi.json.JsonParser$AbstractParseContext.jsonTokenToValue(JsonParser.java:181)
        at org.embulk.spi.json.JsonParser$AbstractParseContext.jsonTokenToValue(JsonParser.java:219)
        at org.embulk.spi.json.JsonParser$AbstractParseContext.jsonTokenToValue(JsonParser.java:219)
        at org.embulk.spi.json.JsonParser$AbstractParseContext.next(JsonParser.java:151)
        ... 10 more
```