### PR TITLE
Cache 'gradle' and '.m2' directories to speed up Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: false
 install:
   - pip install --user sphinx
 script:
-  - ./gradlew --info check rubyTest
+  - ./gradlew --info $GRADLE_TASK
 after_success:
   - PATH="$HOME/.local/bin:$PATH" ./embulk-docs/push-gh-pages.sh
 env:
@@ -16,3 +16,10 @@ env:
     - GIT_USER_NAME=travis
     - GIT_USER_EMAIL=travis@embulk.org
     - secure: K5qT2PcCP/40dNW+1H4NZ6y1+GAZbyP/lMQ1tSMsAICGkMQ/A+Mp5wtnIGIsAf6JGcJ1PvpCoLE1V6wKFL5fEwxi4SRcTnZTh9PkeAk8dgezOMoX4EqeZiQAYv4MM2zKL+Gr6QivjmRA7I5jrZCo8JyaA5XfQ7ygjICKNJy8NaE=
+  matrix:
+    - GRADLE_TASK=':embulk-core:check'
+    - GRADLE_TASK=':embulk-standards:check'
+    - GRADLE_TASK=':embulk-jruby-strptime:check'
+    - GRADLE_TASK=':embulk-test:check'
+    - GRADLE_TASK=':embulk-cli:check'
+    - GRADLE_TASK='rubyTest'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ jdk:
 cache:
   directories:  # run "travis cache --delete" to delete caches
     - $HOME/.gradle
+    - $HOME/gradle
+    - $HOME/.m2
 sudo: false
 install:
   - pip install --user sphinx

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ allprojects {
 
     test {
         maxHeapSize = "1536m"
+        forkEvery = 1 // test processes are forked by each test class (default is 0)
     }
 
     //


### PR DESCRIPTION
This PR enables Travis to cache 'gradle' and '.m2' directries. Since Embulk requires many dependency libraries, It takes a few mins to download their artifacts from Maven repo to '.m2' directory.

- This PR assumes https://github.com/embulk/embulk/pull/716. 
- reference: https://docs.travis-ci.com/user/speeding-up-the-build/