### PR TITLE
Test StrptimeParser and RubyDateParser

### DIFF
--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -5,7 +5,21 @@ test_dir = File.join(base_dir, "test")
 $LOAD_PATH.unshift(lib_dir)
 $LOAD_PATH.unshift(test_dir)
 
+require "date"
 require "test/unit"
+
+module DateExt
+  def self.included base
+    base.instance_eval do
+      def _strptime(str, fmt='%F')
+        parser = org.embulk.spi.time.RubyDateParser.new
+        map = parser.parse(JRuby.runtime.current_context, fmt, str)
+        return map.nil? ? nil : map.to_hash.inject({}){|hash,(k,v)| hash[k.to_sym] = v; hash}
+      end
+    end
+  end
+end
+Date.send(:include, DateExt)
 
 Dir.glob("#{base_dir}/test/**/test{_,-}*.rb") do |file|
   require file.sub(/\.rb$/,"")


### PR DESCRIPTION
This PR changes test/run-test.rb to use https://github.com/embulk/embulk/pull/611's StrptimeParser and RubyDateParser in ruby tests. 