### PR TITLE
Ensure plugin's "gradlew" to have executable permissions by "migrate" subcommand

### DIFF
--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
@@ -97,6 +97,7 @@ public class EmbulkMigrate
         if (migrator.match("gradle/wrapper/gradle-wrapper.properties", GRADLE_VERSION_IN_WRAPPER)) {
             // gradle < 4.1
             migrator.copy("embulk/data/new/java/gradlew", "gradlew");
+            migrator.setExecutable("gradlew");
             migrator.copy("embulk/data/new/java/gradle/wrapper/gradle-wrapper.properties",
                           "gradle/wrapper/gradle-wrapper.properties");
             migrator.copy("embulk/data/new/java/gradle/wrapper/gradle-wrapper.jar",


### PR DESCRIPTION
After an execute `embulk migrate` in a plugin directory,
Migrator dropped an executable permission of the plugin's gradlew.

This PR add executable permission explicitly. 

Current behavior.

```
embulk migrate .
2017-09-05 13:06:00.997 +0900: Embulk v0.8.31
Detected Java plugin for Embulk 0.8.22...
  Modified ./build.gradle
  Modified ./embulk-output-db2/build.gradle
  Modified ./embulk-output-mysql/build.gradle
  Modified ./embulk-output-oracle/build.gradle
  Modified ./embulk-output-sqlserver/build.gradle
Done. Please check modified files.
```

```
ls -l gradlew
-rw-r--r--  1 user  staff  5296 Sep  5 13:06 gradlew
```
