### PR TITLE
embulk/guess/json.rb: JsonGuessPlugin ignores JsonParseException

### DIFF
--- a/lib/embulk/guess/json.rb
+++ b/lib/embulk/guess/json.rb
@@ -22,7 +22,8 @@ module Embulk
             # JSON object type check (isMapValue) is required for v. Because JsonParserPlugin
             # accepts only object type. And single column CSV avoids to be guessed as Json
             # parser type.
-            one_json_parsed = true if v.isMapValue
+            raise JsonParseException.new("v requires JSON object type") unless v.isMapValue
+            one_json_parsed = true
           end
         rescue JsonParseException
           # the exception is ignored

--- a/lib/embulk/guess/json.rb
+++ b/lib/embulk/guess/json.rb
@@ -19,10 +19,10 @@ module Embulk
         one_json_parsed = false
         begin
           while (v = json_parser.next)
-            # JSON object type check (isMapValue) is required for v. Because JsonParserPlugin
-            # accepts only object type. And single column CSV avoids to be guessed as Json
-            # parser type.
-            raise JsonParseException.new("v requires JSON object type") unless v.isMapValue
+            # "v" needs to be JSON object type (isMapValue) because:
+            # 1) Single-column CSV can be mis-guessed as JSON if JSON non-objects are accepted.
+            # 2) JsonParserPlugin accepts only the JSON object type.
+            raise JsonParseException.new("v must be JSON object type") unless v.isMapValue
             one_json_parsed = true
           end
         rescue JsonParseException

--- a/lib/embulk/guess/json.rb
+++ b/lib/embulk/guess/json.rb
@@ -16,11 +16,16 @@ module Embulk
 
         # Use org.embulk.spi.json.JsonParser to respond to multi-line Json
         json_parser = new_json_parser(sample_buffer)
+        one_json_parsed = false
         begin
           while json_parser.next
+            one_json_parsed = true
           end
         rescue JsonParseException
-          return {}
+          # the exception is ignored if JsonParser can parse even one JSON data
+          unless one_json_parsed
+            return {}
+          end
         end
 
         return {"parser" => {"type" => "json"}}


### PR DESCRIPTION
This PR changes `JsonGuessPlugin` to ignore `JsonParseException` if it can parse even one JSON data. 

### Problem

`JsonGuessPlugin` guess sometimes fails because it gets `JsonParseException` when it cannot parse the last line of sampling buffer correctly. 

### Fix

To fix this issue, I changes the guess plugin to ignore `JsonParseException` if even one JSON data can be parsed. I first wanted to use `LineGuessPlugin` but, `JsonGuessPlugin` cannot extend it because `JsonGuessPlugin` should guess multi-line JSON. 