### PR TITLE
Keep the "-b" or "--bundle" option in the argument list.

### DIFF
--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkArguments.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkArguments.java
@@ -22,6 +22,9 @@ public class EmbulkArguments
             if (subcommand == null && (!argument.startsWith("-"))) {
                 subcommand = EmbulkSubcommand.of(argument);
             }
+            else if (subcommand == null && (argument.equals("-b") || argument.equals("--bundle"))) {
+                throw new EmbulkCommandLineException("\"-b\" or \"--bundle\" before a subcommand is not supported.");
+            }
             else if (argument.equals("-version")) {
                 return new EmbulkArguments(EmbulkSubcommand.VERSION_ERR, new ArrayList<String>());
             }

--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkBundle.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkBundle.java
@@ -1,6 +1,6 @@
 package org.embulk.cli;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.embulk.EmbulkVersion;
@@ -39,25 +39,6 @@ public class EmbulkBundle
         //
         // TODO: Consider handling LoadError or similar errors.
         final EmbulkRun runner = new EmbulkRun(embulkVersion, globalJRubyContainer);
-        runner.run(removeBundleOption(embulkArgs), jrubyOptions);
-    }
-
-    private static List<String> removeBundleOption(final String[] args)
-    {
-        final ArrayList<String> removed = new ArrayList<String>();
-
-        int status = 0;
-        for (final String arg : args) {
-            if (status == 0 && (arg.equals("-b") || arg.equals("--bundle"))) {
-                status = 1;
-            }
-            else if (status == 1) {
-                status = 2;
-            }
-            else {
-                removed.add(arg);
-            }
-        }
-        return Collections.unmodifiableList(removed);
+        runner.run(Arrays.asList(embulkArgs), jrubyOptions);
     }
 }

--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkBundle.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkBundle.java
@@ -39,6 +39,6 @@ public class EmbulkBundle
         //
         // TODO: Consider handling LoadError or similar errors.
         final EmbulkRun runner = new EmbulkRun(embulkVersion, globalJRubyContainer);
-        runner.run(Arrays.asList(embulkArgs), jrubyOptions);
+        runner.run(Collections.unmodifiableList(Arrays.asList(embulkArgs)), jrubyOptions);
     }
 }


### PR DESCRIPTION
@muga Sorry for the last-minute update for v0.8.28. This _will_ be required to delay initializing Bundler and to delay creating a JRuby instance.
