### PR TITLE
Parse time zones in Ruby-style in lower priority than Joda-Time

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
@@ -57,20 +57,39 @@ public class TimestampFormat
 
     public static DateTimeZone parseDateTimeZone(String s)
     {
-        final int rubyStyleTimeOffsetInSecond = TimeZoneConverter.dateZoneToDiff(s);
-
-        if (rubyStyleTimeOffsetInSecond != Integer.MIN_VALUE) {
-            return DateTimeZone.forOffsetMillis(rubyStyleTimeOffsetInSecond * 1000);
+        DateTimeZone jodaDateTimeZoneTemporary = null;
+        try {
+            // Use TimeZone#forID, not TimeZone#getTimeZone.
+            // Because getTimeZone returns GMT even if given timezone id is not found.
+            jodaDateTimeZoneTemporary = DateTimeZone.forID(s);
         }
+        catch (IllegalArgumentException ex) {
+            jodaDateTimeZoneTemporary = null;
+        }
+        final DateTimeZone jodaDateTimeZone = jodaDateTimeZoneTemporary;
 
-        if(s.startsWith("+") || s.startsWith("-")) {
-            return DateTimeZone.forID(s);
+        if (jodaDateTimeZone != null && (s.startsWith("+") || s.startsWith("-"))) {
+            return jodaDateTimeZone;
 
         } else if (s.equals("Z")) {
             return DateTimeZone.UTC;
 
         } else {
             try {
+                // DateTimeFormat.forPattern("z").parseMillis(s) is incorrect, but kept for compatibility as of now.
+                //
+                // The offset of PDT (Pacific Daylight Time) should be -07:00.
+                // DateTimeFormat.forPattern("z").parseMillis("PDT") however returns 8 hours (-08:00).
+                // DateTimeFormat.forPattern("z").parseMillis("PDT") == 28800000
+                // https://github.com/JodaOrg/joda-time/blob/v2.9.2/src/main/java/org/joda/time/DateTimeUtils.java#L446
+                //
+                // Embulk has used it to parse time zones for a very long time since it was v0.1.
+                // https://github.com/embulk/embulk/commit/b97954a5c78397e1269bbb6979d6225dfceb4e05
+                //
+                // It is kept as -08:00 for compatibility as of now.
+                //
+                // TODO: Make time zone parsing consistent.
+                // @see <a href="https://github.com/embulk/embulk/issues/860">https://github.com/embulk/embulk/issues/860</a>
                 int rawOffset = (int) DateTimeFormat.forPattern("z").parseMillis(s);
                 if(rawOffset == 0) {
                     return DateTimeZone.UTC;
@@ -83,12 +102,24 @@ public class TimestampFormat
                 // parseMillis failed
             }
 
-            // TimeZone.getTimeZone returns GMT zone if given timezone id is not found
-            // we want to only return timezone if exact match, otherwise exception
-            if (availableTimeZoneNames.contains(s)) {
-                //return TimeZone.getTimeZone(s);
-                return DateTimeZone.forID(s);
+            if (jodaDateTimeZone != null && availableTimeZoneNames.contains(s)) {
+                return jodaDateTimeZone;
             }
+
+            // Parsing Ruby-style time zones in lower priority than Joda-Time because
+            // TimestampParser has parsed time zones with Joda-Time for a long time
+            // since ancient. The behavior is kept for compatibility.
+            //
+            // The following time zone IDs are duplicated in Ruby and Joda-Time 2.9.2
+            // while Ruby does not care summer time and Joda-Time cares summer time.
+            // "CET", "EET", "Egypt", "Iran", "MET", "WET"
+            //
+            // Some zone IDs (ex. "PDT") are parsed by DateTimeFormat#parseMillis as shown above.
+            final int rubyStyleTimeOffsetInSecond = TimeZoneConverter.dateZoneToDiff(s);
+            if (rubyStyleTimeOffsetInSecond != Integer.MIN_VALUE) {
+                return DateTimeZone.forOffsetMillis(rubyStyleTimeOffsetInSecond * 1000);
+            }
+
             return null;
         }
     }

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -55,7 +55,22 @@ public class TestTimestampParser {
     public void test__strptime__3_rfc822() {
         testToParse("Thu, 29 Jul 1999 09:54:21 UT", "%a, %d %b %Y %H:%M:%S %Z", 933242061L);
         testToParse("Thu, 29 Jul 1999 09:54:21 GMT", "%a, %d %b %Y %H:%M:%S %Z", 933242061L);
-        testToParse("Thu, 29 Jul 1999 09:54:21 PDT", "%a, %d %b %Y %H:%M:%S %Z", 933267261L);
+
+        // It should be 933267261L if PDT (Pacific Daylight Time) is correctly -07:00.
+        //
+        // Joda-Time's DateTimeFormat.forPattern("z").parseMillis("PDT") however returns 8 hours (-08:00).
+        // DateTimeFormat.forPattern("z").parseMillis("PDT") == 28800000
+        // https://github.com/JodaOrg/joda-time/blob/v2.9.2/src/main/java/org/joda/time/DateTimeUtils.java#L446
+        //
+        // Embulk has used it to parse time zones for a very long time since it was v0.1.
+        // https://github.com/embulk/embulk/commit/b97954a5c78397e1269bbb6979d6225dfceb4e05
+        //
+        // It is kept as -08:00 for compatibility as of now.
+        //
+        // TODO: Make time zone parsing consistent.
+        // @see <a href="https://github.com/embulk/embulk/issues/860">https://github.com/embulk/embulk/issues/860</a>
+        testToParse("Thu, 29 Jul 1999 09:54:21 PDT", "%a, %d %b %Y %H:%M:%S %Z", 933270861L);
+
         testToParse("Thu, 29 Jul 1999 09:54:21 z", "%a, %d %b %Y %H:%M:%S %Z", 933242061L);
         testToParse("Thu, 29 Jul 1999 09:54:21 +0900", "%a, %d %b %Y %H:%M:%S %Z", 933209661L);
         testToParse("Thu, 29 Jul 1999 09:54:21 +0430", "%a, %d %b %Y %H:%M:%S %Z", 933225861L);

--- a/embulk-core/src/test/ruby/vanilla/time/test_timestamp_parser.rb
+++ b/embulk-core/src/test/ruby/vanilla/time/test_timestamp_parser.rb
@@ -45,7 +45,22 @@ class TimestampParserTest < ::Test::Unit::TestCase
       # rfc822
       ['Thu, 29 Jul 1999 09:54:21 UT', '%a, %d %b %Y %H:%M:%S %Z'],
       ['Thu, 29 Jul 1999 09:54:21 GMT', '%a, %d %b %Y %H:%M:%S %Z'],
-      ['Thu, 29 Jul 1999 09:54:21 PDT', '%a, %d %b %Y %H:%M:%S %Z'],
+
+      # They should be the same if PDT (Pacific Daylight Time) is correctly -07:00.
+      #
+      # Joda-Time's DateTimeFormat.forPattern("z").parseMillis("PDT") however returns 8 hours (-08:00).
+      # DateTimeFormat.forPattern("z").parseMillis("PDT") == 28800000
+      # https://github.com/JodaOrg/joda-time/blob/v2.9.2/src/main/java/org/joda/time/DateTimeUtils.java#L446
+      #
+      # Embulk has used it to parse time zones for a very long time since it was v0.1.
+      # https://github.com/embulk/embulk/commit/b97954a5c78397e1269bbb6979d6225dfceb4e05
+      #
+      # It is kept as -08:00 for compatibility as of now.
+      #
+      # TODO: Make time zone parsing consistent.
+      # See https://github.com/embulk/embulk/issues/860
+      # ['Thu, 29 Jul 1999 09:54:21 PDT', '%a, %d %b %Y %H:%M:%S %Z'],
+
       ['Thu, 29 Jul 1999 09:54:21 z', '%a, %d %b %Y %H:%M:%S %Z'],
       ['Thu, 29 Jul 1999 09:54:21 +0900', '%a, %d %b %Y %H:%M:%S %Z'],
       ['Thu, 29 Jul 1999 09:54:21 +0430', '%a, %d %b %Y %H:%M:%S %Z'],


### PR DESCRIPTION
@muga @sakama Can you have a look?

It was a mistake in #840. I thought there were no duplications between Ruby's and Joda-Time's, but duplicated actually.
https://gist.github.com/dmikurube/c62ea8ebfbb5c41c0dc21584350bb274

If the given time zone is one of "CET", "EET", "Egypt", "Iran", "MET", or "WET", Joda-Time takes care of summer time, but Ruby's does not. It means that Joda-Time considers "CET" to be in summer time (+2) if the date is in a summer time period. Ruby's just always considers "CET" as a fixed offset of an hour (+1).

I'll backport this into v0.8 series, and release v0.8.39.
