### PR TITLE
Unspecify embulk gem's version in Gemfile template of bundle directories

### DIFF
--- a/embulk-cli/src/main/resources/new_bundle_templates/Gemfile
+++ b/embulk-cli/src/main/resources/new_bundle_templates/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org/'
-gem 'embulk', '~> 0.8.0'
+
+# No versions are specified for 'embulk' to use the gem embedded in embulk.jar.
+# Note that prerelease versions (e.g. "0.9.0.beta") do not match the statement.
+# Specify the exact prerelease version (like '= 0.9.0.beta') for prereleases.
+gem 'embulk'
 
 #
 # 1. Use following syntax to specify versions of plugins
@@ -28,4 +32,3 @@ gem 'embulk', '~> 0.8.0'
 #   $ embulk run -b path/to/this/directory  ...
 #   $ embulk preview -b path/to/this/directory  ...
 #
-


### PR DESCRIPTION
We will no longer release `embulk.gem` from the v0.9 series. Embulk's `-b` option however needed to install `embulk.gem` as its dependency.

`embulk.jar`, the only distribution of Embulk v0.9+, will contain gem's structure in itself. `Gemfile` of bundle directories won't need Embulk versions to refer the embedded embulk gem.

@sakama (Cc: @muga) Can you have a look?

----

Bundler (for -b) can find required gems in embulk.jar by the 3 preceding fixes.
Gemfile in "bundle directories" would refer embulk's gem embedded in jar.
Its version should be automatically resolved, not specified in Gemfile.

The preceding fixes:
1. Embulk's Ruby code is now embedded as a gem in embulk.jar by #856.
   Standalone embulk.gem is no longer released.
2. Other dependency gems are also embedded in embulk.jar as gems by #819.
3. Bundler's issue is worked-around by #862.

The difference:
```
$ ../pkg/embulk-0.9.0-SNAPSHOT bundle
YYYY-MM-DD hh:mm:ss.nnn +ZZZZ: Embulk v0.9.0-SNAPSHOT
Fetching gem metadata from https://rubygems.org/...............
Fetching version metadata from https://rubygems.org/..
Resolving dependencies...
Using bundler 1.10.6
Using liquid 4.0.0
Using msgpack 1.1.0
Using embulk 0.9.0.snapshot
Installing embulk-input-s3 0.2.11
Bundle complete! 2 Gemfile dependencies, 5 gems now installed.
Bundled gems are installed into ..
```

```
$ embulk bundle
YYYY-MM-DD hh:mm:ss.nnn +ZZZZ: Embulk v0.8.38
Fetching gem metadata from https://rubygems.org/...............
Fetching version metadata from https://rubygems.org/..
Resolving dependencies...
Using bundler 1.10.6
Installing liquid 4.0.0
Installing msgpack 1.1.0
Installing rjack-icu 4.54.1.1
Installing embulk 0.8.38
Installing embulk-input-s3 0.2.11
Bundle complete! 2 Gemfile dependencies, 6 gems now installed.
Bundled gems are installed into ..
```
