### PR TITLE
Process yday (day of the year) in TimestampParser as well: Fix #834

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
@@ -228,11 +228,16 @@ public class TimestampParser
 
             // set up with min this and then add to allow rolling over
             DateTime dt = new DateTime(year, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
-            if (FormatBag.has(bag.getMon())) {
-                dt = dt.plusMonths(bag.getMon() - 1);
+            if (FormatBag.has(bag.getYDay())) {  // yday is more prioritized than mon/mday in Ruby's strptime.
+                dt = dt.plusDays(bag.getYDay() - 1);
             }
-            if (FormatBag.has(bag.getMDay())) {
-                dt = dt.plusDays(bag.getMDay() - 1);
+            else {
+                if (FormatBag.has(bag.getMon())) {
+                    dt = dt.plusMonths(bag.getMon() - 1);
+                }
+                if (FormatBag.has(bag.getMDay())) {
+                    dt = dt.plusDays(bag.getMDay() - 1);
+                }
             }
             if (FormatBag.has(bag.getHour())) {
                 dt = dt.plusHours(bag.getHour());

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -113,12 +113,10 @@ public class TestTimestampParser {
         testToParse("12006-08-06", "%Y-%m-%d", 316724342400L);
         testToParse("200608 6", "%Y%m%e", 1154822400L);
 
-        // TODO: Process %j with TimestampParser.
-        // https://github.com/embulk/embulk/issues/834
-        // testToParse("2006333", "%Y%j");
-        // testToParse("20069333", "%Y9%j");
-        // testToParse("12006 333", "%Y %j");
-        // testToParse("12006-333", "%Y-%j");
+        testToParse("2006333", "%Y%j", 1164758400L);
+        testToParse("20069333", "%Y9%j", 1164758400L);
+        testToParse("12006 333", "%Y %j", 316734278400L);
+        testToParse("12006-333", "%Y-%j", 316734278400L);
 
         testToParse("232425", "%H%M%S", 81955409065L);
         testToParse("23924925", "%H9%M9%S", 81955409065L);


### PR DESCRIPTION
@muga Fixing #834 ... supporting yday (`%j`) in `TimestampParser`. Can you have a look?