### PR TITLE
Use java.time.Instant in org.embulk.spi.time.Timestamp

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/Timestamp.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/Timestamp.java
@@ -1,107 +1,97 @@
 package org.embulk.spi.time;
 
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.DateTime;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 public class Timestamp
         implements Comparable<Timestamp>
 {
-    private final static DateTimeFormatter TO_STRING_FORMATTER_SECONDS = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss ").withZoneUTC();
-    private final static DateTimeFormatter TO_STRING_FORMATTER_MILLIS = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS ").withZoneUTC();
-    private final static DateTimeFormatter TO_STRING_FORMATTER_CUSTOM = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZoneUTC();
-    private static final Pattern FROM_STRING_PATTERN = Pattern.compile("(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})(?:\\.(\\d{1,9}))? (?:UTC|\\+?00\\:?00)");
-
-    private final long seconds;
-    private final int nano;
-
-    private Timestamp(long seconds, int nano)
+    private Timestamp(final Instant instant)
     {
-        this.seconds = seconds;
-        this.nano = nano;
+        this.instant = instant;
     }
 
-    public static Timestamp ofEpochSecond(long epochSecond)
+    public static Timestamp ofInstant(final Instant instant)
     {
-        return new Timestamp(epochSecond, 0);
+        return new Timestamp(instant);
     }
 
-    public static Timestamp ofEpochSecond(long epochSecond, long nanoAdjustment)
+    public static Timestamp ofEpochSecond(final long epochSecond)
     {
-        return new Timestamp(epochSecond + nanoAdjustment / 1000000000, (int) (nanoAdjustment % 1000000000));
+        return new Timestamp(Instant.ofEpochSecond(epochSecond));
     }
 
-    public static Timestamp ofEpochMilli(long epochMilli)
+    public static Timestamp ofEpochSecond(final long epochSecond, final long nanoAdjustment)
     {
-        return new Timestamp(epochMilli / 1000, (int) (epochMilli % 1000 * 1000000));
+        return new Timestamp(Instant.ofEpochSecond(epochSecond, nanoAdjustment));
+    }
+
+    public static Timestamp ofEpochMilli(final long epochMilli)
+    {
+        return new Timestamp(Instant.ofEpochMilli(epochMilli));
+    }
+
+    public Instant getInstant()
+    {
+        return this.instant;
     }
 
     public long getEpochSecond()
     {
-        return seconds;
+        return this.instant.getEpochSecond();
     }
 
     public int getNano()
     {
-        return nano;
+        return this.instant.getNano();
     }
 
     public long toEpochMilli()
     {
-        return seconds * 1000 + nano / 1000000;
+        return this.instant.toEpochMilli();
     }
 
     @Override
-    public boolean equals(Object other)
+    public boolean equals(final Object otherObject)
     {
-        if (this == other) {
+        if (this == otherObject) {
             return true;
         }
-        if (!(other instanceof Timestamp)) {
+        if (!(otherObject instanceof Timestamp)) {
             return false;
         }
-        Timestamp o = (Timestamp) other;
-        return this.seconds == o.seconds && this.nano == o.nano;
+        final Timestamp other = (Timestamp)otherObject;
+        return this.instant.equals(other.instant);
     }
 
     @Override
     public int hashCode()
     {
-        int h = (int) (seconds ^ (seconds >>> 32));
-        h += 17 * nano;
-        return h;
+        return this.instant.hashCode() ^ 0x55555555;
     }
 
     @Override
-    public int compareTo(Timestamp t)
+    public int compareTo(final Timestamp other)
     {
-        if (seconds < t.seconds) {
-            return -1;
-        } else if (seconds == t.seconds) {
-            return nano == t.nano ? 0 : (nano < t.nano ? -1 : 1);
-        } else {
-            return 1;
-        }
+        return this.instant.compareTo(other.instant);
     }
 
     @Override
     public String toString()
     {
+        final int nano = this.instant.getNano();
         if (nano == 0) {
-            return TO_STRING_FORMATTER_SECONDS.print(getEpochSecond() * 1000) + "UTC";
-
+            return FORMATTER_SECONDS.format(this.instant) + " UTC";
         } else if (nano % 1000000 == 0) {
-            return TO_STRING_FORMATTER_MILLIS.print(toEpochMilli()) + "UTC";
-
+            return FORMATTER_MILLISECONDS.format(this.instant) + " UTC";
         } else {
-            StringBuffer sb = new StringBuffer();
-            TO_STRING_FORMATTER_CUSTOM.printTo(sb, getEpochSecond() * 1000);
-            sb.append(".");
+            final StringBuilder builder = new StringBuilder();
+            FORMATTER_SECONDS.formatTo(this.instant, builder);
+            builder.append(".");
 
-            String digits;
-            int zeroDigits;
+            final String digits;
+            final int zeroDigits;
             if (nano % 1000 == 0) {
                 digits = Integer.toString(nano / 1000);
                 zeroDigits = 6 - digits.length();
@@ -109,34 +99,20 @@ public class Timestamp
                 digits = Integer.toString(nano);
                 zeroDigits = 9 - digits.length();
             }
-            sb.append(digits);
-            for (; zeroDigits > 0; zeroDigits--) {
-                sb.append('0');
+            builder.append(digits);
+            for (int i = 0; i < zeroDigits; i++) {
+                builder.append('0');
             }
 
-            sb.append(" UTC");
-            return sb.toString();
+            builder.append(" UTC");
+            return builder.toString();
         }
     }
 
-    static Timestamp fromString(String text)
-    {
-        // TODO exception handling
-        Matcher m = FROM_STRING_PATTERN.matcher(text);
-        if (!m.matches()) {
-            throw new IllegalArgumentException(String.format("Invalid timestamp format '%s'", text));
-        }
+    private static final DateTimeFormatter FORMATTER_SECONDS =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter FORMATTER_MILLISECONDS =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
 
-        long seconds = TO_STRING_FORMATTER_CUSTOM.parseDateTime(m.group(1)).getMillis() / 1000;
-
-        int nano;
-        String frac = m.group(2);
-        if (frac == null) {
-            nano = 0;
-        } else {
-            nano = Integer.parseInt(frac) * (int) Math.pow(10, 9 - frac.length());
-        }
-
-        return new Timestamp(seconds, nano);
-    }
+    private final Instant instant;
 }

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampSerDe.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampSerDe.java
@@ -1,13 +1,18 @@
 package org.embulk.spi.time;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.module.guice.ObjectMapperModule;
 
 public class TimestampSerDe
@@ -43,7 +48,38 @@ public class TimestampSerDe
         protected Timestamp _deserialize(String value, DeserializationContext context)
                 throws JsonMappingException
         {
-            return Timestamp.fromString(value);
+            return createTimestampFromString(value);
         }
     }
+
+    static Timestamp createTimestampFromStringForTesting(final String string)
+    {
+        return createTimestampFromString(string);
+    }
+
+    private static Timestamp createTimestampFromString(final String string)
+    {
+        // TODO: Handle exceptions.
+        final Matcher matcher = TIMESTAMP_PATTERN.matcher(string);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(String.format("Invalid timestamp format '%s'", string));
+        }
+
+        final long epochSecond = LocalDateTime.parse(matcher.group(1), FORMATTER).toEpochSecond(ZoneOffset.UTC);
+
+        final String fraction = matcher.group(2);
+        final int nanoAdjustment;
+        if (fraction == null) {
+            nanoAdjustment = 0;
+        } else {
+            nanoAdjustment = Integer.parseInt(fraction) * (int) Math.pow(10, 9 - fraction.length());
+        }
+
+        return Timestamp.ofEpochSecond(epochSecond, nanoAdjustment);
+    }
+
+    private static final DateTimeFormatter FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC);
+    private static final Pattern TIMESTAMP_PATTERN =
+        Pattern.compile("(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})(?:\\.(\\d{1,9}))? (?:UTC|\\+?00\\:?00)");
 }

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestamp.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestamp.java
@@ -2,6 +2,7 @@ package org.embulk.spi.time;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -71,10 +72,10 @@ public class TestTimestamp
     @Test
     public void testCompareTo()
     {
-        assertEquals(-1, Timestamp.ofEpochSecond(3).compareTo(Timestamp.ofEpochSecond(4)));
-        assertEquals(-1, Timestamp.ofEpochSecond(3).compareTo(Timestamp.ofEpochSecond(3, 4)));
-        assertEquals( 1, Timestamp.ofEpochSecond(4).compareTo(Timestamp.ofEpochSecond(3)));
-        assertEquals( 1, Timestamp.ofEpochSecond(3, 4).compareTo(Timestamp.ofEpochSecond(3)));
+        assertTrue(Timestamp.ofEpochSecond(3).compareTo(Timestamp.ofEpochSecond(4)) < 0);
+        assertTrue(Timestamp.ofEpochSecond(3).compareTo(Timestamp.ofEpochSecond(3, 4)) < 0);
+        assertTrue(Timestamp.ofEpochSecond(4).compareTo(Timestamp.ofEpochSecond(3)) > 0);
+        assertTrue(Timestamp.ofEpochSecond(3, 4).compareTo(Timestamp.ofEpochSecond(3)) > 0);
     }
 
     @Test
