### PR TITLE
embulk-core: PageReader#get{String,Timestamp,Json} calls #isNull to return null

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/PageReader.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageReader.java
@@ -107,6 +107,9 @@ public class PageReader
 
     public String getString(int columnIndex)
     {
+        if (isNull(columnIndex)) {
+            return null;
+        }
         int index = pageSlice.getInt(getOffset(columnIndex));
         return page.getStringReference(index);
     }
@@ -119,6 +122,9 @@ public class PageReader
 
     public Timestamp getTimestamp(int columnIndex)
     {
+        if (isNull(columnIndex)) {
+            return null;
+        }
         int offset = getOffset(columnIndex);
         long sec = pageSlice.getLong(offset);
         int nsec = pageSlice.getInt(offset + 8);
@@ -133,6 +139,9 @@ public class PageReader
 
     public Value getJson(int columnIndex)
     {
+        if (isNull(columnIndex)) {
+            return null;
+        }
         int index = pageSlice.getInt(getOffset(columnIndex));
         return page.getValueReference(index);
     }


### PR DESCRIPTION
This PR enables `PageReader#getString,Timestamp,Json` to return null object if the column value is null. It came from https://github.com/embulk/embulk-base-restclient/pull/86.

Plugins are responsible for null check because they only know how null object should be handled. In Embulk 0.8.22, if plugins don't do null check, they get `ArrayIndexOutOfBoundsException`. But, it's not easy to understand the exception and the message. This PR changes to call `#isNull` method and return null object if the column value is null, instead of the exception. I believe that this change doesn't have big impact of `PageReader` performance caused by `#isNull` method call. 