### PR TITLE
Add a note on the timestamp format in embulk-doc with a link to Ruby documents

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -241,6 +241,9 @@ The ``columns`` option declares the list of columns. This CSV parser plugin igno
 | date     | Set date part if the format doesn’t include date part  |
 +----------+--------------------------------------------------------+
 
+.. note::
+
+   The Timestamp format refers to `Ruby strftime format <https://docs.ruby-lang.org/en/2.4.0/Date.html#method-i-strftime>`_
 
 List of types:
 
@@ -496,6 +499,10 @@ The ``column_options`` option is a map whose keys are name of columns, and value
 +----------------------+---------+-------------------------------------------------------------------------------------------------------+-----------------------------------------+
 | format               | string  | Timestamp format if type of this column is timestamp.                                                 | ``%Y-%m-%d %H:%M:%S.%6N %z`` by default |
 +----------------------+---------+-------------------------------------------------------------------------------------------------------+-----------------------------------------+
+
+.. note::
+
+   The Timestamp format refers to `Ruby strftime format <https://docs.ruby-lang.org/en/2.4.0/Date.html#method-i-strftime>`_
 
 Example
 ~~~~~~~~


### PR DESCRIPTION
I tested #647  in my environment, and I got the following error.
I use `note` section instead of the writing URL on the table. 

I also write this note on the CSV parser section. 

@toru-takahashi @dmikurube Please take a look.

```
built-in.rst:492: ERROR: Malformed table.

+----------------------+---------+-------------------------------------------------------------------------------------------------------+-----------------------------------------+
| name                 | type    | description                                                                                           | required?                               |
+======================+=========+=======================================================================================================+=========================================+
| timezone             | string  | Time zone if type of this column is timestamp. If not set, ``default\_timezone`` is used.             | optional                                |
+----------------------+---------+-------------------------------------------------------------------------------------------------------+-----------------------------------------+
| format               | string  | Timestamp format if type of this column is timestamp.                                                 | ``%Y-%m-%d %H:%M:%S.%6N %z`` by default. The Timestamp format refers to https://docs.ruby-lang.org/en/2.4.0/Date.html#method-i-strftime |
+----------------------+---------+-------------------------------------------------------------------------------------------------------+-----------------------------------------+
```

![strftime](https://cloud.githubusercontent.com/assets/767650/26395615/937c5bf6-40ab-11e7-8646-f5088310218b.png)
