### PR TITLE
Fix typo in FALSE_STRINGS and add their test

### DIFF
--- a/lib/embulk/guess/schema_guess.rb
+++ b/lib/embulk/guess/schema_guess.rb
@@ -105,7 +105,7 @@ module Embulk::Guess
       FALSE_STRINGS = Hash[%w[
         false False FALSE
         no No NO
-        f N n N
+        f F n N
         off Off OFF
       ].map {|k| [k, true] }]
 

--- a/test/guess/test_schema_guess.rb
+++ b/test/guess/test_schema_guess.rb
@@ -26,4 +26,22 @@ class SchemaGuessTest < ::Test::Unit::TestCase
         {"a" => "12345678"},
       ]))
   end
+
+  def test_boolean
+    %w[
+      true false t f
+      yes no y n
+      on off
+    ].each do |str|
+      # If at least one of three kinds of boolean strings (i.e., downcase, upcase, capitalize) is
+      # mistakenly detected as "string," the guesser concludes the column type is "string."
+      assert_equal(
+        [C.new(0, "a", :boolean)],
+        G.from_hash_records([
+          {"a" => str.downcase},
+          {"a" => str.upcase},
+          {"a" => str.capitalize},
+        ]))
+    end
+  end
 end


### PR DESCRIPTION
`N` is doubly defined. It should be `F`.