### PR TITLE
Release v0.8.26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ def release_projects = [project(":embulk-core"), project(":embulk-standards"), p
 
 allprojects {
     group = 'org.embulk'
-    version = '0.8.25'
+    version = '0.8.26'
 
     ext {
         jrubyVersion = '9.1.5.0'

--- a/embulk-docs/src/release.rst
+++ b/embulk-docs/src/release.rst
@@ -4,6 +4,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.8.26
     release/release-0.8.25
     release/release-0.8.24
     release/release-0.8.23

--- a/embulk-docs/src/release/release-0.8.26.rst
+++ b/embulk-docs/src/release/release-0.8.26.rst
@@ -1,0 +1,16 @@
+Release 0.8.26
+==================================
+
+General Changes
+------------------
+
+* Add ConfigInputPlugin for easier testing [#678]
+* Add MavenPluginSource to load JAR-based plugins into Embulk [#686] [#687] [#684] [#701]
+* Fix the "migrate" subcommand to handle build.gradle correctly [#702] [#703]
+* Fix parent_first_{packages,resources}.properties to delegate msgpack class loading to parent [#694]
+* Fix documents [#683] [#685]
+
+
+Release Date
+------------------
+2017-07-01

--- a/lib/embulk/version.rb
+++ b/lib/embulk/version.rb
@@ -3,7 +3,7 @@
 module Embulk
   @@warned = false
 
-  VERSION_INTERNAL = '0.8.25'
+  VERSION_INTERNAL = '0.8.26'
 
   DEPRECATED_MESSAGE = 'Embulk::VERSION in (J)Ruby is deprecated. Use org.embulk.EmbulkVersion::VERSION instead. If this message is from a plugin, please tell this to the author of the plugin!'
   def self.const_missing(name)


### PR DESCRIPTION
@muga If you're fine with the spec of `MavenPluginSource` (incl. `classifier` and a consensus about plugin's artifact names), I'll be releasing v0.8.26 soon. What do you think?

I'll be merging #685, #702 and #703 as well.