### PR TITLE
Make Ruby Embulk::VERSION based on Java org.embulk.EmbulkVersion.VERSION

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,16 @@ subprojects {
             }
         }
 
+        jar {
+            manifest {
+                attributes 'Implementation-Title': project.name,
+                           'Implementation-Version': project.version,
+                           'Implementation-Vendor-Id': project.group,
+                           'Specification-Title': project.name,
+                           'Specification-Version': project.version
+            }
+        }
+
         // add tests/javadoc/source jar tasks as artifacts to be released
         task testsJar(type: Jar, dependsOn: classes) {
             classifier = 'tests'
@@ -252,10 +262,10 @@ project(':embulk-cli') {
         // NOTE: This 'Implementation-Version' in the manifest is referred to provide the Embulk version at runtime.
         // See also: embulk-core/src/main/java/org/embulk/EmbulkVersion.java
         manifest {
-            attributes 'Implementation-Title': project.name,
+            attributes 'Implementation-Title': 'embulk',
                        'Implementation-Version': project.version,
                        'Implementation-Vendor-Id': project.group,
-                       'Specification-Title': project.name,
+                       'Specification-Title': 'embulk',
                        'Specification-Version': project.version,
                        'Main-Class': 'org.embulk.cli.Main'
         }

--- a/embulk-core/src/main/ruby/embulk/version.rb
+++ b/embulk-core/src/main/ruby/embulk/version.rb
@@ -1,24 +1,5 @@
-# TODO(v2)[#562]: Remove this file.
-# https://github.com/embulk/embulk/issues/562
 module Embulk
-  @@warned = false
-
-  VERSION_INTERNAL = '0.9.0.snapshot'
-
-  DEPRECATED_MESSAGE = 'Embulk::VERSION in (J)Ruby is deprecated. Use org.embulk.EmbulkVersion::VERSION instead. If this message is from a plugin, please tell this to the author of the plugin!'
-  def self.const_missing(name)
-    if name == :VERSION
-      unless @@warned
-        if Embulk.method_defined?(:logger)
-          Embulk.logger.warn(DEPRECATED_MESSAGE)
-          @@warned = true
-        else
-          STDERR.puts(DEPRECATED_MESSAGE)
-        end
-      end
-      return VERSION_INTERNAL
-    else
-      super
-    end
-  end
+  # Converts the original Java-style version string to Ruby-style.
+  # E.g., "0.9.0-SNAPSHOT" (in Java) is converted to "0.9.0.snapshot" in Ruby.
+  VERSION = ::String.new(Java::org.embulk.EmbulkVersion::VERSION).tr('-', '.').downcase
 end


### PR DESCRIPTION
We'd like to have a version declaration just in one place! This PR automatically generates Ruby version string (`lib/embulk/verison.rb`) from Java version strting (`org.embulk.EmbulkVersion.VERSION`).

@sakama (Cc: @muga) Can you have a look?