### PR TITLE
Upgrade embedded Bundler to 1.16.0

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compile 'org.eclipse.aether:aether-impl:1.1.0'
     compile 'org.apache.maven:maven-aether-provider:3.3.9'
 
-    gems 'rubygems:bundler:1.10.6'
+    gems 'rubygems:bundler:1.16.0'
     gems 'rubygems:msgpack:1.1.0'
     gems 'rubygems:liquid:4.0.0'
 }

--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
@@ -291,7 +291,9 @@ public class JRubyScriptingModule
                     "end\n";
                 jruby.runScriptlet(monkeyPatchOnSharedHelpersCleanLoadPath);
 
-                jruby.runScriptlet("Bundler.load.setup_environment");
+                // Bundler.load.setup_environment was called in Bundler 1.10.6.
+                jruby.runScriptlet("Bundler::SharedHelpers.set_bundle_environment");
+
                 jruby.runScriptlet("require 'bundler/setup'");
                 // since here, `require` may load files of different (newer) embulk versions
                 // especially following 'embulk/command/embulk_main'.


### PR DESCRIPTION
@muga @sakama Upgrading the embedded bundler to the latest.

`Bundler.load.setup_environment` was removed in 1.12.0, so calling `Bundler::SharedHelpers.set_bundle_environment` instead.