### PR TITLE
Fix -L option syntax error

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
@@ -563,7 +563,7 @@ public class EmbulkRunner
         // # always has require_paths = ["lib"].
         for (final String pluginPath : pluginPaths) {
             globalJRubyContainer.put("__internal_plugin_path__", pluginPath);
-            globalJRubyContainer.runScriptlet("$LOAD_PATH.unshift File.expand_path(File.join(__internal_plugin_path__, 'lib')");
+            globalJRubyContainer.runScriptlet("$LOAD_PATH.unshift File.expand_path(File.join(__internal_plugin_path__, 'lib'))");
             globalJRubyContainer.remove("__internal_plugin_path__");
         }
 


### PR DESCRIPTION
@dmikurube Please take a look when you can. 

Fix #758 

```
embulk-0.8.29.jar preview -L ./embulk-input-hoge test.yml
2017-08-11 08:24:06.011 +0900: Embulk v0.8.29
2017-08-11 08:24:08.139 +0900 [INFO] (0001:preview): Loaded plugin embulk/input/hoge from a load path
org.embulk.config.ConfigException: com.fasterxml.jackson.databind.JsonMappingException: Field 'option1' is required but not set
 at [Source: N/A; line: -1, column: -1]
```