### PR TITLE
Add ConfigInputPlugin for easier testing.

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/ConfigInputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/ConfigInputPlugin.java
@@ -126,11 +126,13 @@ public class ConfigInputPlugin
                             final JsonNode value = rowValues.get(column.getIndex());
                             if (value == null || value.isNull()) {
                                 pageBuilder.setNull(column);
-                            } else {
+                            }
+                            else {
                                 try {
                                     pageBuilder.setTimestamp(column,
                                                              timestampParsers[column.getIndex()].parse(value.asText()));
-                                } catch (TimestampParseException ex) {
+                                }
+                                catch (TimestampParseException ex) {
                                     throw new DataException(ex);
                                 }
                             }
@@ -141,10 +143,12 @@ public class ConfigInputPlugin
                             final JsonNode value = rowValues.get(column.getIndex());
                             if (value == null || value.isNull()) {
                                 pageBuilder.setNull(column);
-                            } else {
+                            }
+                            else {
                                 try {
                                     pageBuilder.setJson(column, jsonParser.parse(value.toString()));
-                                } catch (JsonParseException ex) {
+                                }
+                                catch (JsonParseException ex) {
                                     throw new DataException(ex);
                                 }
                             }

--- a/embulk-standards/src/main/java/org/embulk/standards/ConfigInputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/ConfigInputPlugin.java
@@ -77,12 +77,9 @@ public class ConfigInputPlugin
         try (final PageBuilder pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)) {
             for (final List<JsonNode> rowValues : taskValues) {
                 schema.visitColumns(new ColumnVisitor() {
-                        private int index = 0;
-
                         public void booleanColumn(Column column)
                         {
-                            final JsonNode value = rowValues.get(index);
-                            ++index;
+                            final JsonNode value = rowValues.get(column.getIndex());
                             if (value == null || value.isNull()) {
                                 pageBuilder.setNull(column);
                             }
@@ -93,8 +90,7 @@ public class ConfigInputPlugin
 
                         public void longColumn(Column column)
                         {
-                            final JsonNode value = rowValues.get(index);
-                            ++index;
+                            final JsonNode value = rowValues.get(column.getIndex());
                             if (value == null || value.isNull()) {
                                 pageBuilder.setNull(column);
                             }
@@ -105,8 +101,7 @@ public class ConfigInputPlugin
 
                         public void doubleColumn(Column column)
                         {
-                            final JsonNode value = rowValues.get(index);
-                            ++index;
+                            final JsonNode value = rowValues.get(column.getIndex());
                             if (value == null || value.isNull()) {
                                 pageBuilder.setNull(column);
                             }
@@ -117,8 +112,7 @@ public class ConfigInputPlugin
 
                         public void stringColumn(Column column)
                         {
-                            final JsonNode value = rowValues.get(index);
-                            ++index;
+                            final JsonNode value = rowValues.get(column.getIndex());
                             if (value == null || value.isNull()) {
                                 pageBuilder.setNull(column);
                             }
@@ -129,8 +123,7 @@ public class ConfigInputPlugin
 
                         public void timestampColumn(Column column)
                         {
-                            final JsonNode value = rowValues.get(index);
-                            ++index;
+                            final JsonNode value = rowValues.get(column.getIndex());
                             if (value == null || value.isNull()) {
                                 pageBuilder.setNull(column);
                             } else {
@@ -145,8 +138,7 @@ public class ConfigInputPlugin
 
                         public void jsonColumn(Column column)
                         {
-                            final JsonNode value = rowValues.get(index);
-                            ++index;
+                            final JsonNode value = rowValues.get(column.getIndex());
                             if (value == null || value.isNull()) {
                                 pageBuilder.setNull(column);
                             } else {

--- a/embulk-standards/src/main/java/org/embulk/standards/ConfigInputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/ConfigInputPlugin.java
@@ -1,0 +1,174 @@
+package org.embulk.standards;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.Task;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.Column;
+import org.embulk.spi.ColumnVisitor;
+import org.embulk.spi.DataException;
+import org.embulk.spi.Exec;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.Schema;
+import org.embulk.spi.SchemaConfig;
+import org.embulk.spi.json.JsonParser;
+import org.embulk.spi.json.JsonParseException;
+import org.embulk.spi.time.TimestampParseException;
+import org.embulk.spi.time.TimestampParser;
+import org.embulk.spi.util.Timestamps;
+
+public class ConfigInputPlugin
+        implements InputPlugin
+{
+    private interface PluginTask
+            extends Task, TimestampParser.Task
+    {
+        @Config("columns")
+        SchemaConfig getSchemaConfig();
+
+        @Config("values")
+        List<List<List<JsonNode>>> getValues();
+    }
+
+    @Override
+    public ConfigDiff transaction(ConfigSource config,
+            InputPlugin.Control control)
+    {
+        final PluginTask task = config.loadConfig(PluginTask.class);
+        final Schema schema = task.getSchemaConfig().toSchema();
+        final List<List<List<JsonNode>>> values = task.getValues();
+        final int taskCount = values.size();
+
+        return resume(task.dump(), schema, taskCount, control);
+    }
+
+    @Override
+    public ConfigDiff resume(TaskSource taskSource,
+            Schema schema, int taskCount,
+            InputPlugin.Control control)
+    {
+        control.run(taskSource, schema, taskCount);
+        return Exec.newConfigDiff();
+    }
+
+    @Override
+    public void cleanup(TaskSource taskSource,
+            Schema schema, int taskCount,
+            List<TaskReport> successTaskReports)
+    {
+    }
+
+    @Override
+    public TaskReport run(TaskSource taskSource,
+            Schema schema, int taskIndex,
+            PageOutput output)
+    {
+        final PluginTask task = taskSource.loadTask(PluginTask.class);
+        final List<List<JsonNode>> taskValues = task.getValues().get(taskIndex);
+        final TimestampParser[] timestampParsers = Timestamps.newTimestampColumnParsers(task, task.getSchemaConfig());
+        final JsonParser jsonParser = new JsonParser();
+
+        try (final PageBuilder pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)) {
+            for (final List<JsonNode> rowValues : taskValues) {
+                schema.visitColumns(new ColumnVisitor() {
+                        private int index = 0;
+
+                        public void booleanColumn(Column column)
+                        {
+                            final JsonNode value = rowValues.get(index);
+                            ++index;
+                            if (value == null || value.isNull()) {
+                                pageBuilder.setNull(column);
+                            }
+                            else {
+                                pageBuilder.setBoolean(column, value.asBoolean());
+                            }
+                        }
+
+                        public void longColumn(Column column)
+                        {
+                            final JsonNode value = rowValues.get(index);
+                            ++index;
+                            if (value == null || value.isNull()) {
+                                pageBuilder.setNull(column);
+                            }
+                            else {
+                                pageBuilder.setLong(column, value.asLong());
+                            }
+                        }
+
+                        public void doubleColumn(Column column)
+                        {
+                            final JsonNode value = rowValues.get(index);
+                            ++index;
+                            if (value == null || value.isNull()) {
+                                pageBuilder.setNull(column);
+                            }
+                            else {
+                                pageBuilder.setDouble(column, value.asDouble());
+                            }
+                        }
+
+                        public void stringColumn(Column column)
+                        {
+                            final JsonNode value = rowValues.get(index);
+                            ++index;
+                            if (value == null || value.isNull()) {
+                                pageBuilder.setNull(column);
+                            }
+                            else {
+                                pageBuilder.setString(column, value.asText());
+                            }
+                        }
+
+                        public void timestampColumn(Column column)
+                        {
+                            final JsonNode value = rowValues.get(index);
+                            ++index;
+                            if (value == null || value.isNull()) {
+                                pageBuilder.setNull(column);
+                            } else {
+                                try {
+                                    pageBuilder.setTimestamp(column,
+                                                             timestampParsers[column.getIndex()].parse(value.asText()));
+                                } catch (TimestampParseException ex) {
+                                    throw new DataException(ex);
+                                }
+                            }
+                        }
+
+                        public void jsonColumn(Column column)
+                        {
+                            final JsonNode value = rowValues.get(index);
+                            ++index;
+                            if (value == null || value.isNull()) {
+                                pageBuilder.setNull(column);
+                            } else {
+                                try {
+                                    pageBuilder.setJson(column, jsonParser.parse(value.toString()));
+                                } catch (JsonParseException ex) {
+                                    throw new DataException(ex);
+                                }
+                            }
+                        }
+                    });
+                pageBuilder.addRecord();
+            }
+            pageBuilder.finish();
+        }
+
+        return Exec.newTaskReport();
+    }
+
+    @Override
+    public ConfigDiff guess(ConfigSource config)
+    {
+        return Exec.newConfigDiff();
+    }
+}

--- a/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
@@ -23,6 +23,7 @@ public class StandardPluginModule
         Preconditions.checkNotNull(binder, "binder is null.");
 
         // input plugins
+        registerPluginTo(binder, InputPlugin.class, "config", ConfigInputPlugin.class);
         registerPluginTo(binder, InputPlugin.class, "file", LocalFileInputPlugin.class);
 
         // parser plugins


### PR DESCRIPTION
When quick-testing in developing the core or plugins (later than input), it is often annoying to set up input. Prepare CSV on a filesystem, confirm the path, ...

An input which does not depend on external resources may help solving the situation. This is it. An input from the Embulk config itself. :)

```
in:
  type:
    name: config
  columns:
  - {name: id, type: long}
  - {name: name, type: string}
  values:
  - - [ 12, "foo" ]
    - [ 24, "bar" ]
  - - [ 98, "hoge" ]
    - [ 21, "fuga" ]
out:
  type: stdout
```

```
2017-06-16 17:34:41.041 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 4 = input tasks 2 * 2
2017-06-16 17:34:41.053 +0900 [INFO] (0001:transaction): {done:  0 / 2, running: 0}
98,hoge
12,foo
21,fuga
24,bar
2017-06-16 17:34:41.130 +0900 [INFO] (0001:transaction): {done:  2 / 2, running: 0}
2017-06-16 17:34:41.130 +0900 [INFO] (0001:transaction): {done:  2 / 2, running: 0}
2017-06-16 17:34:41.138 +0900 [INFO] (main): Committed.
2017-06-16 17:34:41.138 +0900 [INFO] (main): Next config diff: {"in":{},"out":{}}
```