### PR TITLE
Relocate recently-added dependency packages in shadowJar Embulk distribution.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,6 +227,18 @@ project(':embulk-cli') {
     apply plugin: 'com.github.johnrengelman.shadow'
 
     shadowJar {
+        // 'org.apache.maven' is used in:
+        // - embulk-cli: EmbulkMigrate and EmbulkSelfUpdate (from v0.8.17)
+        // - embulk-core: MavenPluginSource and the related (from v0.8.26)
+        relocate 'org.apache.maven', 'org.embulk.third_party.org.apache.maven'
+
+        // 'org.codehaus.plexus' is used from 'org.apache.maven'.
+        relocate 'org.codehaus.plexus', 'org.embulk.third_party.org.codehaus.plexus'
+
+        // 'org.eclipse.aether' is used in:
+        // - embulk-core: MavenPluginSource and the related (from v0.8.26)
+        relocate 'org.eclipse.aether', 'org.embulk.third_party.org.eclipse.aether'
+
         // NOTE: This 'Implementation-Version' in the manifest is referred to provide the Embulk version at runtime.
         // See also: embulk-core/src/main/java/org/embulk/EmbulkVersion.java
         manifest {


### PR DESCRIPTION
@muga To reduce future risks of dependency conflicts between the core and plugins like #640, this PR tries relocating embedded dependency packages. Can you have a look?

For example, `org.apache.maven*` is relocated to `org.embulk.third_party.org.apache.maven*` in embulk-0.8.XX.jar. All references to these classes are automatically relocated as well.

It's based on the relocation feature in the Gradle Shadow Plugin:
http://imperceptiblethoughts.com/shadow/#relocating_packages