### PR TITLE
Fix typo of a parameter name in Javadoc in PluginClassLoader

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
@@ -118,7 +118,7 @@ public class PluginClassLoader
      * @param oneNestedJarFileUrl  "file:" URL of the plugin JAR file
      * @param embeddedJarPathsInNestedJar  collection of resource names of embedded dependency JARs in the plugin JAR
      * @param parentFirstPackages  collection of package names that are to be loaded first before the plugin's
-     * @param parentFirstResourcess  collection of resource names that are to be loaded first before the plugin's
+     * @param parentFirstResources  collection of resource names that are to be loaded first before the plugin's
      */
     public static PluginClassLoader createForNestedJar(
             final ClassLoader parentClassLoader,


### PR DESCRIPTION
@muga Sorry, it had another typo...