### PR TITLE
Fix #580: avoid using ':' in temporary file names to be valid in Windows.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
@@ -27,7 +27,8 @@ public class TempFileSpace
 
     public File createTempFile(String fileExt)
     {
-        return createTempFile(Thread.currentThread().getName()+"_", fileExt);
+        // Thread names contain ':' which is not valid as file names in Windows.
+        return createTempFile(Thread.currentThread().getName().replaceAll(":", "_") + "_", fileExt);
     }
 
     public File createTempFile(String prefix, String fileExt)


### PR DESCRIPTION
Fix #580.  Just fix `createTempFiele` #423 not yet fiexed.

## Test configuration

```yaml
in:
  type: file
  path_prefix: C:/path/to/embulk/hoge/csv/sample_
  decoders:
  - {type: gzip}
  parser:
    charset: UTF-8
    newline: LF
    type: csv
    delimiter: ','
    quote: '"'
    escape: '"'
    null_string: 'NULL'
    trim_if_not_quoted: false
    skip_header_lines: 1
    allow_extra_columns: false
    allow_optional_columns: false
    columns:
    - {name: id, type: long}
    - {name: account, type: long}
    - {name: time, type: timestamp, format: '%Y-%m-%d %H:%M:%S'}
    - {name: purchase, type: timestamp, format: '%Y%m%d'}
    - {name: comment, type: string}
#out: {type: stdout}
out:
  type: sftp
  host: xxx.xxx.xxx.xxx
  user: user
  secret_key_file: ./test.key
  path_prefix: /tmp/hoge
  file_ext: .csv
  formatter:
    type: csv
```

## NG Case (current implementation)

* OS: Windows 10
* Embulk: v0.8.18

