### PR TITLE
Deprecate lib/embulk/version.rb `Embulk::VERSION`, and add `org.embulk.EmbulkVersion` with auto-generated embulk.properties.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,9 +249,22 @@ task rubyTest(type: JRubyExec) {
 rubyTest.dependsOn('classpath')
 
 //
-// gem task
+// gem tasks
 //
-task gemJRuby(type: JRubyExec, dependsOn: ["classpath"]) {
+
+// TODO(v2)[#566]: Remove this task at the same time with stopping embulk.gem.
+// https://github.com/embulk/embulk/issues/566
+task versionRubyForGemspec() {
+    file("build/tmp").mkdirs()
+    file("build/tmp/embulk").mkdirs()
+    file("build/tmp/embulk/version_for_gemspec.rb").withWriter { out ->
+        out.println("module Embulk")
+        out.println("  VERSION_FOR_GEMSPEC = '${project.version}'")
+        out.println("end")
+    }
+}
+
+task gemJRuby(type: JRubyExec, dependsOn: ["versionRubyForGemspec", "classpath"]) {
     jrubyArgs '-rrubygems/gem_runner', '-eGem::GemRunner.new.run(ARGV)'
     script './lib/embulk/version.rb'  // dummy
     scriptArgs 'build', 'embulk.gemspec'
@@ -329,8 +342,10 @@ task setVersion {
         File gradle_ver = file('build.gradle')
         gradle_ver.write(gradle_ver.getText().replaceFirst("version = '(\\d+)(\\.\\d+){2}'", "version = '${to}'"))
 
+        // TODO(v2)[#562]: Remove this part to update the version number in lib/embulk/version.rb.
+        // https://github.com/embulk/embulk/issues/562
         File ruby_ver = file('lib/embulk/version.rb')
-        ruby_ver.write(ruby_ver.getText().replaceFirst("VERSION = '(\\d+)(\\.\\d+){2}'", "VERSION = '${to}'"))
+        ruby_ver.write(ruby_ver.getText().replaceFirst("VERSION_INTERNAL = '(\\d+)(\\.\\d+){2}'", "VERSION_INTERNAL = '${to}'"))
 
         List<String> docs = [
             'README.md',

--- a/build.gradle
+++ b/build.gradle
@@ -249,22 +249,9 @@ task rubyTest(type: JRubyExec) {
 rubyTest.dependsOn('classpath')
 
 //
-// gem tasks
+// gem task
 //
-
-// TODO(v2)[#566]: Remove this task at the same time with stopping embulk.gem.
-// https://github.com/embulk/embulk/issues/566
-task versionRubyForGemspec() {
-    file("build/tmp").mkdirs()
-    file("build/tmp/embulk").mkdirs()
-    file("build/tmp/embulk/version_for_gemspec.rb").withWriter { out ->
-        out.println("module Embulk")
-        out.println("  VERSION_FOR_GEMSPEC = '${project.version}'")
-        out.println("end")
-    }
-}
-
-task gemJRuby(type: JRubyExec, dependsOn: ["versionRubyForGemspec", "classpath"]) {
+task gemJRuby(type: JRubyExec, dependsOn: ["classpath"]) {
     jrubyArgs '-rrubygems/gem_runner', '-eGem::GemRunner.new.run(ARGV)'
     script './lib/embulk/version.rb'  // dummy
     scriptArgs 'build', 'embulk.gemspec'

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -4,6 +4,20 @@ apply plugin: "com.github.jruby-gradle.jar"
 // because IntelliJ causes error if srcDirs includes files out of projectDir.
 processResources.from("${rootProject.projectDir}/lib/", "${buildDir}/gemlib")
 
+task versionProperty(dependsOn: processResources) {
+    doLast {
+        new File("$buildDir/resources/main/version.properties").withWriter { w ->
+            Properties p = new Properties()
+            p['version'] = project.version.toString()
+            p.store w, null
+        }
+    }
+}
+
+classes {
+    dependsOn versionProperty
+}
+
 configurations {
     // com.google.inject:guice depends on asm and cglib but version of the libraries conflict
     // with ones bundled in jruby-complete and cause bytecode compatibility error

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -4,9 +4,9 @@ apply plugin: "com.github.jruby-gradle.jar"
 // because IntelliJ causes error if srcDirs includes files out of projectDir.
 processResources.from("${rootProject.projectDir}/lib/", "${buildDir}/gemlib")
 
-task versionProperty(dependsOn: processResources) {
+task embulkJavaProperty(dependsOn: processResources) {
     doLast {
-        new File("$buildDir/resources/main/version.properties").withWriter { w ->
+        new File("$buildDir/resources/main/embulk.properties").withWriter { w ->
             Properties p = new Properties()
             p['version'] = project.version.toString()
             p.store w, null
@@ -15,7 +15,7 @@ task versionProperty(dependsOn: processResources) {
 }
 
 classes {
-    dependsOn versionProperty
+    dependsOn embulkJavaProperty
 }
 
 configurations {

--- a/embulk-core/src/main/java/org/embulk/EmbulkVersion.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkVersion.java
@@ -1,0 +1,27 @@
+package org.embulk;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+public final class EmbulkVersion
+{
+    private EmbulkVersion()
+    {
+    }
+
+    static {
+        final Properties properties = new Properties();
+        String versionLoaded = null;
+        try (InputStream input = EmbulkVersion.class.getClassLoader().getResourceAsStream("version.properties")) {
+            properties.load(input);
+            versionLoaded = properties.getProperty("version");
+        }
+        catch (IOException ex) {
+            versionLoaded = "(version-properties-not-found)";
+        }
+        VERSION = versionLoaded;
+    }
+
+    public static final String VERSION;
+}

--- a/embulk-core/src/main/java/org/embulk/EmbulkVersion.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkVersion.java
@@ -13,12 +13,12 @@ public final class EmbulkVersion
     static {
         final Properties properties = new Properties();
         String versionLoaded = null;
-        try (InputStream input = EmbulkVersion.class.getClassLoader().getResourceAsStream("version.properties")) {
+        try (InputStream input = EmbulkVersion.class.getClassLoader().getResourceAsStream("embulk.properties")) {
             properties.load(input);
             versionLoaded = properties.getProperty("version");
         }
         catch (IOException ex) {
-            versionLoaded = "(version-properties-not-found)";
+            versionLoaded = "(embulk-java-properties-not-found)";
         }
         VERSION = versionLoaded;
     }

--- a/embulk.gemspec
+++ b/embulk.gemspec
@@ -1,9 +1,10 @@
-$LOAD_PATH.push File.expand_path("../build/tmp", __FILE__)
-require 'embulk/version_for_gemspec'
+# TODO(v2)[#566]: Remove this embulk.gemspec.
+$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+require 'embulk/version'
 
 Gem::Specification.new do |gem|
   gem.name          = "embulk"
-  gem.version       = Embulk::VERSION_FOR_GEMSPEC
+  gem.version       = Embulk::VERSION_INTERNAL
 
   gem.summary       = "Embulk, a plugin-based parallel bulk data loader"
   gem.description   = "Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control."

--- a/embulk.gemspec
+++ b/embulk.gemspec
@@ -1,9 +1,9 @@
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
-require 'embulk/version'
+$LOAD_PATH.push File.expand_path("../build/tmp", __FILE__)
+require 'embulk/version_for_gemspec'
 
 Gem::Specification.new do |gem|
   gem.name          = "embulk"
-  gem.version       = Embulk::VERSION
+  gem.version       = Embulk::VERSION_FOR_GEMSPEC
 
   gem.summary       = "Embulk, a plugin-based parallel bulk data loader"
   gem.description   = "Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control."

--- a/lib/embulk/command/embulk_migrate_plugin.rb
+++ b/lib/embulk/command/embulk_migrate_plugin.rb
@@ -114,7 +114,7 @@ EOF
     ##
 
     # update version at the end
-    migrator.replace("**/build.gradle", /org\.embulk:embulk-(?:core|standards):([\d\.\+]+)?/, Embulk::VERSION)
+    migrator.replace("**/build.gradle", /org\.embulk:embulk-(?:core|standards):([\d\.\+]+)?/, org.embulk.EmbulkVersion::VERSION)
   end
 
   def self.migrate_ruby_plugin(migrator, from_ver)
@@ -128,11 +128,11 @@ EOF
     if from_ver <= version("0.1.0")
       # add add_development_dependency
       migrator.insert_line("**/*.gemspec", /([ \t]*\w+)\.add_development_dependency/) {|m|
-        "#{m[1]}.add_development_dependency 'embulk', ['>= #{Embulk::VERSION}']"
+        "#{m[1]}.add_development_dependency 'embulk', ['>= #{org.embulk.EmbulkVersion::VERSION}']"
       }
     else
-      unless migrator.replace("**/*.gemspec", /add_(?:development_)?dependency\s+\W+embulk\W+\s*(\~\>\s*[\d\.]+)\W+/, ">= #{Embulk::VERSION}")
-        migrator.replace("**/*.gemspec", /add_(?:development_)?dependency\s+\W+embulk\W+\s*([\d\.]+)\W+/, Embulk::VERSION)
+      unless migrator.replace("**/*.gemspec", /add_(?:development_)?dependency\s+\W+embulk\W+\s*(\~\>\s*[\d\.]+)\W+/, ">= #{org.embulk.EmbulkVersion::VERSION}")
+        migrator.replace("**/*.gemspec", /add_(?:development_)?dependency\s+\W+embulk\W+\s*([\d\.]+)\W+/, org.embulk.EmbulkVersion::VERSION)
       end
     end
   end

--- a/lib/embulk/command/embulk_run.rb
+++ b/lib/embulk/command/embulk_run.rb
@@ -11,7 +11,7 @@ module Embulk
     i = argv.find_index {|arg| arg !~ /^\-/ }
     unless i
       if argv.include?('--version')
-        puts "embulk #{Embulk::VERSION}"
+        puts "embulk #{org.embulk.EmbulkVersion::VERSION}"
         system_exit_success
       end
       usage nil
@@ -21,9 +21,9 @@ module Embulk
     require 'java'
     require 'optparse'
     op = OptionParser.new
-    op.version = Embulk::VERSION
+    op.version = org.embulk.EmbulkVersion::VERSION
 
-    puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%3N %z")}: Embulk v#{Embulk::VERSION}"
+    puts "#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%3N %z")}: Embulk v#{org.embulk.EmbulkVersion::VERSION}"
 
     plugin_paths = []
     load_paths = []
@@ -399,7 +399,7 @@ examples:
   end
 
   def self.usage(message)
-    STDERR.puts "Embulk v#{Embulk::VERSION}"
+    STDERR.puts "Embulk v#{org.embulk.EmbulkVersion::VERSION}"
     STDERR.puts "Usage: embulk [-vm-options] <command> [--options]"
     STDERR.puts "Commands:"
     STDERR.puts "   mkbundle   <directory>                             # create a new plugin bundle environment."

--- a/lib/embulk/command/embulk_selfupdate.rb
+++ b/lib/embulk/command/embulk_selfupdate.rb
@@ -29,7 +29,7 @@ module Embulk
       puts "Checking the latest version..."
       target_version = check_latest_version
 
-      current_version = Gem::Version.new(Embulk::VERSION)
+      current_version = Gem::Version.new(org.embulk.EmbulkVersion::VERSION)
       if Gem::Version.new(target_version) <= current_version
         puts "Already up-to-date. #{current_version} is the latest version."
         return
@@ -64,6 +64,7 @@ module Embulk
           data = File.read("jar:#{java.io.File.new(tmp.path).toURI.toURL}!/embulk/version.rb")
           m = Module.new
           m.module_eval(data)
+          # These Embulk::VERSION is kept for forward compatibility. They are reading downloaded jars.
           unless m::Embulk::VERSION == target_version
             raise "Embulk::VERSION does not match with #{target_version}"
           end

--- a/lib/embulk/data/new/java/build.gradle.erb
+++ b/lib/embulk/data/new/java/build.gradle.erb
@@ -19,8 +19,8 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile  "org.embulk:embulk-core:<%= Embulk::VERSION %>"
-    provided "org.embulk:embulk-core:<%= Embulk::VERSION %>"
+    compile  "org.embulk:embulk-core:<%= org.embulk.EmbulkVersion::VERSION %>"
+    provided "org.embulk:embulk-core:<%= org.embulk.EmbulkVersion::VERSION %>"
     // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
     testCompile "junit:junit:4.+"
 }

--- a/lib/embulk/data/new/ruby/gemspec.erb
+++ b/lib/embulk/data/new/ruby/gemspec.erb
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   #spec.add_dependency 'YOUR_GEM_DEPENDENCY', ['~> YOUR_GEM_DEPENDENCY_VERSION']
-  spec.add_development_dependency 'embulk', ['>= <%= Embulk::VERSION %>']
+  spec.add_development_dependency 'embulk', ['>= <%= org.embulk.EmbulkVersion::VERSION %>']
   spec.add_development_dependency 'bundler', ['>= 1.10.6']
   spec.add_development_dependency 'rake', ['>= 10.0']
 end

--- a/lib/embulk/version.rb
+++ b/lib/embulk/version.rb
@@ -11,10 +11,10 @@ module Embulk
       unless @@warned
         if Embulk.method_defined?(:logger)
           Embulk.logger.warn(DEPRECATED_MESSAGE)
+          @@warned = true
         else
           STDERR.puts(DEPRECATED_MESSAGE)
         end
-        @@warned = true
       end
       return VERSION_INTERNAL
     else

--- a/lib/embulk/version.rb
+++ b/lib/embulk/version.rb
@@ -1,15 +1,20 @@
 # TODO(v2)[#562]: Remove this file.
 # https://github.com/embulk/embulk/issues/562
 module Embulk
+  @@warned = false
+
   VERSION_INTERNAL = '0.8.18'
 
   DEPRECATED_MESSAGE = 'Embulk::VERSION in (J)Ruby is deprecated. Use org.embulk.EmbulkVersion::VERSION instead. If this message is from a plugin, please tell this to the author of the plugin!'
   def self.const_missing(name)
     if name == :VERSION
-      if Embulk.method_defined?(:logger)
-        Embulk.logger.warn(DEPRECATED_MESSAGE)
-      else
-        STDERR.puts(DEPRECATED_MESSAGE)
+      unless @@warned
+        if Embulk.method_defined?(:logger)
+          Embulk.logger.warn(DEPRECATED_MESSAGE)
+        else
+          STDERR.puts(DEPRECATED_MESSAGE)
+        end
+        @@warned = true
       end
       return VERSION_INTERNAL
     else

--- a/lib/embulk/version.rb
+++ b/lib/embulk/version.rb
@@ -1,3 +1,19 @@
+# TODO(v2)[#562]: Remove this file.
+# https://github.com/embulk/embulk/issues/562
 module Embulk
-  VERSION = '0.8.18'
+  VERSION_INTERNAL = '0.8.18'
+
+  DEPRECATED_MESSAGE = 'Embulk::VERSION in (J)Ruby is deprecated. Use org.embulk.EmbulkVersion::VERSION instead. If this message is from a plugin, please tell this to the author of the plugin!'
+  def self.const_missing(name)
+    if name == :VERSION
+      if Embulk.method_defined?(:logger)
+        Embulk.logger.warn(DEPRECATED_MESSAGE)
+      else
+        STDERR.puts(DEPRECATED_MESSAGE)
+      end
+      return VERSION_INTERNAL
+    else
+      super
+    end
+  end
 end


### PR DESCRIPTION
@muga Controlling the version number in one place from Gradle, and in Java world. What do you think?