### PR TITLE
[WIP;PoC] Apply security policy by plugin's own manifest.

### DIFF
--- a/embulk-cli/src/main/java/org/embulk/cli/Main.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/Main.java
@@ -1,11 +1,38 @@
 package org.embulk.cli;
 
 import java.net.URISyntaxException;
+import java.security.AllPermission;
+import java.security.CodeSource;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.security.ProtectionDomain;
 
 public class Main
 {
     public static void main(String[] args)
     {
+        java.security.Policy.setPolicy(new java.security.Policy() {
+                // NOTE: Policy#getPermissions(ProtectionDomain) calls Policy#getPermissions(CodeSource)
+                // internally. Overriding just Policy#getPermissions(CodeSource) is usually fine.
+                @Override
+                public PermissionCollection getPermissions(CodeSource codeSource)
+                {
+                    Permissions permissions = new Permissions();
+                    permissions.add(new java.security.AllPermission());
+                    return permissions;
+                }
+
+                @Override
+                public PermissionCollection getPermissions(ProtectionDomain protectionDomain)
+                {
+                    if (protectionDomain.getClassLoader() instanceof org.embulk.plugin.PluginClassLoader) {
+                        return new Permissions();
+                    }
+                    return super.getPermissions(protectionDomain);
+                }
+            });
+        System.setSecurityManager(new SecurityManager());
+
         // $ java -jar jruby-complete.jar embulk-core.jar!/embulk/command/embulk_bundle.rb "$@"
         String[] jrubyArgs = new String[args.length + 1];
         int i;

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactory.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactory.java
@@ -2,8 +2,10 @@ package org.embulk.plugin;
 
 import java.util.Collection;
 import java.net.URL;
+import java.security.PermissionCollection;
 
 public interface PluginClassLoaderFactory
 {
     PluginClassLoader create(Collection<URL> urls, ClassLoader parentClassLoader);
+    PluginClassLoader create(Collection<URL> urls, ClassLoader parentClassLoader, PermissionCollection permissions);
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderModule.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderModule.java
@@ -5,6 +5,7 @@ import java.util.Properties;
 import java.net.URL;
 import java.io.InputStream;
 import java.io.IOException;
+import java.security.PermissionCollection;
 import com.google.inject.Module;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
@@ -65,6 +66,17 @@ public class PluginClassLoaderModule
             {
                 return new PluginClassLoader(urls, parentClassLoader,
                         parentFirstPackages, parentFirstResources);
+            }
+
+            public PluginClassLoader create(Collection<URL> urls,
+                                            ClassLoader parentClassLoader,
+                                            PermissionCollection permissions)
+            {
+                return new PluginClassLoader(urls,
+                                             parentClassLoader,
+                                             parentFirstPackages,
+                                             parentFirstResources,
+                                             permissions);
             }
         }
     }


### PR DESCRIPTION
This is just Proof-of-Concept as well as #592, not for merging. (And it depends on #592 as well.)

It's just a trial to apply a kind of Security Policy for plugin. This is manifest-based, which means that a plugin declares its required permissions by itself. It may make it easier to confirm plugins don't behave out of expectations.

Cc: @muga 

It has problems yet. The biggest one is that the main code (not plugin code) may run under `PluginClassLoader` in case of `ScatterExecutor` or like that.