@@ -91,26 +92,5 @@ public class TestTimestamp
         assertEquals("2015-01-19 07:36:10.123456700 UTC", Timestamp.ofEpochSecond(1421652970, 123456700).toString());
         assertEquals("2015-01-19 07:36:10.123456780 UTC", Timestamp.ofEpochSecond(1421652970, 123456780).toString());
         assertEquals("2015-01-19 07:36:10.123456789 UTC", Timestamp.ofEpochSecond(1421652970, 123456789).toString());
-    }
-
-    @Test
-    public void testFromString()
-    {
-        checkToStringFromString(Timestamp.ofEpochSecond(0));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 100*1000*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 120*1000*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123*1000*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123400*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123450*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456700));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456780));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456789));
-    }
-
-    private void checkToStringFromString(Timestamp timestamp)
-    {
-        assertEquals(timestamp, Timestamp.fromString(timestamp.toString()));
     }
 }

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -220,7 +220,9 @@ public class TestTimestampParser {
         testToParse("-1", "%s", -1L);
         testToParse("-86400", "%s", -86400L);
 
-        testToParse("-999", "%Q", 0L, -999000000);
+        // In |java.time.Instant|, it is always 0 <= nanoAdjustment < 1,000,000,000.
+        // -0.9s is represented like -1s + 100ms.
+        testToParse("-999", "%Q", -1L, 1000000);
         testToParse("-1000", "%Q", -1L);
     }
 

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampSerDe.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampSerDe.java
@@ -1,0 +1,28 @@
+package org.embulk.spi.time;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestTimestampSerDe
+{
+    @Test
+    public void testCreateTimestampFromString()
+    {
+        checkToStringFromString(Timestamp.ofEpochSecond(0));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 100*1000*1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 120*1000*1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123*1000*1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123400*1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123450*1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456*1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456700));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456780));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456789));
+    }
+
+    private void checkToStringFromString(final Timestamp timestamp)
+    {
+        Assert.assertEquals(timestamp, TimestampSerDe.createTimestampFromStringForTesting(timestamp.toString()));
+    }
+}


### PR DESCRIPTION
Just refactoring. Using `java.time.Instant` in `Timestamp`, instead of pairs of epoch seconds and milliseconds. Their interface is almost the same.

At the same time, moving `Timestamp.fromString` into `TimestampSerDe`, which was package-private, and used only from `TimestampSerDe`.

@sakama @muga Can you take a look?