### PR TITLE
Deprecate Timestamp-related methods using JRuby ScriptingContainer.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
@@ -59,6 +59,14 @@ public class TimestampFormatter
     public TimestampFormatter(String format, FormatterTask task)
     {
         this(format, task.getTimeZone());
+        // NOTE: Its deprecation is not actually from ScriptingContainer, though.
+        // TODO: Notify users about deprecated calls through the notification reporter.
+        System.err.println("[WARN] A plugin uses a deprecated constructor of org.embulk.spi.time.TimestampFormatter.");
+        System.err.println("[WARN] Please tell the plugin developer to stop using the constructor, or report this to:");
+        System.err.println("[WARN] https://github.com/embulk/embulk/issues/745");
+        for (final StackTraceElement stackTrace : Thread.currentThread().getStackTrace()) {
+            System.err.println("[WARN] " + stackTrace.toString());
+        }
     }
 
     public TimestampFormatter(Task task, Optional<? extends TimestampColumnOption> columnOption)
@@ -76,6 +84,13 @@ public class TimestampFormatter
     public TimestampFormatter(ScriptingContainer jruby, String format, DateTimeZone timeZone)
     {
         this(format, timeZone);
+        // TODO: Notify users about deprecated calls through the notification reporter.
+        System.err.println("[WARN] A plugin uses a deprecated constructor of org.embulk.spi.time.TimestampFormatter.");
+        System.err.println("[WARN] Please tell the plugin developer to stop using the constructor, or report this to:");
+        System.err.println("[WARN] https://github.com/embulk/embulk/issues/745");
+        for (final StackTraceElement stackTrace : Thread.currentThread().getStackTrace()) {
+            System.err.println("[WARN] " + stackTrace.toString());
+        }
     }
 
     public TimestampFormatter(final String format, final DateTimeZone timeZone)

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
@@ -22,6 +22,7 @@ public class TimestampFormatter
         public DateTimeZone getTimeZone();
 
         @ConfigInject
+        @Deprecated
         public ScriptingContainer getJRuby();
     }
 
@@ -36,6 +37,7 @@ public class TimestampFormatter
         public String getDefaultTimestampFormat();
 
         @ConfigInject
+        @Deprecated
         public ScriptingContainer getJRuby();
     }
 
@@ -56,12 +58,12 @@ public class TimestampFormatter
     @Deprecated
     public TimestampFormatter(String format, FormatterTask task)
     {
-        this(task.getJRuby(), format, task.getTimeZone());
+        this(format, task.getTimeZone());
     }
 
     public TimestampFormatter(Task task, Optional<? extends TimestampColumnOption> columnOption)
     {
-        this(task.getJRuby(),
+        this(
                 columnOption.isPresent() ?
                     columnOption.get().getFormat().or(task.getDefaultTimestampFormat())
                     : task.getDefaultTimestampFormat(),
@@ -70,7 +72,13 @@ public class TimestampFormatter
                     : task.getDefaultTimeZone());
     }
 
+    @Deprecated
     public TimestampFormatter(ScriptingContainer jruby, String format, DateTimeZone timeZone)
+    {
+        this(format, timeZone);
+    }
+
+    public TimestampFormatter(final String format, final DateTimeZone timeZone)
     {
         this.timeZone = timeZone;
         this.dateFormat = new RubyDateFormat(format, Locale.ENGLISH, true);

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
@@ -80,6 +80,14 @@ public class TimestampParser
     public TimestampParser(String format, ParserTask task)
     {
         this(format, task.getDefaultTimeZone());
+        // NOTE: Its deprecation is not actually from ScriptingContainer, though.
+        // TODO: Notify users about deprecated calls through the notification reporter.
+        System.err.println("[WARN] A plugin uses a deprecated constructor of org.embulk.spi.time.TimestampFormatter.");
+        System.err.println("[WARN] Please tell the plugin developer to stop using the constructor, or report this to:");
+        System.err.println("[WARN] https://github.com/embulk/embulk/issues/745");
+        for (final StackTraceElement stackTrace : Thread.currentThread().getStackTrace()) {
+            System.err.println("[WARN] " + stackTrace.toString());
+        }
     }
 
     @VisibleForTesting
@@ -101,6 +109,13 @@ public class TimestampParser
     public TimestampParser(ScriptingContainer jruby, String format, DateTimeZone defaultTimeZone)
     {
         this(format, defaultTimeZone);
+        // TODO: Notify users about deprecated calls through the notification reporter.
+        System.err.println("[WARN] A plugin uses a deprecated constructor of org.embulk.spi.time.TimestampFormatter.");
+        System.err.println("[WARN] Please tell the plugin developer to stop using the constructor, or report this to:");
+        System.err.println("[WARN] https://github.com/embulk/embulk/issues/745");
+        for (final StackTraceElement stackTrace : Thread.currentThread().getStackTrace()) {
+            System.err.println("[WARN] " + stackTrace.toString());
+        }
     }
 
     public TimestampParser(String format, DateTimeZone defaultTimeZone)
@@ -112,6 +127,13 @@ public class TimestampParser
     public TimestampParser(ScriptingContainer jruby, String format, DateTimeZone defaultTimeZone, String defaultDate)
     {
         this(format, defaultTimeZone, defaultDate);
+        // TODO: Notify users about deprecated calls through the notification reporter.
+        System.err.println("[WARN] A plugin uses a deprecated constructor of org.embulk.spi.time.TimestampFormatter.");
+        System.err.println("[WARN] Please tell the plugin developer to stop using the constructor, or report this to:");
+        System.err.println("[WARN] https://github.com/embulk/embulk/issues/745");
+        for (final StackTraceElement stackTrace : Thread.currentThread().getStackTrace()) {
+            System.err.println("[WARN] " + stackTrace.toString());
+        }
     }
 
     public TimestampParser(final String format, final DateTimeZone defaultTimeZone, final String defaultDate)

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
@@ -32,6 +32,7 @@ public class TimestampParser
         public DateTimeZone getDefaultTimeZone();
 
         @ConfigInject
+        @Deprecated
         public ScriptingContainer getJRuby();
     }
 
@@ -50,6 +51,7 @@ public class TimestampParser
         public String getDefaultDate();
 
         @ConfigInject
+        @Deprecated
         public ScriptingContainer getJRuby();
     }
 
