### PR TITLE
Deprecate newFormatter with TimestampFormatter.FormatterTask and newParser with TimestampParser.ParserTask in TimestampFormat

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
@@ -38,11 +38,6 @@ public class TimestampFormat
         return new TimestampFormatter(format, task.getTimeZone());
     }
 
-    public TimestampFormatter newFormatter(final DateTimeZone timezone)
-    {
-        return new TimestampFormatter(format, timezone);
-    }
-
     @Deprecated
     public TimestampParser newParser(TimestampParser.ParserTask task)
     {
@@ -56,11 +51,6 @@ public class TimestampFormat
             newParserDeprecationWarned = true;
         }
         return new TimestampParser(format, task.getDefaultTimeZone());
-    }
-
-    public TimestampParser newParser(final DateTimeZone timezone)
-    {
-        return new TimestampParser(format, timezone);
     }
 
     private static Set<String> availableTimeZoneNames = ImmutableSet.copyOf(DateTimeZone.getAvailableIDs());

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
@@ -26,13 +26,41 @@ public class TimestampFormat
     @Deprecated
     public TimestampFormatter newFormatter(TimestampFormatter.FormatterTask task)
     {
+        // NOTE: Its deprecation is not actually from ScriptingContainer, though.
+        // TODO: Notify users about deprecated calls through the notification reporter.
+        if (!newFormatterDeprecationWarned) {
+            System.err.println("[WARN] Plugin uses deprecated method org.embulk.spi.time.TimestampFormat.newFormatter");
+            System.err.println("[WARN] Report plugins in your config at: https://github.com/embulk/embulk/issues/828");
+            // The |newFormatterDeprecationWarned| flag is used only for warning messages.
+            // Even in case of race conditions, messages are just duplicated -- should be acceptable.
+            newFormatterDeprecationWarned = true;
+        }
         return new TimestampFormatter(format, task.getTimeZone());
+    }
+
+    public TimestampFormatter newFormatter(final DateTimeZone timezone)
+    {
+        return new TimestampFormatter(format, timezone);
     }
 
     @Deprecated
     public TimestampParser newParser(TimestampParser.ParserTask task)
     {
+        // NOTE: Its deprecation is not actually from ScriptingContainer, though.
+        // TODO: Notify users about deprecated calls through the notification reporter.
+        if (!newParserDeprecationWarned) {
+            System.err.println("[WARN] Plugin uses deprecated method org.embulk.spi.time.TimestampFormat.newParser");
+            System.err.println("[WARN] Report plugins in your config at: https://github.com/embulk/embulk/issues/828");
+            // The |newParserDeprecationWarned| flag is used only for warning messages.
+            // Even in case of race conditions, messages are just duplicated -- should be acceptable.
+            newParserDeprecationWarned = true;
+        }
         return new TimestampParser(format, task.getDefaultTimeZone());
+    }
+
+    public TimestampParser newParser(final DateTimeZone timezone)
+    {
+        return new TimestampParser(format, timezone);
     }
 
     private static Set<String> availableTimeZoneNames = ImmutableSet.copyOf(DateTimeZone.getAvailableIDs());
@@ -68,6 +96,9 @@ public class TimestampFormat
             return null;
         }
     }
+
+    private static boolean newFormatterDeprecationWarned = false;
+    private static boolean newParserDeprecationWarned = false;
 
     //// Java standard TimeZone
     //static TimeZone parseDateTimeZone(String s)


### PR DESCRIPTION
`TimestampFormat`'s `newFormatter` and `newParser` have been implemented with `TimestampFormatter.FormatterTask` and `TimestampParser.ParserTask` which have been deprecated for a long time.
