### PR TITLE
Workaround against the rubygems.lasagna.io problem in embulk-docs/

### DIFF
--- a/embulk-docs/build.gradle
+++ b/embulk-docs/build.gradle
@@ -1,3 +1,11 @@
+// TODO: Remove this block once rubygems.lasagna.io is back, or jruby-gradle-jar-plugin is upgraded to 1.5.0.
+// See also: https://github.com/jruby-gradle/jruby-gradle-plugin/issues/297
+// jruby-gradle-jar-plugin is not upgraded yet because its 1.5.0 depends on Java 8.
+repositories {
+    mavenLocal()
+    maven { url 'http://rubygems-proxy.torquebox.org/releases' }
+}
+
 apply plugin: 'com.github.jruby-gradle.base'
 
 import com.github.jrubygradle.JRubyExec


### PR DESCRIPTION
Uploading embulk-docs/ to embulk.org is still failing because of that old lasagna.org problem... https://travis-ci.org/embulk/embulk/jobs/288866021#L1137

@muga @sakama Can you have a look?
