### PR TITLE
Eliminate "import org.jruby..." from CLI and embulk-standards

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
@@ -23,9 +23,7 @@ import org.embulk.exec.ExecutionResult;
 import org.embulk.exec.PreviewResult;
 import org.embulk.exec.ResumeState;
 import org.embulk.exec.TransactionStage;
-import org.jruby.embed.LocalContextScope;
-import org.jruby.embed.LocalVariableBehavior;
-import org.jruby.embed.ScriptingContainer;
+import org.embulk.jruby.ScriptingContainerDelegate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -426,9 +424,11 @@ public class EmbulkRunner
             final String templateIncludePath)
     {
         // TODO: Check if it is required to process JRuby options.
-        // Not |LocalContextScope.SINGLETON| to narrow down considerations.
-        final ScriptingContainer localJRubyContainer =
-            new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.PERSISTENT);
+        // Not |ScriptingContainerDelegate.LocalContextScope.SINGLETON| to narrow down considerations.
+        final ScriptingContainerDelegate localJRubyContainer = ScriptingContainerDelegate.create(
+            EmbulkRunner.class.getClassLoader(),
+            ScriptingContainerDelegate.LocalContextScope.SINGLETHREAD,
+            ScriptingContainerDelegate.LocalVariableBehavior.PERSISTENT);
 
         localJRubyContainer.runScriptlet("require 'liquid'");
 

--- a/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
@@ -22,15 +22,16 @@ import org.embulk.spi.json.JsonParseException;
 import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.type.Types;
 import org.embulk.spi.util.FileInputInputStream;
-import org.jruby.embed.io.ReaderInputStream;
 import org.msgpack.core.Preconditions;
 import org.msgpack.value.Value;
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 public class JsonParserPlugin
@@ -150,7 +151,7 @@ public class JsonParserPlugin
             case UNESCAPE:
                 Iterable<CharSource> lines = Lists.transform(CharStreams.readLines(new BufferedReader(new InputStreamReader(in))),
                         invalidEscapeStringFunction(policy));
-                return new JsonParser().open(new ReaderInputStream(CharSource.concat(lines).openStream()));
+                return new JsonParser().open(new ByteArrayInputStream(CharStreams.toString(CharSource.concat(lines).openStream()).getBytes(StandardCharsets.UTF_8)));
             case PASSTHROUGH:
             default:
                 return new JsonParser().open(in);


### PR DESCRIPTION
After merging embulk-cli to embulk-core (#883), stopping to use JRuby directly from CLI, and embulk-standards.

@muga @sakama Can you PTAL?