### PR TITLE
Travis tests in parallel to speed up Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: false
 install:
   - pip install --user sphinx
 script:
-  - ./gradlew --info $GRADLE_TASK
+  - ./gradlew --info $GRADLE_TASK # each Travis process configures GRADLE_TASK by env.matrix
 after_success:
   - PATH="$HOME/.local/bin:$PATH" ./embulk-docs/push-gh-pages.sh
 env:
@@ -16,6 +16,9 @@ env:
     - GIT_USER_NAME=travis
     - GIT_USER_EMAIL=travis@embulk.org
     - secure: K5qT2PcCP/40dNW+1H4NZ6y1+GAZbyP/lMQ1tSMsAICGkMQ/A+Mp5wtnIGIsAf6JGcJ1PvpCoLE1V6wKFL5fEwxi4SRcTnZTh9PkeAk8dgezOMoX4EqeZiQAYv4MM2zKL+Gr6QivjmRA7I5jrZCo8JyaA5XfQ7ygjICKNJy8NaE=
+  # To speed up the Travis build, the build can be broken up into several parts by env.matrix.
+  # They'll run in parallel. Each Travis process set environment variables declared in each
+  # env.matrix like GRADLE_TASK. See: https://docs.travis-ci.com/user/speeding-up-the-build/
   matrix:
     - GRADLE_TASK=':embulk-core:check'
     - GRADLE_TASK=':embulk-standards:check'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: false
 install:
   - pip install --user sphinx
 script:
-  - ./gradlew --info check rubyTest
+  - ./gradlew --info $GRADLE_TASK
 after_success:
   - PATH="$HOME/.local/bin:$PATH" ./embulk-docs/push-gh-pages.sh
 env:
@@ -16,3 +16,10 @@ env:
     - GIT_USER_NAME=travis
     - GIT_USER_EMAIL=travis@embulk.org
     - secure: K5qT2PcCP/40dNW+1H4NZ6y1+GAZbyP/lMQ1tSMsAICGkMQ/A+Mp5wtnIGIsAf6JGcJ1PvpCoLE1V6wKFL5fEwxi4SRcTnZTh9PkeAk8dgezOMoX4EqeZiQAYv4MM2zKL+Gr6QivjmRA7I5jrZCo8JyaA5XfQ7ygjICKNJy8NaE=
+  matrix:
+    - GRADLE_TASK=':embulk-core:check'
+    - GRADLE_TASK=':embulk-standards:check'
+    - GRADLE_TASK=':embulk-jruby-strptime:check'
+    - GRADLE_TASK=':embulk-test:check'
+    - GRADLE_TASK=':embulk-cli:check'
+    - GRADLE_TASK='rubyTest'


### PR DESCRIPTION
This PR changes .travis.yml to execute sub-projects' tests in parallel on Travis CI. Each matrix row settings will be executed on Travis multiple VMs.

- This PR assumes https://github.com/embulk/embulk/pull/714.
- reference: https://docs.travis-ci.com/user/speeding-up-the-build/