### PR TITLE
[WIP] Load pure-Java JAR-based plugins.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkService.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkService.java
@@ -9,6 +9,7 @@ import org.embulk.config.ConfigSource;
 import org.embulk.exec.SystemConfigModule;
 import org.embulk.exec.ExecModule;
 import org.embulk.exec.ExtensionServiceLoaderModule;
+import org.embulk.jar.JarPluginSourceModule;
 import org.embulk.plugin.PluginClassLoaderModule;
 import org.embulk.plugin.BuiltinPluginSourceModule;
 import org.embulk.jruby.JRubyScriptingModule;
@@ -45,6 +46,7 @@ public class EmbulkService
                 new ExtensionServiceLoaderModule(systemConfig),
                 new PluginClassLoaderModule(systemConfig),
                 new BuiltinPluginSourceModule(),
+                new JarPluginSourceModule(systemConfig),
                 new JRubyScriptingModule(systemConfig));
     }
 

--- a/embulk-core/src/main/java/org/embulk/jar/JarPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/jar/JarPluginSource.java
@@ -1,0 +1,138 @@
+package org.embulk.jar;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+import org.embulk.plugin.PluginClassLoader;
+import org.embulk.plugin.PluginClassLoaderFactory;
+import org.embulk.plugin.PluginSource;
+import org.embulk.plugin.PluginSourceNotMatchException;
+import org.embulk.plugin.PluginType;
+import org.embulk.spi.DecoderPlugin;
+import org.embulk.spi.EncoderPlugin;
+import org.embulk.spi.ExecutorPlugin;
+import org.embulk.spi.FilterPlugin;
+import org.embulk.spi.FormatterPlugin;
+import org.embulk.spi.GuessPlugin;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.ParserPlugin;
+
+public class JarPluginSource
+        implements PluginSource
+{
+    @Inject
+    public JarPluginSource(Injector injector)
+    {
+        this.injector = injector;
+    }
+
+    @Override
+    public <T> T newPlugin(Class<T> pluginInterface, PluginType pluginType)
+            throws PluginSourceNotMatchException
+    {
+        final String category;
+        if (InputPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "input";
+        } else if (OutputPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "output";
+        } else if (ParserPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "parser";
+        } else if (FormatterPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "formatter";
+        } else if (DecoderPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "decoder";
+        } else if (EncoderPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "encoder";
+        } else if (FilterPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "filter";
+        } else if (GuessPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "guess";
+        } else if (ExecutorPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "executor";
+        } else {
+            // unsupported plugin category
+            throw new PluginSourceNotMatchException("Plugin interface " + pluginInterface + " is not supported.");
+        }
+
+        if (!pluginType.getName().startsWith("jar")) {
+            throw new PluginSourceNotMatchException("\"type\" does not start with \"jar:\".");
+        }
+        final Path jarPath = Paths.get(pluginType.getName().substring(4));
+
+        final URL jarUrl;
+        final URL urlPluginProperties;
+        try {
+            jarUrl = jarPath.toUri().toURL();
+            urlPluginProperties = new URL("jar:" + jarPath.toUri().toURL().toString() + "!/plugin.properties");
+        }
+        catch (MalformedURLException ex) {
+            throw new PluginSourceNotMatchException("Invalid plugin path: " + jarPath.toString(), ex);
+        }
+
+        final Properties pluginProperties = new Properties();
+        try (final InputStream inputFromProperties =
+             ((JarURLConnection) urlPluginProperties.openConnection()).getInputStream()) {
+            pluginProperties.load(inputFromProperties);
+        }
+        catch (IOException ex) {
+            throw new PluginSourceNotMatchException("Invalid plugin: \"plugin.properties\" not accessible.", ex);
+        }
+
+        final String pluginMainClassName = pluginProperties.getProperty("pluginMainClass");
+        if (pluginMainClassName == null) {
+            throw new PluginSourceNotMatchException("Invalid plugin: \"pluginMainClass\" not in plugin.properties.");
+        }
+
+        final PluginClassLoaderFactory pluginClassLoaderFactory =
+            this.injector.getInstance(PluginClassLoaderFactory.class);
+        final PluginClassLoader pluginClassLoader =
+            pluginClassLoaderFactory.create(ImmutableList.of(jarUrl), JarPluginSource.class.getClassLoader());
+        final Class pluginMainClass;
+        try {
+            pluginMainClass = pluginClassLoader.loadClass(pluginMainClassName);
+        }
+        catch (ClassNotFoundException ex) {
+            throw new PluginSourceNotMatchException("Invalid plugin: \"" + pluginMainClassName+ "\" not loadable.", ex);
+        }
+
+        if (!pluginInterface.isAssignableFrom(pluginMainClass)) {
+            throw new PluginSourceNotMatchException(
+                "Invalid plugin: \"" + pluginMainClassName + "\" is not " + category + ".");
+        }
+        // TODO(dmikurube): Inject for each plugin as described in plugin.properties.
+
+        final Object pluginMainObject;
+        try {
+            pluginMainObject = pluginMainClass.newInstance();
+        }
+        catch (InstantiationException ex) {
+            throw new PluginSourceNotMatchException(
+                "Invalid plugin: \"" + pluginMainClassName + "\" not instantiatable.", ex);
+        }
+        catch (IllegalAccessException ex) {
+            throw new PluginSourceNotMatchException(
+                "Invalid plugin: \"" + pluginMainClassName + "\" illegal access.", ex);
+        }
+
+        try {
+            return pluginInterface.cast(pluginMainObject);
+        }
+        catch (ClassCastException ex) {
+            throw new PluginSourceNotMatchException(
+                "FATAL: Invalid plugin: \"" + pluginMainClassName + "\" is not " + category + ".");
+        }
+    }
+
+    private final Injector injector;
+}

