### PR TITLE
Fix Javadoc in PluginClassLoader to avoid Javadoc error by Oracle Java8

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
@@ -49,7 +49,7 @@ public class PluginClassLoader
      *
      * Some plugins (embulk-input-jdbc, for example) are calling this method to load external JAR files.
      *
-     * @see https://github.com/embulk/embulk-input-jdbc/blob/ebfff0b249d507fc730c87e08b56e6aa492060ca/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java#L586-L595
+     * @see <a href="https://github.com/embulk/embulk-input-jdbc/blob/ebfff0b249d507fc730c87e08b56e6aa492060ca/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java#L586-L595">embulk-input-jdbc</a>
      */
     public void addPath(Path path)
     {
@@ -84,8 +84,8 @@ public class PluginClassLoader
      *
      * If the specified class is "NOT parent-first", the 2nd and 3rd actions are swapped.
      *
-     * @see https://docs.oracle.com/javase/7/docs/api/java/lang/ClassLoader.html#loadClass(java.lang.String,%20boolean)
-     * @see http://hg.openjdk.java.net/jdk7u/jdk7u/jdk/file/jdk7u141-b02/src/share/classes/java/lang/ClassLoader.java
+     * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/lang/ClassLoader.html#loadClass(java.lang.String,%20boolean)">Oracle Java7's ClassLoader#loadClass</a>
+     * @see <a href="http://hg.openjdk.java.net/jdk7u/jdk7u/jdk/file/jdk7u141-b02/src/share/classes/java/lang/ClassLoader.java">OpenJDK7's ClassLoader</a>
      */
     @Override
     protected Class<?> loadClass(String name, boolean resolve)


### PR DESCRIPTION
This PR fixes Javadoc comments in `PluginClassLoader` to avoid Javadoc error by Oracle Java8. Because Travis CI uses Oracle java8 so, it cannot generate Embulk's Javadoc documents by the following Javadoc error. I think, that might be why embulk.org is not updated.
https://github.com/embulk/embulk/compare/v0.8.25...v0.8.26

```
embulk/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java:87: error: unexpected text
     * @see https://docs.oracle.com/javase/7/docs/api/java/lang/ClassLoader.html#loadClass(java.lang.String,%20boolean)
       ^
embulk/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java:88: error: unexpected text
     * @see http://hg.openjdk.java.net/jdk7u/jdk7u/jdk/file/jdk7u141-b02/src/share/classes/java/lang/ClassLoader.java
       ^
```