### PR TITLE
Stop using the global JRuby runtime when executed through CLI

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkSetup.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkSetup.java
@@ -20,10 +20,6 @@ public class EmbulkSetup
     {
         final HashMap<String, Object> systemConfigModified = new HashMap<String, Object>(systemConfigGiven);
 
-        // use the global ruby runtime for all ScriptingContainer
-        // injected by org.embulk.jruby.JRubyScriptingModule
-        systemConfigModified.put("use_global_ruby_runtime", true);
-
         // Calling ObjectMapper simply just as a formatter here so that it does not depend much on Jackson.
         // Do not leak the Jackson object outside.
         final ObjectMapper jacksonObjectMapper = new ObjectMapper();

--- a/embulk-core/src/test/ruby/helper.rb
+++ b/embulk-core/src/test/ruby/helper.rb
@@ -21,5 +21,9 @@ require 'embulk/java/bootstrap'
 require 'embulk'
 
 require 'embulk/runner'
-runner_java = Embulk::EmbulkRunner.new(Java::org.embulk.EmbulkSetup::setup(Java::java.util.HashMap.new({})))
+
+# "use_global_ruby_runtime" needs to be true because this test process starts from JRuby, the global instance.
+runner_java = Embulk::EmbulkRunner.new(Java::org.embulk.EmbulkSetup::setup(
+                                         Java::java.util.HashMap.new({"use_global_ruby_runtime": true})))
+
 Embulk.const_set :Runner, runner_java


### PR DESCRIPTION
The JRuby instance for plugins is now operated only in `JRubyScriptingModule`. We can use non-global JRuby instance.

@muga @sakama Can you have a look?