### PR TITLE
[Propose] Add Task.leftShift has been deprecated caution message.

### DIFF
--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkMigrate.java
@@ -102,6 +102,10 @@ public class EmbulkMigrate
                           "gradle/wrapper/gradle-wrapper.properties");
             migrator.copy("embulk/data/new/java/gradle/wrapper/gradle-wrapper.jar",
                           "gradle/wrapper/gradle-wrapper.jar");
+            System.out.println("\n\n** CAUTION **\n\n" +
+                    "If you see this message, you need to modify build.gradle.\n" +
+                    "Please see more detail at this URL: https://github.com/embulk/embulk/pull/698#issuecomment-312422241\n\n" +
+                    "\"The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.\"\n\n");
         }
 
         // Add a method |jsonColumn| before the method |timestampColumn| which should exist.


### PR DESCRIPTION
Due to `Task.leftShift(Closure)` method has been deprecated, a plugin developer needs to modify `build.gradle`.
It is hard to implement this change in the `embulk migrate` subcommand. 

Instead, I add the following guide. 

What do you think this idea?


Add example warning (a message may needs modify.)

```
** CAUTION **

If you see this message, you need to modify build.gradle.
Please see more detail at this URL: https://github.com/embulk/embulk/pull/698#issuecomment-312422241

"The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead."
```

Plugin developer will see this warning. 

```
./gradlew classpath

> Configure project :
The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.
        at build_49laod645hpyts1dwsiwbop80$_run_closure2.doCall(/Users/hsato/OpenProjects/embulk/embulk-output-jdbc/build.gradle:95)


BUILD SUCCESSFUL in 1s
21 actionable tasks: 21 up-to-date
```

Proposed example,

```
embulk-0.8.31.jar migrate .

2017-09-05 19:56:27.940 +0900: Embulk v0.8.31
Detected Java plugin for Embulk 0.8.22...


** CAUTION **

If you see this message, you need to modify build.gradle.
Please see more detail at this URL: https://github.com/embulk/embulk/pull/698#issuecomment-312422241

"The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead."


  Modified ./build.gradle
  Modified ./embulk-output-db2/build.gradle
  Modified ./embulk-output-mysql/build.gradle
  Modified ./embulk-output-oracle/build.gradle
  Modified ./embulk-output-sqlserver/build.gradle
Done. Please check modified files.
```