### PR TITLE
PreviewExecutor: to fix incompatible behavior that it requires exec: config

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
@@ -106,7 +106,7 @@ public class PreviewExecutor
         List<FilterPlugin> filterPlugins = newFilterPlugins(task);
 
         if (inputPlugin instanceof FileInputRunner) { // file input runner
-            Buffer sample = SamplingParserPlugin.runFileInputSampling((FileInputRunner)inputPlugin, config.getNested("in"), createSampleBufferConfigFromExecConfig(config.getNested("exec")));
+            Buffer sample = SamplingParserPlugin.runFileInputSampling((FileInputRunner)inputPlugin, config.getNested("in"), createSampleBufferConfigFromExecConfig(task.getExecConfig()));
             FileInputRunner previewRunner = new FileInputRunner(new BufferFileInputPlugin(sample));
             return doPreview(task, previewRunner, filterPlugins);
         }


### PR DESCRIPTION
This PR fixes incompatible behavior of `PreviewExecutor` with previous version. That unexpectedly requires `exec:` config during `preview` command is executed. 0.8.18 or older version doesn't require `exec:` config.

The root cause of this issue is that it calls`config.getNested("exec")`. If `config` doesn't have `exec:` config, it gets the `ConfigException`. It should use `task.getExecConfig()` because it will receive default value `{}` if `config` doesn't have `exec:` config.

#618