### PR TITLE
Use the jar manifest (META-INF/MANIFEST.MF) to provide the Embulk version at runtime [#596]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,6 +224,8 @@ project(':embulk-cli') {
     apply plugin: 'com.github.johnrengelman.shadow'
 
     shadowJar {
+        // NOTE: This 'Implementation-Version' in the manifest is referred to provide the Embulk version at runtime.
+        // See also: embulk-core/src/main/java/org/embulk/EmbulkVersion.java
         manifest {
             attributes 'Implementation-Title': project.name,
                        'Implementation-Version': project.version,

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -4,20 +4,6 @@ apply plugin: "com.github.jruby-gradle.jar"
 // because IntelliJ causes error if srcDirs includes files out of projectDir.
 processResources.from("${rootProject.projectDir}/lib/", "${buildDir}/gemlib")
 
-task embulkJavaProperty(dependsOn: processResources) {
-    doLast {
-        new File("$buildDir/resources/main/embulk.properties").withWriter { w ->
-            Properties p = new Properties()
-            p['version'] = project.version.toString()
-            p.store w, null
-        }
-    }
-}
-
-classes {
-    dependsOn embulkJavaProperty
-}
-
 configurations {
     // com.google.inject:guice depends on asm and cglib but version of the libraries conflict
     // with ones bundled in jruby-complete and cause bytecode compatibility error

--- a/embulk-core/src/main/java/org/embulk/EmbulkVersion.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkVersion.java
@@ -59,7 +59,6 @@ public final class EmbulkVersion
             }
 
             try (final JarFile selfJarFile = new JarFile(selfJarPathString)) {
-                final Manifest selfJarManifest;
                 try {
                     return selfJarFile.getManifest();
                 }

--- a/embulk-core/src/main/java/org/embulk/EmbulkVersion.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkVersion.java
@@ -1,8 +1,12 @@
 package org.embulk;
 
-import java.io.InputStream;
 import java.io.IOException;
-import java.util.Properties;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 
 public final class EmbulkVersion
 {
@@ -10,17 +14,96 @@ public final class EmbulkVersion
     {
     }
 
+    // Expecting Embulk is always packaged in the embulk-cli jar whenever the Embulk version is checked in Java.
     static {
-        final Properties properties = new Properties();
-        String versionLoaded = null;
-        try (InputStream input = EmbulkVersion.class.getClassLoader().getResourceAsStream("embulk.properties")) {
-            properties.load(input);
-            versionLoaded = properties.getProperty("version");
+        VERSION = getImplementationVersion(getSelfJarManifest(), "[embulk-version-unavailable]");
+    }
+
+    private static Manifest getSelfJarManifest()
+    {
+        try {
+            final ProtectionDomain protectionDomain;
+            try {
+                protectionDomain = EmbulkVersion.class.getProtectionDomain();
+            }
+            catch (SecurityException ex) {
+                System.err.println("Embulk version unavailable due to ProtectionDomain inaccessible.");
+                ex.printStackTrace();
+                return null;
+            }
+
+            final CodeSource codeSource = protectionDomain.getCodeSource();
+            if (codeSource == null) {
+                System.err.println("Embulk version unavailable due to CodeSource unavailable.");
+                return null;
+            }
+
+            final URL selfJarUrl = codeSource.getLocation();
+            if (selfJarUrl == null) {
+                System.err.println("Embulk version unavailable due to the location of CodeSource unavailable.");
+                return null;
+            }
+            else if (!selfJarUrl.getProtocol().equals("file")) {
+                System.err.println("Embulk version unavailable as the location of CodeSource is not local.");
+                return null;
+            }
+
+            final String selfJarPathString = selfJarUrl.getPath();
+            if (selfJarPathString == null) {
+                System.err.println("Embulk version unavailable due to the path of CodeSource unavailable.");
+                return null;
+            }
+            else if (selfJarPathString.isEmpty()) {
+                System.err.println("Embulk version unavailable due to the path of CodeSource empty.");
+                return null;
+            }
+
+            try (final JarFile selfJarFile = new JarFile(selfJarPathString)) {
+                final Manifest selfJarManifest;
+                try {
+                    return selfJarFile.getManifest();
+                }
+                catch (IllegalStateException ex) {
+                    System.err.println("Embulk version unavailable due to the jar file closed unexpectedly.");
+                    ex.printStackTrace();
+                    return null;
+                }
+                catch (IOException ex) {
+                    System.err.println("Embulk version unavailable due to failure to get the manifst in the jar file.");
+                    ex.printStackTrace();
+                    return null;
+                }
+            }
+            catch (SecurityException ex) {
+                System.err.println("Embulk version unavailable due to the jar file inaccessible.");
+                ex.printStackTrace();
+                return null;
+            }
+            catch (IOException ex) {
+                System.err.println("Embulk version unavailable due to failure to access the jar file.");
+                ex.printStackTrace();
+                return null;
+            }
         }
-        catch (IOException ex) {
-            versionLoaded = "(embulk-java-properties-not-found)";
+        catch (Throwable ex) {
+            System.err.println("Embulk version unavailable due to an unknown exception.");
+            ex.printStackTrace();
+            return null;
         }
-        VERSION = versionLoaded;
+    }
+
+    private static String getImplementationVersion(final Manifest manifest, final String defaultVersion)
+    {
+        if (manifest == null) {
+            return defaultVersion;
+        }
+        final Attributes mainAttributes = manifest.getMainAttributes();
+        final String implementationVersion = mainAttributes.getValue(Attributes.Name.IMPLEMENTATION_VERSION);
+        if (implementationVersion == null) {
+            System.err.println("Embulk version unavailable due to the manifest not containing Implementation-Version.");
+            return defaultVersion;
+        }
+        return implementationVersion;
     }
 
     public static final String VERSION;


### PR DESCRIPTION
@muga Per #596, removed `embulk.properties` and started to use `Implementation-Version` in the jar manifest. Can you PTAL?

(Will update other PRs depending on `embulk.properties`.)