### PR TITLE
Use netty-buffer 4.x instead of 5.x

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile 'org.apache.bval:bval-jsr303:0.5'
     compile 'io.airlift:slice:0.9'
     compile 'joda-time:joda-time:2.9.2'
-    compile 'io.netty:netty-buffer:5.0.0.Alpha1'
+    compile 'io.netty:netty-buffer:4.0.44.Final'
     compile 'org.fusesource.jansi:jansi:1.11'
     compile 'org.msgpack:msgpack-core:0.8.11'
 


### PR DESCRIPTION
Since Netty v5.0.0 development are not so active instead of v4.0.x, I think that it's better to downgrade netty-buffer version for Embulk.
https://github.com/netty/netty/releases