### PR TITLE
CsvParserPlugin: Refresh the number of skipped header lines for each file

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -236,12 +236,12 @@ public class CsvParserPlugin
         final boolean allowOptionalColumns = task.getAllowOptionalColumns();
         final boolean allowExtraColumns = task.getAllowExtraColumns();
         final boolean stopOnInvalidRecord = task.getStopOnInvalidRecord();
-        int skipHeaderLines = task.getSkipHeaderLines();
+        final int skipHeaderLines = task.getSkipHeaderLines();
 
         try (final PageBuilder pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)) {
             while (tokenizer.nextFile()) {
                 // skip the header lines for each file
-                for (; skipHeaderLines > 0; skipHeaderLines--) {
+                for (int skipHeaderLineNumber = skipHeaderLines; skipHeaderLineNumber > 0; skipHeaderLineNumber--) {
                     if (!tokenizer.skipHeaderLine()) {
                         break;
                     }


### PR DESCRIPTION
CsvParserPlugin needs to refresh the number of skipped header lines for each file. The current CsvParserPlugin can skip header lines in first file but, it doesn't skip header lines in other files. It means that it reads and parses header lines as records. 