### PR TITLE
[Doc] Fix sphinx warnings

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -365,7 +365,7 @@ if you set invalid\_string\_escapes and appear invalid JSON string (such as ``\a
 +----------------------------+------------------+
 | invalid\_string\_escapes   | convert to       |
 +============================+==================+
-| PASSTHROUGH *1             | ``\a``           |
+| PASSTHROUGH \*1            | ``\a``           |
 +----------------------------+------------------+
 | SKIP                       | empty string     |
 +----------------------------+------------------+

--- a/embulk-docs/src/developers/index.rst
+++ b/embulk-docs/src/developers/index.rst
@@ -1,3 +1,8 @@
+.. Avoid the following warning. Remove if you add a link for this document.
+   WARNING: document isn't included in any toctree
+
+:orphan:
+
 For core/plugin developers
 ===========================
 


### PR DESCRIPTION
Fix the following warnings.

Please take a look when you have a time.

```
embulk-docs/src/built-in.rst:369: WARNING: Inline emphasis start-string without end-string.
embulk-docs/src/developers/index.rst:: WARNING: document isn't included in any toctree
```