### PR TITLE
Update snakeyaml to v1.18

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.12'
     compile 'org.jruby:jruby-complete:' + project.jrubyVersion
     compile 'com.google.code.findbugs:annotations:3.0.0'
-    compile 'org.yaml:snakeyaml:1.14'
+    compile 'org.yaml:snakeyaml:1.18'
     compile 'javax.validation:validation-api:1.1.0.Final'
     compile 'org.apache.bval:bval-jsr303:0.5'
     compile 'io.airlift:slice:0.9'


### PR DESCRIPTION
Due to Fix #574, Update SnakeYAML v1.14 to v1.18

Note.
I also tested SnakeYAML version v1.17.
This version does not solve this issue.

From SnkeYAML Changelog.
https://bitbucket.org/asomov/snakeyaml/wiki/Changes

1.18 (2017-02-22)
Fix issue [#323](https://bitbucket.org/asomov/snakeyaml/issues/323/is-there-any-reason-to-not-support): Support "Miscellaneous Symbols and Pictographs"(thanks to Pawel Skierczynski [Atlassian]). This fix introduces minor backwards-incompatible changes - some of the methods have been renamed.This fixes also long standing issue with [iOS emoji](https://code.google.com/archive/p/snakeyaml/issues/205)

