### PR TITLE
Deprecate constructor of org.embulk.spi.util.PagePrinter with TimestampFormatter.FormatterTask

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
@@ -9,6 +9,7 @@ import org.embulk.spi.Column;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.type.TimestampType;
+import org.joda.time.DateTimeZone;
 
 public class PagePrinter
 {
@@ -17,14 +18,29 @@ public class PagePrinter
     private final ArrayList<String> record;
 
     // TODO: Update this constructor because |TimestampFormater.FormatterTask| is deprecated since v0.6.14.
+    @Deprecated
     public PagePrinter(Schema schema, TimestampFormatter.FormatterTask task)
+    {
+        this(schema, task.getTimeZone());
+        // NOTE: Its deprecation is not actually from ScriptingContainer, though.
+        // TODO: Notify users about deprecated calls through the notification reporter.
+        if (!deprecationWarned) {
+            System.err.println("[WARN] Plugin uses deprecated constructor of org.embulk.spi.util.PagePrinter.");
+            System.err.println("[WARN] Report plugins in your config at: https://github.com/embulk/embulk/issues/827");
+            // The |deprecationWarned| flag is used only for warning messages.
+            // Even in case of race conditions, messages are just duplicated -- should be acceptable.
+            deprecationWarned = true;
+        }
+    }
+
+    public PagePrinter(final Schema schema, final DateTimeZone timezone)
     {
         this.schema = schema;
         this.timestampFormatters = new TimestampFormatter[schema.getColumnCount()];
         for (int i=0; i < timestampFormatters.length; i++) {
             if (schema.getColumnType(i) instanceof TimestampType) {
                 TimestampType type = (TimestampType) schema.getColumnType(i);
-                timestampFormatters[i] = new TimestampFormatter(type.getFormat(), task.getTimeZone());
+                timestampFormatters[i] = new TimestampFormatter(type.getFormat(), timezone);
             }
         }
 
@@ -105,4 +121,6 @@ public class PagePrinter
             string = reader.getJson(column).toString();
         }
     }
+
+    private static boolean deprecationWarned = false;
 }

--- a/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
@@ -1,6 +1,8 @@
 package org.embulk.standards;
 
 import java.util.List;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskSource;
 import org.embulk.config.ConfigDiff;
@@ -14,13 +16,17 @@ import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.TransactionalPageOutput;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.util.PagePrinter;
+import org.joda.time.DateTimeZone;
 
 public class StdoutOutputPlugin
         implements OutputPlugin
 {
     public interface PluginTask
-            extends Task, TimestampFormatter.FormatterTask
+            extends Task
     {
+        @Config("timezone")
+        @ConfigDefault("\"UTC\"")
+        public DateTimeZone getTimeZone();
     }
 
     @Override
@@ -54,7 +60,7 @@ public class StdoutOutputPlugin
 
         return new TransactionalPageOutput() {
             private final PageReader reader = new PageReader(schema);
-            private final PagePrinter printer = new PagePrinter(schema, task);
+            private final PagePrinter printer = new PagePrinter(schema, task.getTimeZone());
 
             public void add(Page page)
             {


### PR DESCRIPTION
@muga Can you have a look?

`org.embulk.spi.util.PagePrinter` has been implemented with deprecated `TimestampFormatter.FormatterTask`... The constructor is also to be deprecated.