### PR TITLE
Downgrade liquid 4.0.0 to 3.0.6

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
     gems 'rubygems:bundler:1.10.6'
     gems 'rubygems:msgpack:1.1.0'
-    gems 'rubygems:liquid:4.0.0'
+    gems 'rubygems:liquid:3.0.6'
 }
 
 task unpackGems(type: JRubyPrepare) {


### PR DESCRIPTION
This PR downgrades liquid 4.0.0 to 3.0.6. Liquid was upgraded on Embulk v0.8.19 but, the upgrading causes regression https://github.com/embulk/embulk/issues/627. 
