### PR TITLE
Test with maxHeapSize=2048m

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,8 @@ allprojects {
     apply plugin: 'com.jfrog.bintray'
 
     test {
-        maxHeapSize = "1536m"
+        // TODO: Reduce the size back some day...
+        maxHeapSize = "2048m"
     }
 
     //


### PR DESCRIPTION
AppVeyor tests are really frequently failing by Java heap size error. It's not a "solution", but let's get `maxHeapSize` up...

Can you have a look, @muga?