### PR TITLE
Add updateJRuby task document

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ Task `dependencies` shows dependency tree of embulk-core project:
 ./gradlew :embulk-core:dependencies
 ```
 
+### Update JRuby
+
+Task `updateJRuby` updates JRuby version of embulk-core project.
+
+This is an example to update JRuby to `9.1.5.0`.
+
+```
+./gradlew updateJRuby -Pto=9.1.5.0
+```
+
 ### Documents
 
 Embulk uses Sphinx, YARD (Ruby API) and JavaDoc (Java API) for document generation.


### PR DESCRIPTION
I've forgotten usage `updateJRuby` task.
I update the README. 
Could you add it to README?

By the way, JRuby 9.1.8.0 released at 6/Mar/2017
http://jruby.org/2017/03/06/jruby-9-1-8-0.html
It fixed many issues. 
