### PR TITLE
Load dependency JAR files embedded in plugin JAR

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
@@ -1,31 +1,71 @@
 package org.embulk.plugin;
 
-import java.util.List;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.net.MalformedURLException;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.file.Path;
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.CodeSigner;
+import java.security.CodeSource;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Vector;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
 
 public class PluginClassLoader
         extends URLClassLoader
 {
-    private final List<String> parentFirstPackagePrefixes;
-    private final List<String> parentFirstResourcePrefixes;
-
-    public PluginClassLoader(Collection<URL> urls, ClassLoader parent,
-            Collection<String> parentFirstPackages,
-            Collection<String> parentFirstResources)
+    private PluginClassLoader(
+            final ClassLoader parentClassLoader,
+            final URL oneNestedJarFileUrl,
+            final Collection<String> embeddedJarPathsInNestedJar,
+            final Collection<URL> flatJarUrls,
+            final Collection<String> parentFirstPackages,
+            final Collection<String> parentFirstResources)
     {
-        super(urls.toArray(new URL[urls.size()]), parent);
+        super(combineUrlsToArray(oneNestedJarFileUrl, flatJarUrls == null ? Collections.<URL>emptyList() : flatJarUrls),
+              parentClassLoader);
+
+        // Given |oneNestedJarFileUrl| should be "file:...". |this.oneNestedJarUrlBase| should be "jar:file:...".
+        URL oneNestedJarUrlBaseBuilt = null;
+        if (oneNestedJarFileUrl != null) {
+            try {
+                oneNestedJarUrlBaseBuilt = new URL("jar", "", -1, oneNestedJarFileUrl + "!/");
+            }
+            catch (MalformedURLException ex) {
+                // TODO: Notify this to reporters as far as possible.
+                System.err.println("FATAL: Invalid JAR file URL: " + oneNestedJarFileUrl.toString());
+                ex.printStackTrace();
+            }
+        }
+        this.oneNestedJarUrlBase = oneNestedJarUrlBaseBuilt;
+
+        if (embeddedJarPathsInNestedJar == null) {
+            this.embeddedJarPathsInNestedJar = Collections.<String>emptyList();
+        }
+        else {
+            this.embeddedJarPathsInNestedJar = Collections.unmodifiableCollection(embeddedJarPathsInNestedJar);
+        }
         this.parentFirstPackagePrefixes = ImmutableList.copyOf(
                 Iterables.transform(parentFirstPackages, new Function<String, String>() {
                     public String apply(String pkg)
@@ -40,6 +80,60 @@ public class PluginClassLoader
                         return pkg + "/";
                     }
                 }));
+        this.accessControlContext = AccessController.getContext();
+    }
+
+    @Deprecated  // Constructing directly with the constructor is deprecated (no warnings). Use static creator methods.
+    public PluginClassLoader(
+            final Collection<URL> flatJarUrls,
+            final ClassLoader parentClassLoader,
+            final Collection<String> parentFirstPackages,
+            final Collection<String> parentFirstResources)
+    {
+        this(parentClassLoader, null, null, flatJarUrls, parentFirstPackages, parentFirstResources);
+    }
+
+    /**
+     * Creates PluginClassLoader for plugins with dependency JARs flat on the file system, like Gem-based plugins.
+     */
+    public static PluginClassLoader createForFlatJars(
+            final ClassLoader parentClassLoader,
+            final Collection<URL> flatJarUrls,
+            final Collection<String> parentFirstPackages,
+            final Collection<String> parentFirstResources)
+    {
+        return new PluginClassLoader(
+            parentClassLoader,
+            null,
+            null,
+            flatJarUrls,
+            parentFirstPackages,
+            parentFirstResources);
+    }
+
+    /**
+     * Creates PluginClassLoader for plugins with dependency JARs embedded in the plugin JAR itself.
+     *
+     * @param parentClassLoader  the parent ClassLoader of this PluginClassLoader instance
+     * @param oneNestedJarFileUrl  "file:" URL of the plugin JAR file
+     * @param embeddedJarPathsInNestedJar  collection of resource names of embedded dependency JARs in the plugin JAR
+     * @parma parentFirstPackages  collection of package names that are to be loaded first before the plugin's
+     * @parma parentFirstResourcess  collection of resource names that are to be loaded first before the plugin's
+     */
+    public static PluginClassLoader createForNestedJar(
+            final ClassLoader parentClassLoader,
+            final URL oneNestedJarFileUrl,
+            final Collection<String> embeddedJarPathsInNestedJar,
+            final Collection<String> parentFirstPackages,
+            final Collection<String> parentFirstResources)
+    {
+        return new PluginClassLoader(
+            parentClassLoader,
+            oneNestedJarFileUrl,
+            embeddedJarPathsInNestedJar,
+            null,
+            parentFirstPackages,
+            parentFirstResources);
     }
 
     /**
@@ -63,6 +157,62 @@ public class PluginClassLoader
     public void addUrl(URL url)
     {
         super.addURL(url);
+    }
+
+    /**
+     * Finds a class defined by the given name from given JARs and JARs in the given JAR.
+     *
+     * Classes directly inthe given JARs are always prioritized. Only if no such a class is found
+     * directly in the given JAR, it tries to find the class in JARs in the given JAR.
+     */
+    @Override
+    protected Class<?> findClass(final String className)
+            throws ClassNotFoundException
+    {
+        if (this.oneNestedJarUrlBase == null || this.embeddedJarPathsInNestedJar.isEmpty()) {
+            // Multiple flat JARs -- Gem-based plugins, or Single JAR (JAR-based plugins) without any embedded JAR
+            return super.findClass(className);
+        }
+        else {
+            // Single nested JAR -- JAR-based plugins
+            try {
+                // Classes directly in the plugin JAR are always prioritized.
+                return super.findClass(className);
+            }
+            catch (ClassNotFoundException directClassNotFoundException) {
+                try {
+                    return AccessController.doPrivileged(
+                        new PrivilegedExceptionAction<Class<?>>() {
+                            public Class<?> run()
+                                    throws ClassNotFoundException
+                            {
+                                try {
+                                    return defineClassFromEmbeddedJars(className);
+                                }
+                                catch (ClassNotFoundException | LinkageError | ClassCastException ex) {
+                                    throw ex;
+                                }
+                                catch (Throwable ex) {
+                                    // Resource found from JARs in the JAR, but failed to load it as a class.
+                                    throw new ClassNotFoundException(className, ex);
+                                }
+                            }
+                        }, this.accessControlContext);
+                } catch (PrivilegedActionException ex) {
+                    final Throwable internalException = ex.getException();
+                    if (internalException instanceof ClassNotFoundException) {
+                        throw (ClassNotFoundException) internalException;
+                    }
+                    if (internalException instanceof LinkageError) {
+                        throw (LinkageError) internalException;
+                    }
+                    if (internalException instanceof ClassCastException) {
+                        throw (ClassCastException) internalException;
+                    }
+                    throw new ClassNotFoundException(className, ex);
+                }
+            }
+        }
     }
 
     /**
@@ -135,6 +285,87 @@ public class PluginClassLoader
         return clazz;
     }
 
+    /**
+     * Finds a resource recognized as the given name from given JARs and JARs in the given JAR.
+     *
+     * Resources directly in the given JARs are always prioritized. Only if no such a resource is found
+     * directly in the given JAR, it tries to find the resource in JARs in the given JAR.
+     *
+     * Note that URLClassLoader#findResource is public while ClassLoader#findResource is protected.
+     */
+    @Override
+    public URL findResource(final String resourceName)
+    {
+        if (this.oneNestedJarUrlBase == null || this.embeddedJarPathsInNestedJar.isEmpty()) {
+            // Multiple flat JARs -- Gem-based plugins, or Single JAR (JAR-based plugins) without any embedded JAR
+            return super.findResource(resourceName);
+        }
+        else {
+            // Single nested JAR -- JAR-based plugins
+            // Classes directly in the plugin JAR are always prioritized.
+            final URL rootUrl = super.findResource(resourceName);
+            if (rootUrl != null) {
+                return rootUrl;
+            }
+
+            try {
+                return AccessController.doPrivileged(
+                    new PrivilegedExceptionAction<URL>() {
+                        public URL run()
+                        {
+                            return findResourceFromEmbeddedJars(resourceName);
+                        }
+                    }, this.accessControlContext);
+            } catch (PrivilegedActionException ignored) {
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * Finds resources recognized as the given name from given JARs and JARs in the given JAR.
+     *
+     * Resources directly in the given JARs precede. Resources in JARs in the given JAR follow resources
+     * directly in the given JARs.
+     *
+     * Note that URLClassLoader#findResources is public while ClassLoader#findResources is protected.
+     */
+    @Override
+    public Enumeration<URL> findResources(final String resourceName)
+            throws IOException
+    {
+        if (this.oneNestedJarUrlBase == null || this.embeddedJarPathsInNestedJar.isEmpty()) {
+            // Multiple flat JARs -- Gem-based plugins, or Single JAR (JAR-based plugins) without any embedded JAR
+            return super.findResources(resourceName);
+        }
+        else {
+            // Single nested JAR -- JAR-based plugins
+            final Vector<URL> urls = new Vector<URL>();
+
+            // Classes directly in the plugin JAR are always prioritized.
+            // Note that |super.findResources| may throw IOException.
+            for (final Enumeration<URL> rootUrls = super.findResources(resourceName); rootUrls.hasMoreElements(); ) {
+                urls.add(rootUrls.nextElement());
+            }
+
+            try {
+                final List<URL> childUrls = AccessController.doPrivileged(
+                    new PrivilegedExceptionAction<List<URL>>() {
+                        public List<URL> run()
+                                throws IOException
+                        {
+                            return findResourcesFromEmbeddedJars(resourceName);
+                        }
+                    }, this.accessControlContext);
+                urls.addAll(childUrls);
+            } catch (PrivilegedActionException ignored) {
+            }
+
+            return urls.elements();
+        }
+    }
+
     @Override
     public URL getResource(String name)
     {
@@ -156,6 +387,33 @@ public class PluginClassLoader
             URL childUrl = findResource(name);
             if (childUrl != null) {
                 return childUrl;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public InputStream getResourceAsStream(final String resourceName)
+    {
+        final boolean childFirst = isParentFirstPath(resourceName);
+
+        if (childFirst) {
+            final InputStream childInputStream = getResourceAsStreamFromChild(resourceName);
+            if (childInputStream != null) {
+                return childInputStream;
+            }
+        }
+
+        final InputStream parentInputStream = getParent().getResourceAsStream(resourceName);
+        if (parentInputStream != null) {
+            return parentInputStream;
+        }
+
+        if (!childFirst) {
+            final InputStream childInputStream = getResourceAsStreamFromChild(resourceName);
+            if (childInputStream != null) {
+                return childInputStream;
             }
         }
 
@@ -186,6 +444,527 @@ public class PluginClassLoader
         return Iterators.asEnumeration(Iterators.concat(resources.iterator()));
     }
 
+    /**
+     * URLStreamHandler to handle resources in embedded JARs in the plugin JAR.
+     */
+    private static class PluginClassURLStreamHandler
+            extends URLStreamHandler
+    {
+        public PluginClassURLStreamHandler(final String protocol)
+        {
+            this.protocol = protocol;
+        }
+
+        @Override
+        protected URLConnection openConnection(final URL url)
+                throws IOException
+        {
+            // Note that declaring variables here may cause unexpected behaviors.
+            // https://stackoverflow.com/questions/9952815/s3-java-client-fails-a-lot-with-premature-end-of-content-length-delimited-messa
+            return new URLConnection(url) {
+                @Override
+                public void connect()
+                {
+                }
+
+                @Override
+                public InputStream getInputStream()
+                        throws IOException
+                {
+                    final URL embulkPluginJarUrl = getURL();
+                    if (!embulkPluginJarUrl.getProtocol().equals(protocol)) {
+                        return null;
+                    }
+                    final String[] embulkPluginJarUrlSeparate = embulkPluginJarUrl.getPath().split("!!/");
+                    if (embulkPluginJarUrlSeparate.length != 2) {
+                        return null;
+                    }
+                    final URL embeddedJarUrl = new URL(embulkPluginJarUrlSeparate[0]);
+                    final String embeddedResourceName = embulkPluginJarUrlSeparate[1];
+
+                    final JarURLConnection embeddedJarURLConnection;
+                    try {
+                        final URLConnection urlConnection = embeddedJarUrl.openConnection();
+                        embeddedJarURLConnection = (JarURLConnection) urlConnection;
+                    }
+                    catch (ClassCastException ex) {
+                        return null;
+                    }
+
+                    final JarInputStream embeddedJarInputStream =
+                        new JarInputStream(embeddedJarURLConnection.getInputStream());
+
+                    // Note that |JarInputStream.getNextJarEntry| may throw IOException.
+                    JarEntry jarEntry = embeddedJarInputStream.getNextJarEntry();
+                    while (jarEntry != null) {
+                        if (jarEntry.getName().equals(embeddedResourceName)) {
+                            return embeddedJarInputStream;  // The InputStream points the specific "JAR entry".
+                        }
+                        // Note that |JarInputStream.getNextJarEntry| may throw IOException.
+                        jarEntry = embeddedJarInputStream.getNextJarEntry();
+                    }
+                    return null;
+                }
+            };
+        }
+
+        public final String protocol;
+    }
+
+    private static URL[] combineUrlsToArray(final URL oneNestedJarFileUrl, final Collection<URL> flatJarUrls)
+    {
+        final int offset;
+        final URL[] allDirectJarUrls;
+        if (oneNestedJarFileUrl == null) {
+            offset = 0;
+            allDirectJarUrls = new URL[flatJarUrls.size()];
+        }
+        else {
+            offset = 1;
+            allDirectJarUrls = new URL[flatJarUrls.size() + 1];
+            allDirectJarUrls[0] = oneNestedJarFileUrl;
+        }
+        int i = 0;
+        for (final URL flatJarUrl : flatJarUrls) {
+            allDirectJarUrls[i + offset] = flatJarUrl;
+            ++i;
+        }
+        return allDirectJarUrls;
+    }
+
+    /**
+     * Defines a class with given class name from JARs embedded in the plugin JAR.
+     *
+     * It tries to continue even if Exceptions are throws in one of embedded JARs so that
+     * it can find the target class without affected from other unrelated JARs.
+     */
+    private Class<?> defineClassFromEmbeddedJars(final String className)
+            throws ClassNotFoundException
+    {
+        final String classResourceName = className.replace('.', '/').concat(".class");
+
+        Throwable lastException = null;
+        // TODO: Speed up class loading by caching?
+        for (final String embeddedJarPath : this.embeddedJarPathsInNestedJar) {
+            final URL embeddedJarUrl;
+            final JarURLConnection embeddedJarUrlConnection;
+            final JarInputStream embeddedJarInputStream;
+            try {
+                embeddedJarUrl = getEmbeddedJarUrl(embeddedJarPath);
+                embeddedJarUrlConnection = getEmbeddedJarURLConnection(embeddedJarUrl);
+                embeddedJarInputStream = getEmbeddedJarInputStream(embeddedJarUrlConnection);
+            }
+            catch (IOException ex) {
+                lastException = ex;
+                continue;
+            }
+
+            final Manifest manifest;
+            try {
+                manifest = embeddedJarUrlConnection.getManifest();
+            }
+            catch (IOException ex) {
+                // TODO: Notify this to reporters as far as possible.
+                lastException = ex;
+                System.err.println("Failed to load manifest in embedded JAR: " + embeddedJarPath);
+                ex.printStackTrace();
+                continue;
+            }
+
+            JarEntry jarEntry;
+            try {
+                jarEntry = embeddedJarInputStream.getNextJarEntry();
+            }
+            catch (IOException ex) {
+                // TODO: Notify this to reporters as far as possible.
+                lastException = ex;
+                System.err.println("Failed to load entry in embedded JAR: " + embeddedJarPath);
+                ex.printStackTrace();
+                continue;
+            }
+            jarEntries: while (jarEntry != null) {
+                if (jarEntry.getName().equals(classResourceName)) {
+                    final int lastDotIndexInClassName = className.lastIndexOf('.');
+                    final String packageName;
+                    if (lastDotIndexInClassName != -1) {
+                        packageName = className.substring(0, lastDotIndexInClassName);
+                    }
+                    else {
+                        packageName = null;
+                    }
+
+                    final URL codeSourceUrl = embeddedJarUrl;
+
+                    // Define the package if the package is not loaded / defined yet.
+                    if (packageName != null) {
+                        // TODO: Consider package sealing.
+                        // https://docs.oracle.com/javase/tutorial/deployment/jar/sealman.html
+                        if (this.getPackage(packageName) == null) {
+                            try {
+                                final Attributes fileAttributes;
+                                final Attributes mainAttributes;
+                                if (manifest != null) {
+                                    fileAttributes = manifest.getAttributes(classResourceName);
+                                    mainAttributes = manifest.getMainAttributes();
+                                }
+                                else {
+                                    fileAttributes = null;
+                                    mainAttributes = null;
+                                }
+
+                                this.definePackage(
+                                    packageName,
+                                    getAttributeFromAttributes(mainAttributes, fileAttributes, classResourceName,
+                                                               Attributes.Name.SPECIFICATION_TITLE),
+                                    getAttributeFromAttributes(mainAttributes, fileAttributes, classResourceName,
+                                                               Attributes.Name.SPECIFICATION_VERSION),
+                                    getAttributeFromAttributes(mainAttributes, fileAttributes, classResourceName,
+                                                               Attributes.Name.SPECIFICATION_VENDOR),
+                                    getAttributeFromAttributes(mainAttributes, fileAttributes, classResourceName,
+                                                               Attributes.Name.IMPLEMENTATION_TITLE),
+                                    getAttributeFromAttributes(mainAttributes, fileAttributes, classResourceName,
+                                                               Attributes.Name.IMPLEMENTATION_VERSION),
+                                    getAttributeFromAttributes(mainAttributes, fileAttributes, classResourceName,
+                                                               Attributes.Name.IMPLEMENTATION_VENDOR),
+                                    null);
+                            }
+                            catch (IllegalArgumentException ex) {
+                                // The package duplicates -- in parallel cases
+                                if (getPackage(packageName) == null) {
+                                    // TODO: Notify this to reporters as far as possible.
+                                    lastException = ex;
+                                    System.err.println("FATAL: Should not happen. Package duplicated: " + packageName);
+                                    ex.printStackTrace();
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+
+                    final long classResourceSize = jarEntry.getSize();
+                    final byte[] classResourceBytes;
+                    final long actualSize;
+
+                    if (classResourceSize > -1) {  // JAR entry size available
+                        classResourceBytes = new byte[(int) classResourceSize];
+                        try {
+                            actualSize = embeddedJarInputStream.read(classResourceBytes, 0, (int) classResourceSize);
+                        }
+                        catch (IOException ex) {
+                            // TODO: Notify this to reporters as far as possible.
+                            lastException = ex;
+                            System.err.println("Failed to load entry in embedded JAR: " + classResourceName);
+                            ex.printStackTrace();
+                            break jarEntries;  // Breaking from loading since this JAR looks broken.
+                        }
+                        if (actualSize != classResourceSize) {
+                            // TODO: Notify this to reporters as far as possible.
+                            System.err.println("Broken entry in embedded JAR: " + classResourceName);
+                            break jarEntries;  // Breaking from loading since this JAR looks broken.
+                        }
+                    }
+                    else {  // JAR entry size unavailable
+                        final ByteArrayOutputStream bytesStream = new ByteArrayOutputStream();
+                        final byte[] buffer = new byte[1024];
+                        long accumulatedSize = 0;
+                        while (true) {
+                            final long readSize;
+                            try {
+                                readSize = embeddedJarInputStream.read(buffer, 0, 1024);
+                            }
+                            catch (IOException ex) {
+                                // TODO: Notify this to reporters as far as possible.
+                                lastException = ex;
+                                System.err.println("Failed to load entry in embedded JAR: " + classResourceName);
+                                ex.printStackTrace();
+                                break jarEntries;  // Breaking from loading since this JAR looks broken.
+                            }
+
+                            if (readSize < 0) {
+                                break;
+                            }
+
+                            bytesStream.write(buffer, 0, (int) readSize);
+                            accumulatedSize += readSize;
+                        }
+                        actualSize = accumulatedSize;
+                        classResourceBytes = bytesStream.toByteArray();
+                    }
+
+                    final CodeSource codeSource = new CodeSource(codeSourceUrl, (CodeSigner[]) null);
+                    final Class<?> definedClass;
+                    try {
+                        definedClass = defineClass(className, classResourceBytes, 0, (int) actualSize, codeSource);
+                    }
+                    catch (Throwable ex) {
+                        // TODO: Notify this to reporters as far as possible.
+                        lastException = ex;
+                        System.err.println("Failed to load entry in embedded JAR: " + classResourceName);
+                        ex.printStackTrace();
+                        continue;
+                    }
+                    return definedClass;
+                }
+                try {
+                    jarEntry = embeddedJarInputStream.getNextJarEntry();
+                }
+                catch (IOException ex) {
+                    // TODO: Notify this to reporters as far as possible.
+                    lastException = ex;
+                    System.err.println("Failed to load entry in embedded JAR: " + classResourceName);
+                    ex.printStackTrace();
+                    break jarEntries;  // Breaking from loading since this JAR looks broken.
+                }
+            }
+        }
+        if (lastException != null) {
+            throw new ClassNotFoundException(className, lastException);
+        }
+        else {
+            throw new ClassNotFoundException(className);
+        }
+    }
+
+    private InputStream getResourceAsStreamFromChild(final String resourceName)
+    {
+        if (this.oneNestedJarUrlBase == null || this.embeddedJarPathsInNestedJar.isEmpty()) {
+            // Multiple flat JARs -- Gem-based plugins, or Single JAR (JAR-based plugins) without any embedded JAR
+            return super.getResourceAsStream(resourceName);
+        }
+        else {
+            // Single nested JAR -- JAR-based plugins
+            // Resources directly in the plugin JAR are prioritized.
+            final InputStream inputStream = super.getResourceAsStream(resourceName);
+            if (inputStream == null) {
+                try {
+                    final InputStream childInputStream = AccessController.doPrivileged(
+                        new PrivilegedExceptionAction<InputStream>() {
+                            public InputStream run()
+                            {
+                                return getResourceAsStreamFromEmbeddedJars(resourceName);
+                            }
+                        }, this.accessControlContext);
+                    if (childInputStream != null) {
+                        return childInputStream;
+                    }
+                } catch (PrivilegedActionException ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    private InputStream getResourceAsStreamFromEmbeddedJars(final String resourceName)
+    {
+        for (final String embeddedJarPath : this.embeddedJarPathsInNestedJar) {
+            final JarInputStream embeddedJarInputStream;
+            try {
+                embeddedJarInputStream = getEmbeddedJarInputStream(embeddedJarPath);
+            }
+            catch (IOException ex) {
+                // TODO: Notify this to reporters as far as possible.
+                System.err.println("Failed to load entry in embedded JAR: " + resourceName + " / " + embeddedJarPath);
+                ex.printStackTrace();
+                continue;
+            }
+
+            JarEntry jarEntry;
+            try {
+                jarEntry = embeddedJarInputStream.getNextJarEntry();
+            }
+            catch (IOException ex) {
+                // TODO: Notify this to reporters as far as possible.
+                System.err.println("Failed to load entry in embedded JAR: " + resourceName + " / " + embeddedJarPath);
+                ex.printStackTrace();
+                continue;
+            }
+            while (jarEntry != null) {
+                if (jarEntry.getName().equals(resourceName)) {
+                    return embeddedJarInputStream;  // Pointing the specific "JAR entry"
+                }
+            }
+        }
+        return null;
+    }
+
+    private URL findResourceFromEmbeddedJars(final String resourceName)
+    {
+        for (final String embeddedJarPath : this.embeddedJarPathsInNestedJar) {
+            final URL embeddedJarUrl;
+            final JarURLConnection embeddedJarUrlConnection;
+            final JarInputStream embeddedJarInputStream;
+            try {
+                embeddedJarUrl = getEmbeddedJarUrl(embeddedJarPath);
+                embeddedJarUrlConnection = getEmbeddedJarURLConnection(embeddedJarUrl);
+                embeddedJarInputStream = getEmbeddedJarInputStream(embeddedJarUrlConnection);
+            }
+            catch (IOException ex) {
+                // TODO: Notify this to reporters as far as possible.
+                System.err.println("Failed to load entry in embedded JAR: " +
+                                   resourceName + " / " + embeddedJarPath);
+                ex.printStackTrace();
+                continue;
+            }
+
+            JarEntry jarEntry;
+            try {
+                jarEntry = embeddedJarInputStream.getNextJarEntry();
+            }
+            catch (IOException ex) {
+                // TODO: Notify this to reporters as far as possible.
+                System.err.println("Failed to load entry in embedded JAR: " +
+                                   resourceName + " / " + embeddedJarPath);
+                ex.printStackTrace();
+                continue;
+            }
+            jarEntries: while (jarEntry != null) {
+                if (jarEntry.getName().equals(resourceName)) {
+                    // For resources (not classes) in nested JARs, the schema and the URL should be like:
+                    // "embulk-plugin-jar:jar:file://.../plugin.jar!/classpath/library.jar!!/org.library/resource.txt"
+                    //
+                    // The "embulk-plugin-jar" URL is processed with |PluginClassURLStreamHandler|.
+                    // See also: https://www.ibm.com/developerworks/library/j-onejar/index.html
+                    //
+                    // The URL lives only in the JVM execution.
+                    try {
+                        // The URL lives only in the JVM execution.
+                        return new URL("embulk-plugin-jar", "", -1, embeddedJarUrl + "!!/" + resourceName,
+                                       new PluginClassURLStreamHandler("embulk-plugin-jar"));
+                    }
+                    catch (MalformedURLException ex) {
+                        // TODO: Notify this to reporters as far as possible.
+                        System.err.println("Failed to load entry in embedded JAR: " +
+                                           resourceName + " / " + embeddedJarPath);
+                        ex.printStackTrace();
+                        break jarEntries;
+                    }
+                }
+                try {
+                    jarEntry = embeddedJarInputStream.getNextJarEntry();
+                }
+                catch (IOException ex) {
+                    // TODO: Notify this to reporters as far as possible.
+                    System.err.println("Failed to load entry in embedded JAR: " +
+                                       resourceName + " / " + embeddedJarPath);
+                    ex.printStackTrace();
+                    break jarEntries;
+                }
+            }
+        }
+        return null;
+    }
+
+    private List<URL> findResourcesFromEmbeddedJars(final String resourceName)
+            throws IOException
+    {
+        final ArrayList<URL> resourceUrls = new ArrayList<URL>();
+        for (final String embeddedJarPath : this.embeddedJarPathsInNestedJar) {
+            final URL embeddedJarUrl = getEmbeddedJarUrl(embeddedJarPath);
+            final JarURLConnection embeddedJarUrlConnection = getEmbeddedJarURLConnection(embeddedJarUrl);
+            final JarInputStream embeddedJarInputStream = getEmbeddedJarInputStream(embeddedJarUrlConnection);
+
+            // Note that |JarInputStream.getNextJarEntry| may throw IOException.
+            JarEntry jarEntry = embeddedJarInputStream.getNextJarEntry();
+            while (jarEntry != null) {
+                if (jarEntry.getName().equals(resourceName)) {
+                    // For resources (not classes) in nested JARs, the schema and the URL should be like:
+                    // "embulk-plugin-jar:jar:file://.../plugin.jar!/classpath/library.jar!/org.library/resource.txt"
+                    //
+                    // The "embulk-plugin-jar" URL is processed with |PluginClassURLStreamHandler|.
+                    // See also: https://www.ibm.com/developerworks/library/j-onejar/index.html
+                    //
+                    // The URL lives only in the JVM execution.
+                    //
+                    // Note that |new URL| may throw MalformedURLException (extending IOException).
+                    resourceUrls.add(new URL("embulk-plugin-jar", "", -1, embeddedJarUrl + "!!/" + resourceName,
+                                             new PluginClassURLStreamHandler("embulk-plugin-jar")));
+                }
+                // Note that |JarInputStream.getNextJarEntry| may throw IOException.
+                jarEntry = embeddedJarInputStream.getNextJarEntry();
+            }
+        }
+        return resourceUrls;
+    }
+
+    private URL getEmbeddedJarUrl(final String embeddedJarPath)
+            throws MalformedURLException
+    {
+        final URL embeddedJarUrl;
+        try {
+            embeddedJarUrl = new URL(this.oneNestedJarUrlBase, embeddedJarPath);
+        }
+        catch (MalformedURLException ex) {
+            // TODO: Notify this to reporters as far as possible.
+            System.err.println("Failed to load entry in embedded JAR: " + embeddedJarPath);
+            ex.printStackTrace();
+            throw ex;
+        }
+        return embeddedJarUrl;
+    }
+
+    private JarURLConnection getEmbeddedJarURLConnection(final URL embeddedJarUrl)
+            throws IOException
+    {
+        final JarURLConnection embeddedJarURLConnection;
+        try {
+            final URLConnection urlConnection = embeddedJarUrl.openConnection();
+            embeddedJarURLConnection = (JarURLConnection) urlConnection;
+        }
+        catch (IOException ex) {
+            // TODO: Notify this to reporters as far as possible.
+            System.err.println("Failed to load entry in embedded JAR: " + embeddedJarUrl.toString());
+            ex.printStackTrace();
+            throw ex;
+        }
+        return embeddedJarURLConnection;
+    }
+
+    private JarInputStream getEmbeddedJarInputStream(final JarURLConnection embeddedJarURLConnection)
+            throws IOException
+    {
+        final JarInputStream embeddedJarInputStream;
+        try {
+            final InputStream inputStream = embeddedJarURLConnection.getInputStream();
+            embeddedJarInputStream = new JarInputStream(inputStream);
+        }
+        catch (IOException ex) {
+            // TODO: Notify this to reporters as far as possible.
+            System.err.println("Failed to load entry in embedded JAR: " + embeddedJarURLConnection.toString());
+            ex.printStackTrace();
+            throw ex;
+        }
+        return embeddedJarInputStream;
+    }
+
+    private JarInputStream getEmbeddedJarInputStream(final String embeddedJarPath)
+            throws IOException
+    {
+        final URL embeddedJarUrl = getEmbeddedJarUrl(embeddedJarPath);
+        final JarURLConnection embeddedJarUrlConnection = getEmbeddedJarURLConnection(embeddedJarUrl);
+        return getEmbeddedJarInputStream(embeddedJarUrlConnection);
+    }
+
+    private static String getAttributeFromAttributes(
+            final Attributes mainAttributes,
+            final Attributes fileAttributes,
+            final String classResourceName,
+            final Attributes.Name attributeName)
+    {
+        if (fileAttributes != null) {
+            final String value = fileAttributes.getValue(attributeName);
+            if (value != null) {
+                return value;
+            }
+        }
+        if (mainAttributes != null) {
+            final String value = mainAttributes.getValue(attributeName);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
     private boolean isParentFirstPackage(String name)
     {
         for (String pkg : parentFirstPackagePrefixes) {
@@ -205,4 +984,10 @@ public class PluginClassLoader
         }
         return false;
     }
+
+    private final URL oneNestedJarUrlBase;
+    private final Collection<String> embeddedJarPathsInNestedJar;
+    private final List<String> parentFirstPackagePrefixes;
+    private final List<String> parentFirstResourcePrefixes;
+    private final AccessControlContext accessControlContext;
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactory.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactory.java
@@ -5,5 +5,12 @@ import java.net.URL;
 
 public interface PluginClassLoaderFactory
 {
-    PluginClassLoader create(Collection<URL> urls, ClassLoader parentClassLoader);
+    PluginClassLoader create(Collection<URL> flatJarUrls, ClassLoader parentClassLoader);
+    PluginClassLoader createForNestedJar(
+        final ClassLoader parentClassLoader,
+        final URL oneNestedJarUrl);
+    PluginClassLoader createForNestedJar(
+        final ClassLoader parentClassLoader,
+        final URL oneNestedJarUrl,
+        final Collection<String> embeddedJarPathsInNestedJar);
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderModule.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderModule.java
@@ -61,10 +61,41 @@ public class PluginClassLoaderModule
 
         private class Factory implements PluginClassLoaderFactory
         {
+            @Override
             public PluginClassLoader create(Collection<URL> urls, ClassLoader parentClassLoader)
             {
-                return new PluginClassLoader(urls, parentClassLoader,
-                        parentFirstPackages, parentFirstResources);
+                return PluginClassLoader.createForFlatJars(
+                    parentClassLoader,
+                    urls,
+                    parentFirstPackages,
+                    parentFirstResources);
+            }
+
+            @Override
+            public PluginClassLoader createForNestedJar(
+                    final ClassLoader parentClassLoader,
+                    final URL oneNestedJarUrl)
+            {
+                return PluginClassLoader.createForNestedJar(
+                    parentClassLoader,
+                    oneNestedJarUrl,
+                    null,
+                    parentFirstPackages,
+                    parentFirstResources);
+            }
+
+            @Override
+            public PluginClassLoader createForNestedJar(
+                    final ClassLoader parentClassLoader,
+                    final URL oneNestedJarUrl,
+                    final Collection<String> embeddedJarPathsInNestedJar)
+            {
+                return PluginClassLoader.createForNestedJar(
+                    parentClassLoader,
+                    oneNestedJarUrl,
+                    embeddedJarPathsInNestedJar,
+                    parentFirstPackages,
+                    parentFirstResources);
             }
         }
     }

--- a/embulk-core/src/main/resources/embulk/parent_first_packages.properties
+++ b/embulk-core/src/main/resources/embulk/parent_first_packages.properties
@@ -40,6 +40,7 @@ edu.umd.cs.findbugs.annotations
 io.airlift.slice
 io.netty.buffer
 io.netty.util
+java
 javax.annotation
 javax.inject
 javax.validation


### PR DESCRIPTION
@muga @sakama It tries to load dependency JARs that are embedded in specified plugin JAR. Such nested JARs are built with https://github.com/embulk/embulk-plugins-gradle-plugin/pull/11. They are to be compliant with dependencies' licenses (such as "keep distribution's file structure as-is").

Can you have a look?

This change is trying to avoid impacts on existing behaviors (especially around Gem plugins).

JFYI: Nested JAR files and their `MANIFEST.MF` are structured like below:

```
  Length     Date   Time    Name
 --------    ----   ----    ----
        0  09-25-17 19:39   META-INF/
      284  09-25-17 19:39   META-INF/MANIFEST.MF
        0  09-25-17 19:39   classpath/
   514875  09-21-17 13:46   classpath/threetenbp-1.3.6.jar
    57264  09-21-17 18:53   classpath/json-20170516.jar
        0  09-21-17 14:28   org/
        0  09-21-17 14:28   org/embulk/
        0  09-21-17 14:28   org/embulk/input/
        0  09-25-17 19:39   org/embulk/input/dummy/
      266  09-25-17 19:39   org/embulk/input/dummy/DummyInputPlugin$PluginTask.class
     4514  09-25-17 19:39   org/embulk/input/dummy/DummyInputPlugin.class
 --------                   -------
   577203                   11 files
```

```
Manifest-Version: 1.0
Implementation-Title: embulk-input-dummy
Implementation-Version: 0.0.4
Embulk-Plugin-Spi-Version: 0
Embulk-Plugin-Class-Path: classpath/threetenbp-1.3.6.jar classpath/jso
 n-20170516.jar
Embulk-Plugin-Main-Class: org.embulk.input.dummy.DummyInputPlugin
```
