### PR TITLE
Bump master to 0.9.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ def release_projects = [project(":embulk-core"), project(":embulk-standards"), p
 
 allprojects {
     group = 'org.embulk'
-    version = '0.8.38'
+    version = '0.9.0-SNAPSHOT'
 
     ext {
         jrubyVersion = '9.1.13.0'

--- a/lib/embulk/version.rb
+++ b/lib/embulk/version.rb
@@ -3,7 +3,7 @@
 module Embulk
   @@warned = false
 
-  VERSION_INTERNAL = '0.8.38'
+  VERSION_INTERNAL = '0.9.0.snapshot'
 
   DEPRECATED_MESSAGE = 'Embulk::VERSION in (J)Ruby is deprecated. Use org.embulk.EmbulkVersion::VERSION instead. If this message is from a plugin, please tell this to the author of the plugin!'
   def self.const_missing(name)


### PR DESCRIPTION
@muga @sakama Considering to go into v0.9 series development after v0.8.38 is released (#851). Can you have a look?