### PR TITLE
Make Liquid's "include" work again: Fix #757

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
@@ -417,7 +417,9 @@ public class EmbulkRunner
             return this.embed.newConfigLoader().fromYamlString(
                 runLiquid(new String(Files.readAllBytes(configFilePath), StandardCharsets.UTF_8),
                           templateParams,
-                          templateIncludePath));
+                          (templateIncludePath == null
+                           ? configFilePath.toAbsolutePath().getParent().toString()
+                           : templateIncludePath)));
         }
         else if (EXT_YAML.matcher(configFilePath.toString()).matches()) {
             return this.embed.newConfigLoader().fromYamlString(


### PR DESCRIPTION
@muga Can you have a look? It fixes #757.

It was originally like https://github.com/embulk/embulk/blob/v0.8.26/lib/embulk/runner.rb#L128 in Ruby.

Cc: @hiroyuki-sato 