### PR TITLE
Allow no guess plugins registered in embulk-core: Fix #876

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/BuiltinPluginSourceModule.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/BuiltinPluginSourceModule.java
@@ -3,6 +3,7 @@ package org.embulk.plugin;
 import com.google.inject.Module;
 import com.google.inject.Binder;
 import com.google.inject.multibindings.Multibinder;
+import org.embulk.exec.ForGuess;
 
 public class BuiltinPluginSourceModule
         implements Module
@@ -13,5 +14,11 @@ public class BuiltinPluginSourceModule
         Multibinder<PluginSource> multibinder = Multibinder.newSetBinder(binder, PluginSource.class);
         //multibinder.addBinding().to(LocalDirectoryPluginSource.class);  // TODO
         multibinder.addBinding().to(InjectedPluginSource.class);
+
+        // This workaround allows no any guess plugin registered. See also:
+        // https://github.com/embulk/embulk/issues/876
+        // https://groups.google.com/forum/#!topic/google-guice/5Rnm-d7MU34
+        // TODO: Remove this workaround.
+        Multibinder.newSetBinder(binder, PluginType.class, ForGuess.class);
     }
 }


### PR DESCRIPTION
@muga @sakama Can you PTAL?

I've just found a problem around guess (#876), and this PR workarounds the problem.

----

I'm actually not 100% sure whether `BuiltinPluginSourceModule` is the right place to add this workaround. But I thought adding a new Guice Module was too much, and `BuiltinPluginSourceModule` could fit the purpose as it's binding a kind of dummy as a default builtin.