### PR TITLE
Remove unnecessary error validations

### DIFF
--- a/lib/embulk/error.rb
+++ b/lib/embulk/error.rb
@@ -3,25 +3,11 @@ module Embulk
   # ConfigError is not a ::StandardError but is a java.lang.RuntimeException.
   # "rescue => e" can rescues ConfigError.
   class ConfigError < Java::Config::ConfigException
-    def initialize(message=nil)
-      if message
-        super(message.to_s)
-      else
-        super()
-      end
-    end
   end
 
   # DataError is not a ::StandardError but is a java.lang.RuntimeException.
   # "rescue => e" can rescues DataError.
   class DataError < Java::SPI::DataException
-    def initialize(message=nil)
-      if message
-        super(message.to_s)
-      else
-        super()
-      end
-    end
   end
 
   class PluginLoadError < ConfigError


### PR DESCRIPTION
fix https://github.com/embulk/embulk/issues/630

As I wrote in https://github.com/embulk/embulk/issues/630, `ConfigError`, `DataError` and `PluginLoadError` cannot have `cause`. Since the behavior is difficult for Ruby Plugin Creators, I think the error class should behave like inherited Ruby Exception class. Now I found the error class behaves like inherited Ruby Exception class even if they inherit Java Error class. See https://gist.github.com/civitaspo/415142e2d567ec5ff79827b35d50f9fb (This is just the same on issue 630.)
So, I remove the special implementations.