### PR TITLE
embulk-core: Fix BulkLoader to pass file input/output plugins' task source to plugins' cleanup

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
+++ b/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
@@ -16,6 +16,8 @@ import org.embulk.config.TaskSource;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.TaskReport;
 import org.embulk.plugin.PluginType;
+import org.embulk.spi.FileInputRunner;
+import org.embulk.spi.FileOutputRunner;
 import org.embulk.spi.Schema;
 import org.embulk.spi.Exec;
 import org.embulk.spi.ExecSession;
@@ -502,10 +504,24 @@ public class BulkLoader
             }
         }
 
-        plugins.getInputPlugin().cleanup(resume.getInputTaskSource(), resume.getInputSchema(),
+        final TaskSource inputTaskSource;
+        if (plugins.getInputPlugin() instanceof FileInputRunner) {
+            inputTaskSource = FileInputRunner.getFileInputTaskSource(resume.getInputTaskSource());
+        }
+        else {
+            inputTaskSource = resume.getInputTaskSource();
+        }
+        plugins.getInputPlugin().cleanup(inputTaskSource, resume.getInputSchema(),
                 resume.getInputTaskReports().size(), successfulInputTaskReports.build());
 
-        plugins.getOutputPlugin().cleanup(resume.getOutputTaskSource(), resume.getOutputSchema(),
+        final TaskSource outputTaskSource;
+        if (plugins.getOutputPlugin() instanceof FileOutputRunner) {
+            outputTaskSource = FileOutputRunner.getFileOutputTaskSource(resume.getOutputTaskSource());
+        }
+        else {
+            outputTaskSource = resume.getOutputTaskSource();
+        }
+        plugins.getOutputPlugin().cleanup(outputTaskSource, resume.getOutputSchema(),
                 resume.getOutputTaskReports().size(), successfulOutputTaskReports.build());
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
@@ -161,4 +161,9 @@ public class FileInputRunner
             }
         }
     }
+
+    public static TaskSource getFileInputTaskSource(TaskSource runnerTaskSource)
+    {
+        return runnerTaskSource.loadTask(RunnerTask.class).getFileInputTaskSource();
+    }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/FileOutputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileOutputRunner.java
@@ -191,4 +191,9 @@ public class FileOutputRunner
             return tran.commit();
         }
     }
+
+    public static TaskSource getFileOutputTaskSource(TaskSource runnerTaskSource)
+    {
+        return runnerTaskSource.loadTask(RunnerTask.class).getFileOutputTaskSource();
+    }
 }


### PR DESCRIPTION
This PR allows `BulkLoader` to pass file input/output plugins' task source to plugins' `cleanup` method. 0.8.22's `BulkLoader` passes `File Input/Output Runner`s' task source that wrap file input/output plugins' task source defined by the plugins. The behavior doesn't make sense because file input/output plugins should not care of concerns about `Runner` classes directly. 

One concern about this PR is that it breaks backward compatibility of passed task source in `cleanup` method in file input/output plugins but, I think that the PR behavior is more reasonable for the plugins.

This PR fixes https://github.com/embulk/embulk/issues/658. 