### PR TITLE
Update liquid 4.0.0 again

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 
     gems 'rubygems:bundler:1.10.6'
     gems 'rubygems:msgpack:1.1.0'
-    gems 'rubygems:liquid:3.0.6'
+    gems 'rubygems:liquid:4.0.0'
 }
 
 task unpackGems(type: JRubyPrepare) {

--- a/embulk.gemspec
+++ b/embulk.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   if RUBY_PLATFORM =~ /java/i
     gem.add_dependency "bundler", '>= 1.10.6'
     gem.add_dependency "msgpack", '~> 1.1.0'
-    gem.add_dependency "liquid", '~> 3.0.6'
+    gem.add_dependency "liquid", '~> 4.0.0'
 
     # For embulk/guess/charset.rb. See also embulk-core/build.gradle
     gem.add_dependency "rjack-icu", '~> 4.54.1.1'


### PR DESCRIPTION
@dmikurube @muga 

Please take a look when you can.

## Summary.

* This PR fix #586 issue. 
* The #586 issue fixed by #587 once. but It occurred regression #627 (See detail #637)
* For fix #627, we needed update JRuby 9.1.11.0 and above.
* The #791 Updated JRuby to 9.1.13.0 (Embulk 0.8.34)
* After update JRuby 9.1.13.0, regression #627 has been fixed.

I checked the following.

1. Fix #586 
2. Does not regression #627 


## 1. Fix #586 Test

This PR Fix #586.

## 1.1 Prepare test

```
git clone https://github.com/yynozk/embulk-error-sample +embulk-error-sample
cd +embulk-error-sample/
```

### 1.2 NG Case (embulk 0.8.34)

```
% embulk run sample.yml.liquid
2017-09-20 20:55:15.297 +0900: Embulk v0.8.34
org.embulk.config.ConfigException: com.fasterxml.jackson.databind.JsonMappingException: Field 'out' is required but not set
 at [Source: N/A; line: -1, column: -1]
	at org.embulk.config.ModelManager.readObjectWithConfigSerDe(ModelManager.java:75)
	at org.embulk.config.DataSourceImpl.loadConfig(DataSourceImpl.java:220)
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:536)
	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:35)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:391)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:387)
	at org.embulk.spi.Exec.doWith(Exec.java:25)
	at org.embulk.exec.BulkLoader.run(BulkLoader.java:387)
	at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:180)
	at org.embulk.EmbulkRunner.runInternal(EmbulkRunner.java:337)
	at org.embulk.EmbulkRunner.run(EmbulkRunner.java:174)
	at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:467)
	at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:99)
	at org.embulk.cli.Main.main(Main.java:28)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Field 'out' is required but not set
 at [Source: N/A; line: -1, column: -1]
	at org.embulk.config.TaskSerDe$TaskDeserializer.deserialize(TaskSerDe.java:181)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:3708)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2005)
	at org.embulk.config.ModelManager.readObjectWithConfigSerDe(ModelManager.java:72)
	... 13 more

Error: com.fasterxml.jackson.databind.JsonMappingException: Field 'out' is required but not set
 at [Source: N/A; line: -1, column: -1]
```

### 1.3. Proposed version (Update Liquid 4.0.0)

```
% embulk-0.8.34.jar run sample.yml.liquid
2017-09-20 20:55:49.153 +0900: Embulk v0.8.3X (Update liquid version)
2017-09-20 20:55:54.745 +0900 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'sample.json'
2017-09-20 20:55:54.748 +0900 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2017-09-20 20:55:54.752 +0900 [INFO] (0001:transaction): Loading files [sample.json]
2017-09-20 20:55:54.772 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 4 = input tasks 1 * 4
2017-09-20 20:55:54.781 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
{"id":1,"name":"foo"}
2017-09-20 20:55:54.874 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2017-09-20 20:55:54.878 +0900 [INFO] (main): Committed.
2017-09-20 20:55:54.879 +0900 [INFO] (main): Next config diff: {"in":{"last_path":"sample.json"},"out":{}}
```

## 2. Regression test

Regression #627 test.

### 2.1 build embulk.gem and startup local rubygems server

```
mkdir -p /tmp/rubygems/gems
cp pkg/embulk-0.8.34.gem /tmp/rubygems/gems
cd /tmp/rubygems
gem generate_index
python3 -m http.server 
```

## 2.2 create mkbundle directory

```
% embulk mkbundle embulk_bundle
2017-09-20 17:08:43.458 +0900: Embulk v0.8.34
Initializing embulk_bundle...
  Creating embulk_bundle/Gemfile
  Creating embulk_bundle/.ruby-version
  Creating embulk_bundle/.bundle/config
  Creating embulk_bundle/embulk/input/example.rb
  Creating embulk_bundle/embulk/output/example.rb
  Creating embulk_bundle/embulk/filter/example.rb
```

```
cd embulk_bundle
vi Gemfile
```

```ruby
source 'https://rubygems.org/'

source 'http://localhost:8000/' do
  gem 'embulk', '~> 0.8.0'
end
```

```
embulk bundle install
2017-09-20 17:10:58.616 +0900: Embulk v0.8.34
Fetching source index from http://localhost:8000/
Fetching gem metadata from https://rubygems.org/...............
Fetching version metadata from https://rubygems.org/..
Resolving dependencies...
Using bundler 1.10.6
Installing liquid 4.0.0     # <-- Liquid 4.0.0 install
Installing msgpack 1.1.0
Installing rjack-icu 4.54.1.1
Installing embulk 0.8.34
Bundle complete! 1 Gemfile dependency, 5 gems now installed.
Bundled gems are installed into ..
```


```
cd ..
```

`config.yml.liquid`

```
{% include 'test' %}
out: {type: stdout}
```

`_test.yml.liquid`

```
in:
  type: file
  path_prefix: /private/tmp/hoge/csv/sample_
  decoders:
  - {type: gzip}
  parser:
    charset: UTF-8
    newline: LF
    type: csv
    delimiter: ','
    quote: '"'
    escape: '"'
    null_string: 'NULL'
    trim_if_not_quoted: false
    skip_header_lines: 1
    allow_extra_columns: false
    allow_optional_columns: false
    columns:
    - {name: id, type: long}
    - {name: account, type: long}
    - {name: time, type: timestamp, format: '%Y-%m-%d %H:%M:%S'}
    - {name: purchase, type: timestamp, format: '%Y%m%d'}
    - {name: comment, type: string}
#out: {type: stdout}
```

### 2.3. embulk run/preview with -b 

```
embulk run -b embulk_bundle config.yml.liquid
2017-09-20 17:12:29.193 +0900: Embulk v0.8.34
2017-09-20 17:12:32.886 +0900 [INFO] (0001:preview): Listing local files at directory '/private/tmp/hoge/csv' filtering filename by prefix 'sample_'
2017-09-20 17:12:32.888 +0900 [INFO] (0001:preview): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2017-09-20 17:12:32.891 +0900 [INFO] (0001:preview): Loading files [/private/tmp/hoge/csv/sample_01.csv.gz]
2017-09-20 17:12:32.898 +0900 [INFO] (0001:preview): Try to read 32,768 bytes from input source
+---------+--------------+-------------------------+-------------------------+----------------------------+
| id:long | account:long |          time:timestamp |      purchase:timestamp |             comment:string |
+---------+--------------+-------------------------+-------------------------+----------------------------+
|       1 |       32,864 | 2015-01-27 19:23:49 UTC | 2015-01-27 00:00:00 UTC |                     embulk |
|       2 |       14,824 | 2015-01-27 19:01:23 UTC | 2015-01-27 00:00:00 UTC |               embulk jruby |
|       3 |       27,559 | 2015-01-28 02:20:02 UTC | 2015-01-28 00:00:00 UTC | Embulk "csv" parser plugin |
|       4 |       11,270 | 2015-01-29 11:54:36 UTC | 2015-01-29 00:00:00 UTC |                            |
+---------+--------------+-------------------------+-------------------------+----------------------------+
```


```
~/OpenProjects/embulk/embulk/pkg/embulk-0.8.34.jar run -b embulk_bundle config.yml.liquid
2017-09-20 17:19:31.115 +0900: Embulk v0.8.34
2017-09-20 17:19:37.480 +0900 [INFO] (0001:transaction): Listing local files at directory '/private/tmp/hoge/csv' filtering filename by prefix 'sample_'
2017-09-20 17:19:37.482 +0900 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2017-09-20 17:19:37.486 +0900 [INFO] (0001:transaction): Loading files [/private/tmp/hoge/csv/sample_01.csv.gz]
2017-09-20 17:19:37.528 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 4 = input tasks 1 * 4
2017-09-20 17:19:37.538 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
1,32864,2015-01-27 19:23:49,20150127,embulk
2,14824,2015-01-27 19:01:23,20150127,embulk jruby
3,27559,2015-01-28 02:20:02,20150128,Embulk "csv" parser plugin
4,11270,2015-01-29 11:54:36,20150129,
2017-09-20 17:19:37.636 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2017-09-20 17:19:37.639 +0900 [INFO] (main): Committed.
2017-09-20 17:19:37.640 +0900 [INFO] (main): Next config diff: {"in":{"last_path":"/private/tmp/hoge/csv/sample_01.csv.gz"},"out":{}}
```