### PR TITLE
Overwriting output file should truncate its contents first

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
@@ -480,7 +480,7 @@ public class EmbulkRunner
     {
         final String yamlString = dumpDataSourceInYaml(modelObject);
         if (path != null) {
-            Files.write(path, yamlString.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            Files.write(path, yamlString.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
         }
         return yamlString;
     }
@@ -490,7 +490,7 @@ public class EmbulkRunner
     {
         final String yamlString = dumpResumeStateInYaml(modelObject);
         if (path != null) {
-            Files.write(path, yamlString.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            Files.write(path, yamlString.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
         }
         return yamlString;
     }


### PR DESCRIPTION
`embulk guess` command with `-o` option makes invalid config file if the
output file is longer than the contents existent in the file before.
How to reproduce:

    $ dd if=/dev/zero of=out.yml count=10
    $ embulk guess seed.yml -o out.yml