```
embulk run config.yml
2017-04-03 14:17:13.194 +0900: Embulk v0.8.18
2017-04-03 14:17:15.983 +0900 [INFO] (0001:transaction): Loaded plugin embulk-output-sftp (0.0.9)
2017-04-03 14:17:16.036 +0900 [INFO] (0001:transaction): Listing local files at directory 'C:\path\to\test\hoge\csv' filtering filename by prefix 'sample_'
2017-04-03 14:17:16.036 +0900 [INFO] (0001:transaction): Loading files [C:\path\to\test\hoge\csv\sample_01.csv.gz]
2017-04-03 14:17:16.083 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2017-04-03 14:17:16.168 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2017-04-03 14:17:16.268 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
org.embulk.exec.PartialExecutionException: java.nio.file.InvalidPathException: Illegal char <:> at index 73: C:\Users\user\AppData\Local\Temp\embulk\2017-04-03 05-17-15.712 UTC\0018:task-0000_3643826611262033713.tmp
        at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(org/embulk/exec/BulkLoader.java:373)
        at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:591)
        at org.embulk.exec.BulkLoader.access$000(org/embulk/exec/BulkLoader.java:33)
        at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:389)
        at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:385)
        at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:25)
        at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:385)
        at org.embulk.EmbulkEmbed.run(org/embulk/EmbulkEmbed.java:180)
        at java.lang.reflect.Method.invoke(java/lang/reflect/Method)
        at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:453)
        at org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:314)
        at RUBY.run(C:/path/to/embulk/embulk.bat!/embulk/runner.rb:84)
        at RUBY.run(C:/path/to/embulk/embulk.bat!/embulk/command/embulk_run.rb:307)
        at RUBY.<main>(C:/path/to/embulk/embulk.bat!/embulk/command/embulk_main.rb:2)
        at org.jruby.Ruby.runInterpreter(org/jruby/Ruby.java:850)
        at org.jruby.Ruby.loadFile(org/jruby/Ruby.java:2976)
        at org.jruby.RubyKernel.requireCommon(org/jruby/RubyKernel.java:963)
        at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:956)
        at org.jruby.RubyKernel$INVOKER$s$1$0$require19.call(org/jruby/RubyKernel$INVOKER$s$1$0$require19.gen)
        at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1)
        at C_3a_.Users.user.Desktop.works.embulk_dot_bat.embulk.command.embulk_bundle.invokeOther66:require(C_3a_/path/to/embulk/embulk_dot_bat/embulk/command/file:/C:/path/to/embulk/embulk.bat!/embulk/command/embulk_bundle.rb:51)
        at C_3a_.Users.user.Desktop.works.embulk_dot_bat.embulk.command.embulk_bundle.<main>(file:/C:/path/to/embulk/embulk.bat!/embulk/command/embulk_bundle.rb:51)
        at java.lang.invoke.MethodHandle.invokeWithArguments(java/lang/invoke/MethodHandle)
        at org.jruby.Ruby.runScript(org/jruby/Ruby.java:834)
        at org.jruby.Ruby.runNormally(org/jruby/Ruby.java:749)
        at org.jruby.Ruby.runNormally(org/jruby/Ruby.java:767)
        at org.jruby.Ruby.runFromMain(org/jruby/Ruby.java:580)
        at org.jruby.Main.doRunFromMain(org/jruby/Main.java:425)
        at org.jruby.Main.internalRun(org/jruby/Main.java:313)
        at org.jruby.Main.run(org/jruby/Main.java:242)
        at org.jruby.Main.main(org/jruby/Main.java:204)
        at org.embulk.cli.Main.main(org/embulk/cli/Main.java:23)
Caused by: java.nio.file.InvalidPathException: Illegal char <:> at index 73: C:\Users\user\AppData\Local\Temp\embulk\2017-04-03 05-17-15.712 UTC\0018:task-0000_3643826611262033713.tmp
        at sun.nio.fs.WindowsPathParser.normalize(Unknown Source)
        at sun.nio.fs.WindowsPathParser.parse(Unknown Source)
        at sun.nio.fs.WindowsPathParser.parse(Unknown Source)
        at sun.nio.fs.WindowsPath.parse(Unknown Source)
        at sun.nio.fs.WindowsFileSystem.getPath(Unknown Source)
        at java.io.File.toPath(Unknown Source)
        at org.embulk.spi.unit.LocalFile.getPath(LocalFile.java:76)
        at org.embulk.spi.unit.LocalFile.getPath(LocalFile.java:70)
        at org.embulk.output.sftp.SftpFileOutput$4.apply(SftpFileOutput.java:339)
        at org.embulk.output.sftp.SftpFileOutput$4.apply(SftpFileOutput.java:336)
        at com.google.common.base.Present.transform(Present.java:71)
        at org.embulk.output.sftp.SftpFileOutput.initializeFsOptions(SftpFileOutput.java:89)
        at org.embulk.output.sftp.SftpFileOutput.<init>(SftpFileOutput.java:131)
        at org.embulk.output.sftp.SftpFileOutputPlugin.open(SftpFileOutputPlugin.java:110)
        at org.embulk.spi.FileOutputRunner.open(FileOutputRunner.java:133)
        at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput.openOutputs(LocalExecutorPlugin.java:449)
        at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.runInputTask(LocalExecutorPlugin.java:281)
        at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.access$000(LocalExecutorPlugin.java:212)
        at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:257)
        at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:253)
        at java.util.concurrent.FutureTask.run(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.lang.Thread.run(Unknown Source)

Error: java.nio.file.InvalidPathException: Illegal char <:> at index 73: C:\Users\user\AppData\Local\Temp\embulk\2017-04-03 05-17-15.712 UTC\0018:task-0000_3643826611262033713.tmp
```

## Applied patch version

