### PR TITLE
Skip org.junit.AssumptionViolatedException correctly without wrapping with Embulk's Exceptions.

### DIFF
--- a/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
+++ b/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
@@ -1,6 +1,7 @@
 package org.embulk;
 
 import java.util.Random;
+import org.junit.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import com.google.inject.Injector;
@@ -95,7 +96,17 @@ public class EmbulkTestRuntime
                         }
                     });
                 } catch (RuntimeException ex) {
-                    throw ex.getCause();
+                    Throwable cause = ex;
+                    boolean throwsCause = true;
+                    while (cause != null) {
+                        if (cause instanceof AssumptionViolatedException) {
+                            throwsCause = false;
+                        }
+                        cause = cause.getCause();
+                    }
+                    if (throwsCause) {
+                        throw ex.getCause();
+                    }
                 } finally {
                     exec.cleanup();
                 }


### PR DESCRIPTION
Plugin testing code cannot skip tests with `org.junit.Assume` since `AssumptionViolatedException` is even wrapped with Embulk's internal Exceptions. JUnit cannot recognize `AssumptionViolatedException` to skip correctly because of this wrapping.

@muga Wdyt?