### PR TITLE
JsonParser: Enable to parse non numeric numbers as floating number values

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/json/JsonParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/json/JsonParser.java
@@ -29,6 +29,7 @@ public class JsonParser
     {
         this.factory = new JsonFactory();
         factory.enable(Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
+        factory.enable(Feature.ALLOW_NON_NUMERIC_NUMBERS);
     }
 
     public Stream open(InputStream in) throws IOException


### PR DESCRIPTION
It would be better that Embulk's Json parser could read and parse non-standard Json formatted files as much as possible. For example, `{"value": Infinity}` and `{"value": -Infinity}` are not Json standard but, they are often used. 

As first implementation, we could use Jackson's Feature.ALLOW_NON_NUMERIC_NUMBERS. If we will care of other cases more, we will need to improve it at that time. 
https://fasterxml.github.io/jackson-core/javadoc/2.5/com/fasterxml/jackson/core/JsonParser.Feature.html#ALLOW_NON_NUMERIC_NUMBERS