### PR TITLE
Fix "could not find or load main class org.jruby.Main" when run as just "embulk" on Windows.

### DIFF
--- a/embulk-cli/src/main/bat/selfrun.bat
+++ b/embulk-cli/src/main/bat/selfrun.bat
@@ -2,7 +2,10 @@
 
 setlocal
 
+rem Do not use %0 to identify the JAR (bat) file.
+rem %0 is just "embulk" when run by just "> embulk" while %0 is "embulk.bat" when run by "> embulk.bat".
 set this=%~f0
+
 set java_args=
 set jruby_args=
 set default_optimize=
@@ -76,7 +79,7 @@ endlocal && set BUNDLE_GEMFILE=%bundle_gemfile%
 setlocal enabledelayedexpansion
 
 if not defined EMBULK_BUNDLE_PATH (
-    for /f "delims=" %%w in ('java -cp %0 org.jruby.Main -e "print RbConfig::CONFIG['ruby_version']"') do set ruby_version=%%w
+    for /f "delims=" %%w in ('java -cp %this% org.jruby.Main -e "print RbConfig::CONFIG['ruby_version']"') do set ruby_version=%%w
     set gem_home=%USERPROFILE%\.embulk\jruby\!ruby_version!
 ) else (
     set gem_home=


### PR DESCRIPTION
A fix for a problem found on Windows. Can you have a look? @muga 