```
2017-04-03 14:20:55.126 +0900: Embulk v0.8.18
2017-04-03 14:20:57.813 +0900 [INFO] (0001:transaction): Loaded plugin embulk-output-sftp (0.0.9)
2017-04-03 14:20:57.866 +0900 [INFO] (0001:transaction): Listing local files at directory 'C:\path\to\test\hoge\csv' filtering filename by prefix 'sample_'
2017-04-03 14:20:57.871 +0900 [INFO] (0001:transaction): Loading files [C:\path\to\test\hoge\csv\sample_01.csv.gz]
2017-04-03 14:20:57.940 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2017-04-03 14:20:58.002 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2017-04-03 14:20:58.087 +0900 [INFO] (0018:task-0000): set identity: org.embulk.spi.unit.LocalFile@2fd94467
2017-04-03 14:20:58.634 +0900 [INFO] (0018:task-0000): parent directory sftp://user@xxx.xxx.xxx.xxx/tmp exists there
2017-04-03 14:20:58.650 +0900 [INFO] (0018:task-0000): new sftp file: sftp://user@xxx.xxx.xxx.xxx/tmp/hoge000.00..csv
2017-04-03 14:20:58.682 +0900 [INFO] (0018:task-0000): set identity: org.embulk.spi.unit.LocalFile@6e8fedcd
2017-04-03 14:20:58.935 +0900 [INFO] (0018:task-0000): parent directory sftp://user@xxx.xxx.xxx.xxx/tmp exists there
2017-04-03 14:20:58.935 +0900 [INFO] (0018:task-0000): new sftp file: sftp://user@xxx.xxx.xxx.xxx/tmp/hoge001.00..csv
2017-04-03 14:20:58.966 +0900 [INFO] (0018:task-0000): set identity: org.embulk.spi.unit.LocalFile@630cfd17
2017-04-03 14:20:59.185 +0900 [INFO] (0018:task-0000): parent directory sftp://user@xxx.xxx.xxx.xxx/tmp exists there
2017-04-03 14:20:59.188 +0900 [INFO] (0018:task-0000): new sftp file: sftp://user@xxx.xxx.xxx.xxx/tmp/hoge002.00..csv
2017-04-03 14:20:59.204 +0900 [INFO] (0018:task-0000): set identity: org.embulk.spi.unit.LocalFile@6d6b4f23
2017-04-03 14:20:59.451 +0900 [INFO] (0018:task-0000): parent directory sftp://user@xxx.xxx.xxx.xxx/tmp exists there
2017-04-03 14:20:59.467 +0900 [INFO] (0018:task-0000): new sftp file: sftp://user@xxx.xxx.xxx.xxx/tmp/hoge003.00..csv
2017-04-03 14:20:59.489 +0900 [INFO] (0018:task-0000): set identity: org.embulk.spi.unit.LocalFile@4f5fce8f
2017-04-03 14:20:59.720 +0900 [INFO] (0018:task-0000): parent directory sftp://user@xxx.xxx.xxx.xxx/tmp exists there
2017-04-03 14:20:59.735 +0900 [INFO] (0018:task-0000): new sftp file: sftp://user@xxx.xxx.xxx.xxx/tmp/hoge004.00..csv
2017-04-03 14:20:59.767 +0900 [INFO] (0018:task-0000): set identity: org.embulk.spi.unit.LocalFile@4f67dbe8
2017-04-03 14:20:59.967 +0900 [INFO] (0018:task-0000): parent directory sftp://user@xxx.xxx.xxx.xxx/tmp exists there
2017-04-03 14:20:59.989 +0900 [INFO] (0018:task-0000): new sftp file: sftp://user@xxx.xxx.xxx.xxx/tmp/hoge005.00..csv
2017-04-03 14:21:00.020 +0900 [INFO] (0018:task-0000): set identity: org.embulk.spi.unit.LocalFile@4ab77e67
2017-04-03 14:21:00.321 +0900 [INFO] (0018:task-0000): parent directory sftp://user@xxx.xxx.xxx.xxx/tmp exists there
2017-04-03 14:21:00.336 +0900 [INFO] (0018:task-0000): new sftp file: sftp://user@xxx.xxx.xxx.xxx/tmp/hoge006.00..csv
2017-04-03 14:21:00.352 +0900 [INFO] (0018:task-0000): set identity: org.embulk.spi.unit.LocalFile@40bc12f0
2017-04-03 14:21:00.591 +0900 [INFO] (0018:task-0000): parent directory sftp://user@xxx.xxx.xxx.xxx/tmp exists there
2017-04-03 14:21:00.607 +0900 [INFO] (0018:task-0000): new sftp file: sftp://user@xxx.xxx.xxx.xxx/tmp/hoge007.00..csv
2017-04-03 14:21:00.949 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2017-04-03 14:21:00.962 +0900 [INFO] (main): Committed.
2017-04-03 14:21:00.964 +0900 [INFO] (main): Next config diff: {"in":{"last_path":"C:\\Users\\user\\Desktop\\works\\hoge\\csv\\sample_01.csv.gz"},"out":{}}
```