### PR TITLE
Add a method in EmbulkMigrate to set executable permissions into plugin's "gradlew"

### DIFF
--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
@@ -13,6 +13,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -408,6 +409,18 @@ public class EmbulkMigrate
             catch (NoSuchFileException ex) {
                 return new byte[0];
             }
+        }
+
+        private void setExecutable(String targetFileName)
+                throws IOException
+        {
+            final Path targetPath = this.basePath.resolve(targetFileName);
+            final Set<PosixFilePermission> permissions =
+                    new HashSet<PosixFilePermission>(Files.getPosixFilePermissions(targetPath));
+            permissions.add(PosixFilePermission.OWNER_EXECUTE);
+            permissions.add(PosixFilePermission.GROUP_EXECUTE);
+            permissions.add(PosixFilePermission.OTHERS_EXECUTE);
+            Files.setPosixFilePermissions(targetPath, permissions);
         }
 
         private final Path basePath;


### PR DESCRIPTION
* This PR split #698 PR into three PRs.
* This PR is (1/3)

I want to add executable permission to `gradlew` file. 
That's why I add `setExecutable` method. 

I'll create another PRs later. Both depend on this PR.
* (2/3) https://github.com/hiroyuki-sato/embulk/tree/update_gradle_4_0
* (3/3) https://github.com/hiroyuki-sato/embulk/tree/task_left_shift_deprecated_caution