### PR TITLE
Fix the "migrate" subcommand to handle build.gradle correctly

### DIFF
--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableList;
 
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 public class EmbulkMigrate
 {
     public void migratePlugin(final String pathInString, final String thisEmbulkVersion)
@@ -236,7 +238,8 @@ public class EmbulkMigrate
         {
             Path destinationPath = this.basePath.resolve(destinationFileName);
             Files.createDirectories(destinationPath.getParent());
-            Files.copy(EmbulkMigrate.class.getClassLoader().getResourceAsStream(sourceResourcePath), destinationPath);
+            Files.copy(EmbulkMigrate.class.getClassLoader().getResourceAsStream(sourceResourcePath), destinationPath,REPLACE_EXISTING);
+            this.modifiedFiles.add(destinationPath);
         }
 
         public boolean match(String filePath, Pattern pattern)
@@ -424,7 +427,7 @@ public class EmbulkMigrate
     private static final Pattern OLD_EMBULK_IN_GEMSPEC = Pattern.compile(
         "embulk-");
     private static final Pattern GRADLE_VERSION_IN_WRAPPER = Pattern.compile(
-        "gradle-[23]\\.\\d+(\\.\\d+)?-/");
+        "gradle-[23]\\.\\d+(\\.\\d+)?-");
     private static final Pattern JSON_COLUMN_METHOD_IN_ALL_JAVA = Pattern.compile(
         "void\\s+jsonColumn");
     private static final Pattern TIMESTAMP_COLUMN_METHOD_IN_ALL_JAVA = Pattern.compile(

--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -24,8 +25,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
 import org.apache.maven.artifact.versioning.ComparableVersion;
-
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class EmbulkMigrate
 {
@@ -238,7 +237,7 @@ public class EmbulkMigrate
         {
             Path destinationPath = this.basePath.resolve(destinationFileName);
             Files.createDirectories(destinationPath.getParent());
-            Files.copy(EmbulkMigrate.class.getClassLoader().getResourceAsStream(sourceResourcePath), destinationPath,REPLACE_EXISTING);
+            Files.copy(EmbulkMigrate.class.getClassLoader().getResourceAsStream(sourceResourcePath), destinationPath, StandardCopyOption.REPLACE_EXISTING);
             this.modifiedFiles.add(destinationPath);
         }
 

--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
@@ -237,7 +237,8 @@ public class EmbulkMigrate
         {
             Path destinationPath = this.basePath.resolve(destinationFileName);
             Files.createDirectories(destinationPath.getParent());
-            Files.copy(EmbulkMigrate.class.getClassLoader().getResourceAsStream(sourceResourcePath), destinationPath, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(EmbulkMigrate.class.getClassLoader().getResourceAsStream(sourceResourcePath), destinationPath,
+                    StandardCopyOption.REPLACE_EXISTING);
             this.modifiedFiles.add(destinationPath);
         }
 


### PR DESCRIPTION
Fix #699 @dmikurube Please take a look when you can.

Un-JRuby embulk migrate replace files properly.

* Fix GRADLE_VERSION_IN_WRAPPER matching pattern.
  * Remove trailing character '/'.
  * The version strings is `gradle-2.12-bin.zip`
* Avoid `FileAlreadyExistsException`.
  * Throw that exception if the file exists.
* Add files into modifiedFiles.
  * For output the following message.
  * `Done. Please check modifieid files.`


By the way, I found typo (not fixed yet this PR)
* modifieid -> modified