### PR TITLE
Make selfrun scripts not to run JRuby to get ruby_version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,17 +210,26 @@ task classpath(dependsOn: ['build', ':embulk-cli:classpath']) { doLast {} }
 clean { delete 'classpath' }
 
 //
+// Gets RbConfig::CONFIG['ruby_version'] from the same version of JRuby with Embulk's embedded.
+//
+task retrieveRubyVersion(type: JRubyExec) {
+    standardOutput = new ByteArrayOutputStream()
+    jrubyArgs '-e', "print RbConfig::CONFIG['ruby_version']"
+}
+
+//
 // cli task
 //
-task cli(dependsOn: ':embulk-cli:shadowJar') {
+task cli(dependsOn: ['retrieveRubyVersion', ':embulk-cli:shadowJar']) {
     doLast {
+        def rubyVersion = retrieveRubyVersion.standardOutput.toString().trim()
         file('pkg').mkdirs()
         File f = file("pkg/embulk-${project.version}.jar")
         f.write("")
         f.append("\n: <<END_OF_EMBULK_SELFRUN_BATCH_PART\r\n")
-        f.append(file("embulk-cli/src/main/bat/selfrun.bat").readBytes())
+        f.append(file("embulk-cli/src/main/bat/selfrun.bat.template").getText().replace("<%= ruby_version %>", rubyVersion))
         f.append("\r\nEND_OF_EMBULK_SELFRUN_BATCH_PART\r\n\n")
-        f.append(file("embulk-cli/src/main/sh/selfrun.sh").readBytes())
+        f.append(file("embulk-cli/src/main/sh/selfrun.sh.template").getText().replace("<%= ruby_version %>", rubyVersion))
         f.append(file("embulk-cli/build/libs/embulk-cli-${project.version}-all.jar").readBytes())
         f.setExecutable(true)
     }

--- a/embulk-cli/src/main/bat/selfrun.bat.template
+++ b/embulk-cli/src/main/bat/selfrun.bat.template
@@ -79,8 +79,7 @@ endlocal && set BUNDLE_GEMFILE=%bundle_gemfile%
 setlocal enabledelayedexpansion
 
 if not defined EMBULK_BUNDLE_PATH (
-    for /f "delims=" %%w in ('java -cp %this% org.jruby.Main -e "print RbConfig::CONFIG['ruby_version']"') do set ruby_version=%%w
-    set gem_home=%USERPROFILE%\.embulk\jruby\!ruby_version!
+    set gem_home=%USERPROFILE%\.embulk\jruby\<%= ruby_version %>
 ) else (
     set gem_home=
 )

--- a/embulk-cli/src/main/sh/selfrun.sh.template
+++ b/embulk-cli/src/main/sh/selfrun.sh.template
@@ -64,7 +64,7 @@ done
 if test -z ${EMBULK_BUNDLE_PATH}; then
     unset EMBULK_BUNDLE_PATH
     unset BUNDLE_GEMFILE
-    GEM_HOME="`cd && pwd`/.embulk/jruby/`java -cp $0 org.jruby.Main -e 'print RbConfig::CONFIG["ruby_version"]'`"
+    GEM_HOME="`cd && pwd`/.embulk/jruby/<%= ruby_version %>"
     export GEM_HOME
     GEM_PATH=""
     export GEM_PATH

--- a/embulk-cli/src/test/java/org/embulk/cli/SelfrunTest.java
+++ b/embulk-cli/src/test/java/org/embulk/cli/SelfrunTest.java
@@ -40,7 +40,11 @@ public class SelfrunTest {
             .replaceAll("java ",
                         "java -classpath "
                         + classpath.getAbsolutePath().replaceAll("\\\\", "\\\\\\\\")
-                        + " org.embulk.cli.DummyMain ");
+                        + " org.embulk.cli.DummyMain ")
+            // The following version string emulates RbConfig::CONFIG["ruby_version"].
+            // RbConfig::CONFIG["ruby_version"] is different from org.jruby.runtime.Constants.RUBY_VERSION.
+            // https://github.com/jruby/jruby/blob/9.1.5.0/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java#L229-L235
+            .replace("<%= ruby_version %>", org.jruby.runtime.Constants.RUBY_MAJOR_VERSION + ".0");
 
         // Modify selfrun so that arguments are written in 'args.txt' .
         Files.write(fileSystem.getPath(testSelfrunFile.getAbsolutePath()),
@@ -288,9 +292,9 @@ public class SelfrunTest {
             folder = new File(folder, "embulk-cli");
         }
         if (System.getProperty("file.separator").equals("\\")) {
-            return new File(new File(new File(new File(folder, "src"), "main"), "bat"), "selfrun.bat");
+            return new File(new File(new File(new File(folder, "src"), "main"), "bat"), "selfrun.bat.template");
         } else {
-            return new File(new File(new File(new File(folder, "src"), "main"), "sh"), "selfrun.sh");
+            return new File(new File(new File(new File(folder, "src"), "main"), "sh"), "selfrun.sh.template");
         }
     }
 }


### PR DESCRIPTION
@muga Can you have a look?

### Context:

Selfrun scripts run JRuby to get its `ruby_version` since #604. Although the change was made successfully, it needed JRuby to run everytime within selfrun scripts. It made the bootstrap slower.

This PR tries solving the problem by getting `ruby_version` and filling the version in building the jar file.