### PR TITLE
Fix nanoseconds set by StrptimeParser's %Q

### DIFF
--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -207,7 +207,7 @@ public class TestTimestampParser {
         testToParse("-1", "%s", -1L);
         testToParse("-86400", "%s", -86400L);
 
-        testToParse("-999", "%Q", 0L);
+        testToParse("-999", "%Q", 0L, -999000000);
         testToParse("-1000", "%Q", -1L);
     }
 


### PR DESCRIPTION
@muga Can you have a look? I guess it's the last fix on `TimestampParser`.