### PR TITLE
Name and comment StrptimeParser's %Q as milliseconds, not microseconds

### DIFF
--- a/embulk-jruby-strptime/src/main/java/org/embulk/spi/time/StrptimeFormat.java
+++ b/embulk-jruby-strptime/src/main/java/org/embulk/spi/time/StrptimeFormat.java
@@ -36,7 +36,7 @@ enum StrptimeFormat
     FORMAT_NANOSEC, // %N
     FORMAT_MERIDIAN_LOWER_CASE, // %P
     FORMAT_MERIDIAN, // %p
-    FORMAT_MICROSEC_EPOCH, // %Q Only for Date/DateTime from here
+    FORMAT_MILLISEC_EPOCH, // %Q Only for Date/DateTime from here
     FORMAT_SECONDS, // %S
     FORMAT_EPOCH, // %s
     FORMAT_WEEK_YEAR_S, // %U

--- a/embulk-jruby-strptime/src/main/java/org/embulk/spi/time/StrptimeParser.java
+++ b/embulk-jruby-strptime/src/main/java/org/embulk/spi/time/StrptimeParser.java
@@ -576,7 +576,7 @@ public class StrptimeParser
                         }
                         break;
                     }
-                    case FORMAT_MICROSEC_EPOCH: { // %Q - Number of microseconds since 1970-01-01 00:00:00 UTC.
+                    case FORMAT_MILLISEC_EPOCH: { // %Q - Number of milliseconds since 1970-01-01 00:00:00 UTC.
                         boolean negative = false;
                         if (isMinus(text, pos)) {
                             negative = true;

--- a/embulk-jruby-strptime/src/main/java/org/embulk/spi/time/StrptimeToken.java
+++ b/embulk-jruby-strptime/src/main/java/org/embulk/spi/time/StrptimeToken.java
@@ -39,7 +39,7 @@ public class StrptimeToken
         CONVERSION2TOKEN['N'] = new StrptimeToken(FORMAT_NANOSEC);
         CONVERSION2TOKEN['P'] = new StrptimeToken(FORMAT_MERIDIAN_LOWER_CASE);
         CONVERSION2TOKEN['p'] = new StrptimeToken(FORMAT_MERIDIAN);
-        CONVERSION2TOKEN['Q'] = new StrptimeToken(FORMAT_MICROSEC_EPOCH);
+        CONVERSION2TOKEN['Q'] = new StrptimeToken(FORMAT_MILLISEC_EPOCH);
         CONVERSION2TOKEN['S'] = new StrptimeToken(FORMAT_SECONDS);
         CONVERSION2TOKEN['s'] = new StrptimeToken(FORMAT_EPOCH);
         CONVERSION2TOKEN['U'] = new StrptimeToken(FORMAT_WEEK_YEAR_S);


### PR DESCRIPTION
@muga Not affecting any behavior, though.

`%Q` looks actually "milliseconds" in Ruby's documents, and even in our implementation behavior. But, the constant name and the comments are written it's "microseconds"...
https://docs.ruby-lang.org/en/2.4.0/DateTime.html#method-i-strftime

It might come from JRuby's long-lived code:
https://github.com/jruby/jruby/blame/a41e22b8f44114fc2783798cd22c76c47876bc51/core/src/main/java/org/jruby/util/RubyDateFormatter.java#L144-L146
