### PR TITLE
Ignore JsonParseException in JSON preview if at least one JSON is already parsed.

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
@@ -65,6 +65,7 @@ public class JsonParserPlugin
         try (PageBuilder pageBuilder = newPageBuilder(schema, output);
                 FileInputInputStream in = new FileInputInputStream(input)) {
             while (in.nextFile()) {
+                boolean evenOneJsonParsed = false;
                 try (JsonParser.Stream stream = newJsonStream(in)) {
                     Value value;
                     while ((value = stream.next()) != null) {
@@ -76,6 +77,7 @@ public class JsonParserPlugin
 
                             pageBuilder.setJson(column, value);
                             pageBuilder.addRecord();
+                            evenOneJsonParsed = true;
                         }
                         catch (JsonRecordValidateException e) {
                             if (stopOnInvalidRecord) {
@@ -86,6 +88,9 @@ public class JsonParserPlugin
                     }
                 }
                 catch (IOException | JsonParseException e) {
+                    if (Exec.isPreview() && evenOneJsonParsed) {
+                        break;
+                    }
                     throw new DataException(e);
                 }
             }

--- a/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
@@ -89,6 +89,9 @@ public class JsonParserPlugin
                 }
                 catch (IOException | JsonParseException e) {
                     if (Exec.isPreview() && evenOneJsonParsed) {
+			// JsonParseException occurs when it cannot parse the last part of sampling buffer. Because
+			// the last part is sometimes invalid as JSON data. Therefore JsonParseException can be
+			// ignore in preview if at least one JSON is already parsed.
                         break;
                     }
                     throw new DataException(e);


### PR DESCRIPTION
Similar to #659, it is required for JSON preview.