### PR TITLE
Return non-zero exit status in case of errors: Fix #771

### DIFF
--- a/embulk-cli/src/main/java/org/embulk/cli/Main.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/Main.java
@@ -25,6 +25,7 @@ public class Main
         }
 
         final EmbulkRun run = new EmbulkRun(EmbulkVersion.VERSION);
-        run.run(Collections.unmodifiableList(embulkArgs), Collections.unmodifiableList(jrubyOptions));
+        final int error = run.run(Collections.unmodifiableList(embulkArgs), Collections.unmodifiableList(jrubyOptions));
+        System.exit(error);
     }
 }


### PR DESCRIPTION
@muga I'd include this fix in 0.8.31. Can you have a look?