--- a/embulk-core/src/main/java/org/embulk/jar/JarPluginSourceModule.java
+++ b/embulk-core/src/main/java/org/embulk/jar/JarPluginSourceModule.java
@@ -1,0 +1,25 @@
+package org.embulk.jar;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.multibindings.Multibinder;
+
+import org.slf4j.ILoggerFactory;
+
+import org.embulk.config.ConfigSource;
+import org.embulk.plugin.PluginSource;
+
+public class JarPluginSourceModule
+        implements Module
+{
+    public JarPluginSourceModule(ConfigSource systemConfig)
+    {
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        Multibinder<PluginSource> multibinder = Multibinder.newSetBinder(binder, PluginSource.class);
+        multibinder.addBinding().to(JarPluginSource.class);
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginSourceNotMatchException.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginSourceNotMatchException.java
@@ -5,6 +5,7 @@ public class PluginSourceNotMatchException
 {
     public PluginSourceNotMatchException()
     {
+        super();
     }
 
     public PluginSourceNotMatchException(String message)
@@ -15,5 +16,10 @@ public class PluginSourceNotMatchException
     public PluginSourceNotMatchException(Throwable cause)
     {
         super(cause);
+    }
+
+    public PluginSourceNotMatchException(String message, Throwable cause)
+    {
+        super(message, cause);
     }
 }


### PR DESCRIPTION
@muga It's just a PoC, not to be merged yet. Let me just share the status atm.

Confirmed that a pure-Java (non-Gem) plugin can be a kind loaded.

1. Build https://github.com/dmikurube/embulk-input-dummyjar with `./gradlew pluginJar`
2. Build Embulk with this PR.
3. Write a simple YAML config like:
```
in:
  type: jar:/full/path/to/your/built/embulk-input-dummyjar-plugin-0.0.1.jar
out:
  type: stdout
```
4. `pkg/embulk-0.8.18.jar run dummyjar.yml` with Embulk built at 2.