### PR TITLE
[Doc] Remove `make html` build warning.

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -322,7 +322,7 @@ JSON parser plugin
 
 The ``json`` parser plugin parses a JSON file that contains a sequence of JSON objects. Example:
 
-.. code-block:: json
+.. code-block:: javascript
 
     {"time":1455829282,"ip":"93.184.216.34","name":frsyuki}
     {"time":1455829282,"ip":"172.36.8.109":sadayuki}

--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -95,7 +95,7 @@ Configuration file can include another configuration file. To use it, configurat
 
 File will be searched from the relative path of the input configuration file. And file name will be ``_<name>.yml.liquid``. For example, if you add ``{% include 'subdir/inc' %}`` tag to ``myconfig/config.yml.liquid`` file, it includes ``myconfig/subdir/_inc.yml.liquid`` file.
 
-.. code-block:: yaml
+.. code-block:: liquid
 
     # config.yml.liquid
     {% include 'in_mysql' %}

--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -48,7 +48,7 @@ A configuration file consists of following sections:
 
 * **out:** Output plugin options. An output plugin is either record-based (`Oracle <https://github.com/embulk/embulk-output-jdbc>`_, `Elasticsearch <https://github.com/muga/embulk-output-elasticsearch>`_, etc) or file-based (`Google Cloud Storage <https://github.com/hakobera/embulk-output-gcs>`_, `Command <https://github.com/embulk/embulk-output-command>`_, etc)
 
-  * **formatter:** If the output is file-based, formatter plugin formats a file format (such as built-in csv, `JSON <https://github.com/takei-yuya/embulk-formatter-jsonl>`_)
+  * **formatter:** If the output is file-based, formatter plugin formats a file format (such as built-in csv, `jsonl <https://github.com/takei-yuya/embulk-formatter-jsonl>`_)
 
   * **encoder:** If the output is file-based, encoder plugin encodes compression or encryption (such as built-in gzip or bzip2)
 

--- a/embulk-docs/src/customization.rst
+++ b/embulk-docs/src/customization.rst
@@ -19,7 +19,7 @@ Creating a new plugin is 4 steps:
 This article describes how to create a plugin step by step.
 
 Step 1: Creating a new project
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Embulk comes with a number of templates that generates a new project so that you can start development instantly. Because the generated project contains completely working code without additional code, you can focus on the necessary coding.
 
@@ -59,7 +59,7 @@ For example, if you want to parse a new file format using Java, type this comman
 This will create a Java-based parser plugin called ``myformat`` in ``embulk-parser-myformat`` directory.
 
 Step 2: Building the project
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the plugin is Java-based, you need to build the project. To build, type this command:
 
@@ -71,7 +71,7 @@ If the plugin is Java-based, you need to build the project. To build, type this 
 Now, the plugin is ready to use.
 
 Step 3: Confirm it works
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 The next step is to actually use the plugin.
 
@@ -82,7 +82,7 @@ Let's suppose you have a configuration file named ``your-config.yml``. You can u
     $ embulk run -L ./embulk-parser-myformat/ your-config.yml
 
 Step 4: Modifying the code
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The final step is to modify code as you want!
 
@@ -104,7 +104,7 @@ Releasing plugins
 You can release publicly so that all people can use your awesome plugins.
 
 Checking plugin description
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To prepare the plugin ready to release, you need to include some additional information. The plugin information is written in this file:
 
@@ -136,14 +136,14 @@ You will find following section in the file.
 The items in above example are important. Please make sure that they are good.
 
 Creating account on RubyGems.org
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Embulk uses `RubyGems.org <https://rubygems.org/>`_ as a package distribution service. Please create an account there to release plugins at `Sign Up <https://rubygems.org/sign_up>`_ page.
 
 Don't forget the password! It will be necessary at the next step.
 
 Releasing the plugin to RubyGems.org
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now, you're ready to release the plugin. To release, type following command:
 
@@ -158,7 +158,7 @@ Now, you're ready to release the plugin. To release, type following command:
 If everything is good, you can find your plugin at https://rubygems.org/. Congratulations!
 
 Installing your plugin
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 Usage of plugin installer is:
 

--- a/embulk-docs/src/recipe/scheduled-csv-load-to-elasticsearch-kibana5.rst
+++ b/embulk-docs/src/recipe/scheduled-csv-load-to-elasticsearch-kibana5.rst
@@ -157,7 +157,7 @@ For example, if you create ``./mydata/csv/sample_02.csv.gz`` file, embulk skips 
 
 So, if you want to loads newly created files every day, you can setup this cron schedule:
 
-.. code-block:: cron
+.. code-block:: text
 
     0 * * * * embulk run /path/to/config.yml -c /path/to/diff.yml
 

--- a/embulk-docs/src/release/release-0.4.0.rst
+++ b/embulk-docs/src/release/release-0.4.0.rst
@@ -2,7 +2,7 @@ Release 0.4.0
 ==================================
 
 Plugin Template Generator
-------------------
+-------------------------
 
 A new CLI subcommand ``new`` generate a plugin template.
 

--- a/embulk-docs/src/release/release-0.5.0.rst
+++ b/embulk-docs/src/release/release-0.5.0.rst
@@ -2,7 +2,7 @@ Release 0.5.0
 ==================================
 
 New Guess Plugin Architecture
-------------------
+-----------------------------
 
 Embulk v0.5.0 supports dynamically loadable guess plugins.
 

--- a/embulk-docs/src/release/release-0.6.0.rst
+++ b/embulk-docs/src/release/release-0.6.0.rst
@@ -2,7 +2,7 @@ Release 0.6.0
 ==================================
 
 Executor Plugin Mechanism
-------------------
+-------------------------
 
 Now executor of Embulk is fully extensible using plugins. Executor plugins get input, filter and output plugins from the Embulk framework and runs them using multiple threads, processes, or servers. While input, filter and output plugins are response for data processing, executor plugins are responsible for scheduling the processing tasks and managing parallelism for performance.
 

--- a/embulk-docs/src/release/release-0.6.20.rst
+++ b/embulk-docs/src/release/release-0.6.20.rst
@@ -2,7 +2,7 @@ Release 0.6.20
 ==================================
 
 Command line interface
-------------------
+----------------------
 
 * Added ``-X key=value`` argument to set system config. This argument is intended to overwrite performance parameters such as number of threads (``max_threads``) or page buffer size (``page_size``).
 


### PR DESCRIPTION
This PR remove the following warning. 
No contents change.

```
Creating account on RubyGems.org
~~~~~~~~~~~~~~~~~~
/path/to/change/embulk/embulk-docs/src/customization.rst:139: WARNING: Title underline too short.
```

The following WARNING can't solve yet. 

```
checking consistency... /path/to/embulk/embulk/embulk-docs/src/developers/index.rst:: WARNING: document isn't included in any toctree
done
preparing documents... done
/path/to/embulk/embulk/embulk-docs/src/built-in.rst:98: WARNING: Could not lex literal_block as "yaml". Highlighting skipped.
/path/to/embulk/embulk/embulk-docs/src/built-in.rst:325: WARNING: Could not lex literal_block as "json". Highlighting skipped.
```