### PR TITLE
Revert "Merge pull request #585 from hiroyuki-sato/filetree-follow-symlink"

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -128,19 +128,17 @@ The ``file`` input plugin reads files from local file system.
 Options
 ~~~~~~~~
 
-+------------------+----------+------------------------------------------------+-----------------------+
-| name             | type     | description                                    | required?             |
-+==================+==========+================================================+=======================+
-| path\_prefix     | string   | Path prefix of input files                     | required              |
-+------------------+----------+------------------------------------------------+-----------------------+
-| parsers          | hash     | Parsers configurations (see below)             | required              |
-+------------------+----------+------------------------------------------------+-----------------------+
-| decoders         | array    | Decoder configuration (see below)              |                       |
-+------------------+----------+------------------------------------------------+-----------------------+
-| last\_path       | string   | Name of last read file in previous operation   |                       |
-+------------------+----------+------------------------------------------------+-----------------------+
-| follow\_symlinks | boolean  | If `true`, follow symbolic link directories    | ``false`` by default  |
-+------------------+----------+------------------------------------------------+-----------------------+
++----------------+----------+------------------------------------------------+-----------+
+| name           | type     | description                                    | required? |
++================+==========+================================================+===========+
+| path\_prefix   | string   | Path prefix of input files                     | required  |
++----------------+----------+------------------------------------------------+-----------+
+| parsers        | hash     | Parsers configurations (see below)             | required  |
++----------------+----------+------------------------------------------------+-----------+
+| decoders       | array    | Decoder configuration (see below)              |           |
++----------------+----------+------------------------------------------------+-----------+
+| last\_path     | string   | Name of last read file in previous operation   |           |
++----------------+----------+------------------------------------------------+-----------+
 
 The ``path_prefix`` option is required. If you have files as following, you may set ``path_prefix: /path/to/files/sample_``:
 


### PR DESCRIPTION
We had a report from @hiroyuki-sato that v0.8.19 did not work for the case below on Mac OS:

```
cd /tmp ; embulk example sample ; embulk guess -o config.yml sample/seed.yml
```

It looked because /tmp is a symbolic link to /private/tmp due to #585.