### PR TITLE
PreviewExecutor: Fix and avoid to call SamplingPageOutput#finish twice

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
@@ -26,6 +26,7 @@ import org.embulk.spi.Exec;
 import org.embulk.spi.ExecSession;
 import org.embulk.spi.ExecAction;
 import org.embulk.spi.util.Filters;
+import org.slf4j.Logger;
 
 public class PreviewExecutor
 {
@@ -144,6 +145,7 @@ public class PreviewExecutor
     private static class SamplingPageOutput
             implements PageOutput
     {
+        private final Logger log = Exec.getLogger(this.getClass());
         private final int sampleRows;
         private final Schema schema;
         private List<Page> pages;
@@ -177,8 +179,7 @@ public class PreviewExecutor
         public void finish()
         {
             if (res != null) {
-                // if PreviewResult object already exists, we should reuse it and throw PreviewedNoticeError.
-                throw new PreviewedNoticeError(res);
+                log.error("PreviewResult recreation will cause a bug. The plugin must call PageOutput#finish() only once.");
             }
 
             if (recordCount == 0) {

--- a/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
@@ -148,12 +148,14 @@ public class PreviewExecutor
         private final Schema schema;
         private List<Page> pages;
         private int recordCount;
+        private PreviewResult res;
 
         public SamplingPageOutput(int sampleRows, Schema schema)
         {
             this.sampleRows = sampleRows;
             this.schema = schema;
             this.pages = new ArrayList<Page>();
+            this.res = null;
         }
 
         public int getRecordCount()
@@ -174,10 +176,15 @@ public class PreviewExecutor
         @Override
         public void finish()
         {
+            if (res != null) {
+                // if PreviewResult object already exists, we should reuse it and throw PreviewedNoticeError.
+                throw new PreviewedNoticeError(res);
+            }
+
             if (recordCount == 0) {
                 throw new NoSampleException("No input records to preview");
             }
-            PreviewResult res = new PreviewResult(schema, pages);
+            res = new PreviewResult(schema, pages);
             pages = null;
             throw new PreviewedNoticeError(res);
         }


### PR DESCRIPTION
This PR fixes https://github.com/embulk/embulk/issues/570. 

The cause of https://github.com/embulk/embulk/issues/570 is that SamplingPageOutput#finish method is called twice (unexpectedly). Null object is inserted into `pages` object by 1st call. 2nd call uses the null object. Then, we get NPE. 

I think that a plugin implementation causes this issue but, Embulk itself should have the way to avoid this situation. In this case, PreviewResult object should be reused. 