### PR TITLE
Fix typos in 0.7.8 release note

### DIFF
--- a/embulk-docs/src/release/release-0.7.8.rst
+++ b/embulk-docs/src/release/release-0.7.8.rst
@@ -4,7 +4,7 @@ Release 0.7.8
 General Changes
 ------------------
 
-* Added "mkbundle" subcommand. Its help messae shows how to use plugin blundes with examples.
+* Added "mkbundle" subcommand. Its help messae shows how to use plugin bundles with examples.
 * When a transaction throws an exception and cleanup code (close() method) also throws an exception, the exception of transaction was hidden. Now the exception of transaction is the primary error and exception of cleanup code is also included as a suppressed exception.
 * CSV parser plugin doesn't show lines twice with "Unexpected extra character" error.
 

--- a/embulk-docs/src/release/release-0.7.8.rst
+++ b/embulk-docs/src/release/release-0.7.8.rst
@@ -4,7 +4,7 @@ Release 0.7.8
 General Changes
 ------------------
 
-* Added "mkbundle" subcommand. Its help messae shows how to use plugin bundles with examples.
+* Added "mkbundle" subcommand. Its help message shows how to use plugin bundles with examples.
 * When a transaction throws an exception and cleanup code (close() method) also throws an exception, the exception of transaction was hidden. Now the exception of transaction is the primary error and exception of cleanup code is also included as a suppressed exception.
 * CSV parser plugin doesn't show lines twice with "Unexpected extra character" error.
 


### PR DESCRIPTION
I found 2 typos in [0.7.8 release note](http://www.embulk.org/docs/release/release-0.7.8.html) so fixed them.