### PR TITLE
Pass Embulk's version from JRuby (bin/embulk) for Java EmbulkBundle.

### DIFF
--- a/bin/embulk
+++ b/bin/embulk
@@ -44,7 +44,10 @@ if RUBY_PLATFORM =~ /java/i
       ENV.delete('BUNDLE_GEMFILE')
     end
 
-    Java::org.embulk.cli.EmbulkBundle::checkBundle(ARGV, Java::JavaUtil::ArrayList.new)
+    require 'embulk/version'
+    Java::org.embulk.cli.EmbulkBundle::checkBundleWithEmbulkVersion(ARGV,
+                                                                    Java::JavaUtil::ArrayList.new,
+                                                                    Embulk::VERSION_INTERNAL)
   else
     # bin/embulk is started by JRuby (embulk gem for JRuby is installed).
     # Bundler must be disabled in this path not to bother the JRuby's bundler.

--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkBundle.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkBundle.java
@@ -8,7 +8,18 @@ import org.jruby.embed.ScriptingContainer;
 
 public class EmbulkBundle
 {
-    public static void checkBundle(final String[] embulkArgs, final List<String> jrubyOptions)
+    public static void checkBundle(
+            final String[] embulkArgs,
+            final List<String> jrubyOptions)
+    {
+        checkBundleWithEmbulkVersion(embulkArgs, jrubyOptions, EmbulkVersion.VERSION);
+    }
+
+    // It accepts |embulkVersion| so that it can receive Embulk's version from Ruby (bin/embulk).
+    public static void checkBundleWithEmbulkVersion(
+            final String[] embulkArgs,
+            final List<String> jrubyOptions,
+            final String embulkVersion)
     {
         final String bundlePath = System.getenv("EMBULK_BUNDLE_PATH");
 
@@ -27,7 +38,7 @@ public class EmbulkBundle
         //   require 'embulk/command/embulk_main'
         //
         // TODO: Consider handling LoadError or similar errors.
-        final EmbulkRun runner = new EmbulkRun(EmbulkVersion.VERSION, globalJRubyContainer);
+        final EmbulkRun runner = new EmbulkRun(embulkVersion, globalJRubyContainer);
         runner.run(removeBundleOption(embulkArgs), jrubyOptions);
     }
 


### PR DESCRIPTION
@muga Embulk's version was not passed well to Java `EmbulkBundle` when started from `bin/embulk` (embulk.gem) through CRuby. Can you have a look?