### PR TITLE
[Doc] Fix WARNING: Title underline too short.

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -949,7 +949,7 @@ Example
       ...
 
 Preview executor
----------------
+----------------
 
 The preview executor is called by ``preview`` command. It tries to read sample buffer from a specified input source and writes them to Page objects. ``preview`` outputs the Page objects to console.
 


### PR DESCRIPTION

This PR fix the following WARNING. 

```
/path/to/embulk/embulk-docs/src/built-in.rst:952: WARNING: Title underline too short.

Preview executor
---------------
```