### PR TITLE
Use JRuby's ScriptingContainer for bootstrap instead of org.jruby.Main.main

### DIFF
--- a/embulk-cli/src/main/java/org/embulk/cli/Main.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/Main.java
@@ -1,37 +1,84 @@
 package org.embulk.cli;
 
-import java.net.URISyntaxException;
+import java.util.ArrayList;
+import org.jruby.RubyInstanceConfig;
+import org.jruby.embed.LocalContextScope;
+import org.jruby.embed.PathType;
+import org.jruby.embed.ScriptingContainer;
+import org.jruby.util.cli.Options;
 
 public class Main
 {
-    public static void main(String[] args)
+    public static void main(final String[] args)
     {
-        // $ java -jar jruby-complete.jar embulk-core.jar!/embulk/command/embulk_bundle.rb "$@"
-        String[] jrubyArgs = new String[args.length + 1];
+        final ArrayList<String> jrubyOptions = new ArrayList<String>();
+
         int i;
-        for (i = 0; i < args.length; i++) {
+        for (i = 0; i < args.length; ++i) {
             if (args[i].startsWith("-R")) {
-                jrubyArgs[i] = args[i].substring(2);
+                jrubyOptions.add(args[i].substring(2));
             } else {
                 break;
             }
         }
-        jrubyArgs[i] = getScriptPath();
-        for (; i < args.length; i++) {
-            jrubyArgs[i+1] = args[i];
+
+        final String[] embulkArgs = new String[args.length - i];
+        for (int j = 0; i < args.length; ++i, ++j) {
+            embulkArgs[j] = args[i];
         }
-        org.jruby.Main.main(jrubyArgs);
+
+        // Running embulk/command/embulk_bundle.rb in CLASSPATH (in the JAR file)
+        final ScriptingContainer jrubyGlobalContainer = new ScriptingContainer(LocalContextScope.SINGLETON);
+        final RubyInstanceConfig jrubyGlobalConfig = jrubyGlobalContainer.getProvider().getRubyInstanceConfig();
+
+        for (final String jrubyOption : jrubyOptions) {
+            try {
+                processJRubyOption(jrubyOption, jrubyGlobalConfig);
+            }
+            catch (UnrecognizedJRubyOptionException ex) {
+                System.err.println("[WARN] The \"-R\" option(s) are not recognized in Embulk: -R" + jrubyOption);
+                System.err.println("[WARN] Please add your requests at: https://github.com/embulk/embulk/issues/707");
+                System.err.println("");
+            }
+            catch (NotWorkingJRubyOptionException ex) {
+                System.err.println("[WARN] The \"-R\" option(s) do not work in Embulk: -R" + jrubyOption);
+                System.err.println("");
+            }
+        }
+
+        jrubyGlobalContainer.setArgv(embulkArgs);
+        jrubyGlobalContainer.runScriptlet(PathType.CLASSPATH, "embulk/command/embulk_bundle.rb");
     }
 
-    private static String getScriptPath()
+    private static final class UnrecognizedJRubyOptionException extends Exception {}
+    private static final class NotWorkingJRubyOptionException extends Exception {}
+
+    private static void processJRubyOption(final String jrubyOption, final RubyInstanceConfig jrubyGlobalConfig)
+            throws UnrecognizedJRubyOptionException, NotWorkingJRubyOptionException
     {
-        String resourcePath;
-        try {
-            resourcePath = Main.class.getProtectionDomain().getCodeSource().getLocation().toURI().toString() + "!/";
+        if (jrubyOption.charAt(0) != '-') {
+            throw new UnrecognizedJRubyOptionException();
         }
-        catch (URISyntaxException ex) {
-            resourcePath = "uri:classloader:/";
+
+        for (int index = 1; index < jrubyOption.length(); ++index) {
+            switch (jrubyOption.charAt(index)) {
+            case '-':
+                if (jrubyOption.equals("--dev")) {
+                    // They are not all of "--dev", but they are most possible configurations after JVM boot.
+                    Options.COMPILE_INVOKEDYNAMIC.force("false");  // NOTE: Options is global.
+                    jrubyGlobalConfig.setCompileMode(RubyInstanceConfig.CompileMode.OFF);
+                    return;
+                }
+                else if (jrubyOption.equals("--client")) {
+                    throw new NotWorkingJRubyOptionException();
+                }
+                else if (jrubyOption.equals("--server")) {
+                    throw new NotWorkingJRubyOptionException();
+                }
+                throw new UnrecognizedJRubyOptionException();
+            default:
+                throw new UnrecognizedJRubyOptionException();
+            }
         }
-        return resourcePath + "embulk/command/embulk_bundle.rb";
     }
 }


### PR DESCRIPTION
@muga Can you have a look? Details are in #707.

### Context

Embulk is calling org.jruby.Main.main in org.embulk.cli.Main. It is not very good in terms of JRuby's suggestion and JRuby environment isolation -- which "JRuby instance" does `org.jruby.Main.main` use?

In the process of un-JRuby-ing, let's replace it with `ScriptingContainer` which is the standard way to call JRuby embedded from Java.