### PR TITLE
Release v0.8.27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ def release_projects = [project(":embulk-core"), project(":embulk-standards"), p
 
 allprojects {
     group = 'org.embulk'
-    version = '0.8.26'
+    version = '0.8.27'
 
     ext {
         jrubyVersion = '9.1.5.0'

--- a/embulk-docs/src/release.rst
+++ b/embulk-docs/src/release.rst
@@ -4,6 +4,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.8.27
     release/release-0.8.26
     release/release-0.8.25
     release/release-0.8.24

--- a/embulk-docs/src/release/release-0.8.27.rst
+++ b/embulk-docs/src/release/release-0.8.27.rst
@@ -1,0 +1,13 @@
+Release 0.8.27
+==================================
+
+General Changes
+------------------
+
+* Add Java timestamp parser [#611]
+* Add the test for the timestamp parser [#712]
+
+
+Release Date
+------------------
+2017-07-08

--- a/lib/embulk/version.rb
+++ b/lib/embulk/version.rb
@@ -3,7 +3,7 @@
 module Embulk
   @@warned = false
 
-  VERSION_INTERNAL = '0.8.26'
+  VERSION_INTERNAL = '0.8.27'
 
   DEPRECATED_MESSAGE = 'Embulk::VERSION in (J)Ruby is deprecated. Use org.embulk.EmbulkVersion::VERSION instead. If this message is from a plugin, please tell this to the author of the plugin!'
   def self.const_missing(name)


### PR DESCRIPTION
This PR prepares 0.8.27. 

- [x] Add Java timestamp parser and RubyDateParser [#611]
- [x] Add the test for Java timestamp parser and RubyDateParser [#712]