@@ -77,30 +79,42 @@ public class TimestampParser
     @Deprecated
     public TimestampParser(String format, ParserTask task)
     {
-        this(task.getJRuby(), format, task.getDefaultTimeZone());
+        this(format, task.getDefaultTimeZone());
     }
 
     @VisibleForTesting
     static TimestampParser createTimestampParserForTesting(Task task)
 
     {
-        return new TimestampParser(task.getJRuby(), task.getDefaultTimestampFormat(), task.getDefaultTimeZone(), task.getDefaultDate());
+        return new TimestampParser(task.getDefaultTimestampFormat(), task.getDefaultTimeZone(), task.getDefaultDate());
     }
 
     public TimestampParser(Task task, TimestampColumnOption columnOption)
     {
-        this(task.getJRuby(),
+        this(
                 columnOption.getFormat().or(task.getDefaultTimestampFormat()),
                 columnOption.getTimeZone().or(task.getDefaultTimeZone()),
                 columnOption.getDate().or(task.getDefaultDate()));
     }
 
+    @Deprecated
     public TimestampParser(ScriptingContainer jruby, String format, DateTimeZone defaultTimeZone)
     {
-        this(jruby, format, defaultTimeZone, "1970-01-01");
+        this(format, defaultTimeZone);
     }
 
+    public TimestampParser(String format, DateTimeZone defaultTimeZone)
+    {
+        this(format, defaultTimeZone, "1970-01-01");
+    }
+
+    @Deprecated
     public TimestampParser(ScriptingContainer jruby, String format, DateTimeZone defaultTimeZone, String defaultDate)
+    {
+        this(format, defaultTimeZone, defaultDate);
+    }
+
+    public TimestampParser(final String format, final DateTimeZone defaultTimeZone, final String defaultDate)
     {
         // TODO get default current time from ExecTask.getExecTimestamp
         this.format = format;

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
@@ -52,16 +52,16 @@ public class DynamicColumnSetterFactory
         } else if (type instanceof DoubleType) {
             return new DoubleColumnSetter(pageBuilder, column, defaultValue);
         } else if (type instanceof StringType) {
-            TimestampFormatter formatter = new TimestampFormatter(task.getJRuby(),
+            TimestampFormatter formatter = new TimestampFormatter(
                     getTimestampFormat(column).getFormat(), getTimeZone(column));
             return new StringColumnSetter(pageBuilder, column, defaultValue, formatter);
         } else if (type instanceof TimestampType) {
             // TODO use flexible time format like Ruby's Time.parse
-            TimestampParser parser = new TimestampParser(task.getJRuby(),
+            TimestampParser parser = new TimestampParser(
                     getTimestampFormat(column).getFormat(), getTimeZone(column));
             return new TimestampColumnSetter(pageBuilder, column, defaultValue, parser);
         } else if (type instanceof JsonType) {
-            TimestampFormatter formatter = new TimestampFormatter(task.getJRuby(),
+            TimestampFormatter formatter = new TimestampFormatter(
                     getTimestampFormat(column).getFormat(), getTimeZone(column));
             return new JsonColumnSetter(pageBuilder, column, defaultValue, formatter);
         }

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java
@@ -43,6 +43,7 @@ public class DynamicPageBuilder
 
         // required by TimestampFormatter
         @ConfigInject
+        @Deprecated
         public ScriptingContainer getJRuby();
     }
 


### PR DESCRIPTION
@muga Deprecating them for the future. Can you have a look?

They have never been used actually although they're passed through constructors!