### PR TITLE
[WIP] Save original GEM environment variables

### DIFF
--- a/lib/embulk/command/embulk_bundle.rb
+++ b/lib/embulk/command/embulk_bundle.rb
@@ -1,4 +1,5 @@
-
+ENV['EMBULK_ORIG_GEM_HOME'] = ENV['GEM_HOME']
+ENV['EMBULK_ORIG_GEM_PATH'] = ENV['GEM_PATH']
 bundle_path = ENV['EMBULK_BUNDLE_PATH'].to_s
 bundle_path = nil if bundle_path.empty?
 


### PR DESCRIPTION
This PR is for satisfy this ISSUE. 
https://github.com/embulk/embulk-input-command/issues/6

### My Idea

* Save original environment variables with prefix `EMBULK_ORG`
* Restore it on a plugin. 

### Question

* How do you think my idea? (Good or Bad)
* What parameter should I save?
* Where this code should I write?

### Example



```
env GEM_HOME=/hoge ./pkg/embulk-0.8.18.jar run /tmp/conf.yml
```

```
in:
  type: command
  command: env
  parser:
    type: none
out:
  type: stdout
```  

```
EMBULK_ORIG_GEM_HOME=/hoge
GEM_HOME=/path/to/home/.embulk/jruby/2.3.0
GEM_PATH=
```

