### PR TITLE
embulk/guess_plugin.rb: Fix and remove last line from sample_lines

### DIFF
--- a/lib/embulk/guess_plugin.rb
+++ b/lib/embulk/guess_plugin.rb
@@ -114,7 +114,7 @@ module Embulk
           sample_lines << line
         end
         unless sample.end_with?(parser_task.getNewline.getString)
-          sample_lines.pop if sample_lines.empty? # last line is partial
+          sample_lines.pop unless sample_lines.empty? # last line is partial
         end
       end
 


### PR DESCRIPTION
guess_plugin.rb should not use last line because the last line is not always a line. It should remove it from sample_lines.
