### PR TITLE
Use single-quotes to quote path strings in YAML for Windows.

### DIFF
--- a/embulk-cli/src/main/java/org/embulk/cli/EmbulkExample.java
+++ b/embulk-cli/src/main/java/org/embulk/cli/EmbulkExample.java
@@ -69,7 +69,11 @@ public class EmbulkExample
         StringBuilder ymlBuilder = new StringBuilder();
         ymlBuilder.append("in:\n");
         ymlBuilder.append("  type: file\n");
-        ymlBuilder.append(String.format("  path_prefix: \"%s\"\n",
+
+        // Use single-quotes to quote path strings in YAML for Windows.
+        // Ref YAML spec: Single-Quoted Style
+        // http://yaml.org/spec/1.2/spec.html#id2788097
+        ymlBuilder.append(String.format("  path_prefix: \'%s\'\n",
                                         csvPath.toAbsolutePath().resolve("sample_").toString()));
         ymlBuilder.append("out:\n");
         ymlBuilder.append("  type: stdout\n");


### PR DESCRIPTION
@dmikurube Please take a look when you have a time.

Fix #804

Windows use `\` character in a path.
(ex: C:\Users\admin...)
It treats as an escape character when quoted by a double quote.
For avoiding it use a single quote instead.

Ref: YAML specification [7.3.2. Single-Quoted Style](http://yaml.org/spec/1.2/spec.html#id2788097)