### PR TITLE
Release v0.8.28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ def release_projects = [project(":embulk-core"), project(":embulk-standards"), p
 
 allprojects {
     group = 'org.embulk'
-    version = '0.8.27'
+    version = '0.8.28'
 
     ext {
         jrubyVersion = '9.1.5.0'

--- a/embulk-docs/src/release.rst
+++ b/embulk-docs/src/release.rst
@@ -4,6 +4,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.8.28
     release/release-0.8.27
     release/release-0.8.26
     release/release-0.8.25

--- a/embulk-docs/src/release/release-0.8.28.rst
+++ b/embulk-docs/src/release/release-0.8.28.rst
@@ -1,0 +1,14 @@
+Release 0.8.28
+==================================
+
+General Changes
+------------------
+
+* Make selfrun scripts not to run JRuby to get ruby_version. [#721]
+* Un-JRuby the bootstrap. [#706] [#708] [#543] [#725] [#726] [#727] [#729] [#731]
+* Fix the "migrate" subcommand. [#732]
+* Improve building. [#716] [#724] [#728]
+
+Release Date
+------------------
+2017-07-25

--- a/embulk-docs/src/release/release-0.8.28.rst
+++ b/embulk-docs/src/release/release-0.8.28.rst
@@ -5,7 +5,7 @@ General Changes
 ------------------
 
 * Make selfrun scripts not to run JRuby to get ruby_version. [#721]
-* Un-JRuby the bootstrap. [#706] [#708] [#543] [#725] [#726] [#727] [#729] [#731]
+* Un-JRuby the bootstrap. [#706] [#708] [#543] [#725] [#726] [#727] [#729] [#731] [#741] [#742]
 * Fix the "migrate" subcommand. [#732]
 * Improve building. [#716] [#724] [#728]
 

--- a/lib/embulk/version.rb
+++ b/lib/embulk/version.rb
@@ -3,7 +3,7 @@
 module Embulk
   @@warned = false
 
-  VERSION_INTERNAL = '0.8.27'
+  VERSION_INTERNAL = '0.8.28'
 
   DEPRECATED_MESSAGE = 'Embulk::VERSION in (J)Ruby is deprecated. Use org.embulk.EmbulkVersion::VERSION instead. If this message is from a plugin, please tell this to the author of the plugin!'
   def self.const_missing(name)


### PR DESCRIPTION
@muga As mentioned in #731, v0.8.28 will be released after that. Can you have a look?