### PR TITLE
Locate embedded dependency gems under gems/ in Embulk .jar file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,10 +269,10 @@ project(':embulk-cli') {
 }
 
 task rubyTestVanilla(type: JRubyExec, dependsOn: "classpath") {
-    jrubyArgs '-Ilib', '-Itest', '-rtest/unit', '--debug', './test/vanilla/run-test.rb'
+    jrubyArgs '-Ilib', '-Itest', '--debug', './test/vanilla/run-test.rb', "${rootProject.projectDir}/classpath/embulk-core-${project.version}.jar"
 }
 task rubyTestMonkeyStrptime(type: JRubyExec, dependsOn: "classpath") {
-    jrubyArgs '-Ilib', '-Itest', '-rtest/unit', '--debug', './test/monkey_strptime/run-test.rb'
+    jrubyArgs '-Ilib', '-Itest', '--debug', './test/monkey_strptime/run-test.rb', "${rootProject.projectDir}/classpath/embulk-core-${project.version}.jar"
 }
 task rubyTest(dependsOn: ["rubyTestVanilla", "rubyTestMonkeyStrptime"]) {
 }

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.github.jruby-gradle.jar"
 
 // include ruby scripts to jar. don't use sourceSets.main.resources.srcDirs
 // because IntelliJ causes error if srcDirs includes files out of projectDir.
-processResources.from("${rootProject.projectDir}/lib/", "${buildDir}/gemlib")
+processResources.from("${rootProject.projectDir}/lib/", "${buildDir}/gems_as_resources")
 
 configurations {
     // com.google.inject:guice depends on asm and cglib but version of the libraries conflict
@@ -58,18 +58,24 @@ dependencies {
 }
 
 task unpackGems(type: JRubyPrepare) {
-    outputDir file("${buildDir}/gem")
+    doFirst {
+        delete("${buildDir}/gems_as_resources")
+    }
+    outputDir file("${buildDir}/gems_installed")
     dependencies configurations.gems
     doLast {
-        // move to build/gem/*/lib/* to build/gemlib/
-        file("${buildDir}/gem/gems").eachDir { gemDir ->
+        configurations.gems.each { gemFilePath ->
             copy {
-                from "${gemDir}/lib"
-                into "${buildDir}/gemlib/"
-                include "**"
+                from "${buildDir}/gems_installed"
+                into "${buildDir}/gems_as_resources"
+                // These "include" may contain both pure-Ruby and JRuby gems, e.g. "msgpack" and "msgpack-java".
+                // TODO: Specify exact pure-Ruby or JRuby gems.
+                include "gems/${gemFilePath.name.take(gemFilePath.name.lastIndexOf('.'))}/**"
+                include "gems/${gemFilePath.name.take(gemFilePath.name.lastIndexOf('.'))}-java/**"
+                include "specifications/${gemFilePath.name.take(gemFilePath.name.lastIndexOf('.'))}*.gemspec"
             }
         }
-        fileTree(dir: "${buildDir}/gemlib", include: "**/.jrubydir").each { f -> f.delete() }
+        fileTree(dir: "${buildDir}/gems_as_resources", include: "**/.jrubydir").each { f -> f.delete() }
     }
 }
 processResources.dependsOn("unpackGems")

--- a/test/monkey_strptime/run-test.rb
+++ b/test/monkey_strptime/run-test.rb
@@ -5,6 +5,28 @@ test_dir = File.join(base_dir, "test")
 $LOAD_PATH.unshift(lib_dir)
 $LOAD_PATH.unshift(test_dir)
 
+if ARGV.empty?
+  STDERR.puts "No JAR is specified in ARGV. Looking for Embulk core's JAR in: #{base_dir}/classpath"
+  found_jar_files = Dir.glob("#{base_dir}/classpath/embulk-core-*.jar")
+  if found_jar_files.empty?
+    raise IOError, "Embulk core's JAR not found."
+  end
+  if found_jar_files.length > 1
+    raise IOError, "Mulitiple files found like Embulk core's JAR."
+  end
+  embulk_core_jar_path = found_jar_files[0]
+  STDERR.puts "Found. Loading: #{embulk_core_jar_path}"
+else
+  embulk_core_jar_path = ARGV[0]
+end
+# This `require` makes gems embedded in embulk-core-*.jar available to be required.
+require "#{embulk_core_jar_path}"
+
+# This Gem.path trick is needed to load gems embedded in embulk-core.jar when run through jruby-gradle-plugin.
+# It can be after `require "embulk-core.jar"`.
+Gem.path << 'uri:classloader://'
+Gem::Specification.reset
+
 require "helper"
 require "date"
 require "test/unit"

--- a/test/vanilla/run-test.rb
+++ b/test/vanilla/run-test.rb
@@ -5,6 +5,28 @@ test_dir = File.join(base_dir, "test")
 $LOAD_PATH.unshift(lib_dir)
 $LOAD_PATH.unshift(test_dir)
 
+if ARGV.empty?
+  STDERR.puts "No JAR is specified in ARGV. Looking for Embulk core's JAR in: #{base_dir}/classpath"
+  found_jar_files = Dir.glob("#{base_dir}/classpath/embulk-core-*.jar")
+  if found_jar_files.empty?
+    raise IOError, "Embulk core's JAR not found."
+  end
+  if found_jar_files.length > 1
+    raise IOError, "Mulitiple files found like Embulk core's JAR."
+  end
+  embulk_core_jar_path = found_jar_files[0]
+  STDERR.puts "Found. Loading: #{embulk_core_jar_path}"
+else
+  embulk_core_jar_path = ARGV[0]
+end
+# This `require` makes gems embedded in embulk-core-*.jar available to be required.
+require "#{embulk_core_jar_path}"
+
+# This Gem.path trick is needed to load gems embedded in embulk-core.jar when run through jruby-gradle-plugin.
+# It can be after `require "embulk-core.jar"`.
+Gem.path << 'uri:classloader://'
+Gem::Specification.reset
+
 require "test/unit"
 
 Dir.glob("#{base_dir}/test/vanilla/**/test{_,-}*.rb") do |file|


### PR DESCRIPTION
Embedded dependency gems (`msgpack-java`, `liquid`, and `bundler` for the time being) are located under `gems/` and `specifications/` in the embulk-core jar file.

```
META-INF/
  ...
org/
  embulk/
    *.class
    ...
gems/
  bundler-1.10.6/
    ...
  liquid-4.0.0/
    ...
  msgpack-java-1.1.0/
     ...
specifications/
  bundler-1.10.6.gemspec
  msgpack-java-1.1.0.gemspec
  liquid-4.0.0.gemspec
```

With the location, developers and users can load embulk "like gem" in JRuby by

```
require `./embulk-core-....jar`
require `msgpack`
```

Eventually, Embulk's Ruby code would be located like this as well.

@sakama Can you have a look? (Cc: @muga)
