### PR TITLE
Update JRuby to 9.1.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ allprojects {
     version = '0.8.27'
 
     ext {
-        jrubyVersion = '9.1.5.0'
+        jrubyVersion = '9.1.12.0'
     }
 
     apply plugin: 'java'


### PR DESCRIPTION
@muga Can you test JRuby 9.1.11 or newer when you can?

Some users want to use Digdag server with Embulk & Liquid. 
However, It doesn't work correctly. 
The root cause is #586

Digdag server uses a working directory name which starts `+` character. 
(ex: `+sample+cwd_5526548746336894942`)
https://github.com/treasure-data/digdag/issues/586

For fix #586, It requires update Liquid and JRuby
(See detail #637). 

This PR update JRuby.

* [9.1.12.0](http://jruby.org/2017/06/15/jruby-9-1-12-0.html)
* [9.1.11.0](http://jruby.org/2017/06/14/jruby-9-1-11-0.html)
* [9.1.10.0](http://jruby.org/2017/05/25/jruby-9-1-10-0.html)
* [9.1.9.0](http://jruby.org/2017/05/16/jruby-9-1-9-0.html)
* [9.1.8.0](http://jruby.org/2017/03/06/jruby-9-1-8-0.html)
* [9.1.7.0](http://jruby.org/2017/01/11/jruby-9-1-7-0.html)
* [9.1.6.0](http://jruby.org/2016/11/09/jruby-9-1-6-0.html)

### Ref

Tweet from Digdag and Embulk user. (written in Japanese)

* [Twitter](https://twitter.com/huntinggirled/status/887549321767301120)