### PR TITLE
Indirect org.joda.time.DateTimeZone in config Tasks

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/TaskInvocationHandler.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskInvocationHandler.java
@@ -1,5 +1,7 @@
 package org.embulk.config;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationHandler;
@@ -33,7 +35,9 @@ class TaskInvocationHandler
         for (Method method : iface.getMethods()) {
             String methodName = method.getName();
             String fieldName = getterFieldNameOrNull(methodName);
-            if (fieldName != null && hasExpectedArgumentLength(method, 0)) {
+            if (fieldName != null && hasExpectedArgumentLength(method, 0) &&
+                (!method.isDefault() || method.getAnnotation(Config.class) != null)) {
+                // If the method has default implementation, and @Config is not annotated there, the method is kept.
                 builder.put(fieldName, method);
             }
         }
@@ -134,6 +138,54 @@ class TaskInvocationHandler
                 String fieldName;
                 fieldName = getterFieldNameOrNull(methodName);
                 if (fieldName != null) {
+                    if (method.isDefault() && !this.objects.containsKey(fieldName)) {
+                        // If and only if the method has default implementation, and @Config is not annotated there,
+                        // it is tried to call the default implementation directly without proxying.
+                        //
+                        // methodWithDefaultImpl.invoke(proxy) without this hack would cause infinite recursive calls.
+                        //
+                        // See hints:
+                        // https://rmannibucau.wordpress.com/2014/03/27/java-8-default-interface-methods-and-jdk-dynamic-proxies/
+                        // https://stackoverflow.com/questions/22614746/how-do-i-invoke-java-8-default-methods-reflectively
+                        //
+                        // This hack is required to support `org.joda.time.DateTimeZone` in some Tasks, for example
+                        // TimestampParser.Task and TimestampParser.TimestampColumnOption.
+                        //
+                        // TODO: Remove the hack once a cleaner way is found, or Joda-Time is finally removed.
+                        // https://github.com/embulk/embulk/issues/890
+                        if (CONSTRUCTOR_MethodHandles_Lookup != null) {
+                            synchronized (CONSTRUCTOR_MethodHandles_Lookup) {
+                                boolean hasSetAccessible = false;
+                                try {
+                                    CONSTRUCTOR_MethodHandles_Lookup.setAccessible(true);
+                                    hasSetAccessible = true;
+                                }
+                                catch (SecurityException ex) {
+                                    // Skip handling default implementation in case of errors.
+                                }
+
+                                if (hasSetAccessible) {
+                                    try {
+                                        return CONSTRUCTOR_MethodHandles_Lookup
+                                            .newInstance(method.getDeclaringClass(),
+                                                         MethodHandles.Lookup.PUBLIC |
+                                                         MethodHandles.Lookup.PRIVATE |
+                                                         MethodHandles.Lookup.PROTECTED |
+                                                         MethodHandles.Lookup.PACKAGE)
+                                            .unreflectSpecial(method, method.getDeclaringClass())
+                                            .bindTo(proxy)
+                                            .invokeWithArguments();
+                                    }
+                                    catch (Throwable ex) {
+                                        // Skip handling default implementation in case of errors.
+                                    }
+                                    finally {
+                                        CONSTRUCTOR_MethodHandles_Lookup.setAccessible(false);
+                                    }
+                                }
+                            }
+                        }
+                    }
                     checkArgumentLength(method, 0, methodName);
                     return invokeGetter(method, fieldName);
                 }
@@ -177,4 +229,20 @@ class TaskInvocationHandler
                     String.format("Method '%s' expected %d argument but got %d arguments", methodName, expected, method.getParameterTypes().length));
         }
     }
+
+    static {
+        Constructor<MethodHandles.Lookup> constructorMethodHandlesLookupTemporary = null;
+        try {
+            constructorMethodHandlesLookupTemporary =
+                MethodHandles.Lookup.class.getDeclaredConstructor(Class.class, int.class);
+        }
+        catch (NoSuchMethodException | SecurityException ex) {
+            constructorMethodHandlesLookupTemporary = null;
+        }
+        finally {
+            CONSTRUCTOR_MethodHandles_Lookup = constructorMethodHandlesLookupTemporary;
+        }
+    }
+
+    private static final Constructor<MethodHandles.Lookup> CONSTRUCTOR_MethodHandles_Lookup;
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java
@@ -3,7 +3,6 @@ package org.embulk.spi.util;
 import java.util.List;
 import java.util.Map;
 import com.google.common.base.Optional;
-import org.joda.time.DateTimeZone;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.embulk.config.Config;
@@ -34,7 +33,16 @@ public class DynamicPageBuilder
     {
         @Config("default_timezone")
         @ConfigDefault("\"UTC\"")
-        public DateTimeZone getDefaultTimeZone();
+        public String getDefaultTimeZoneId();
+
+        public default org.joda.time.DateTimeZone getDefaultTimeZone() {
+            if (getDefaultTimeZoneId() != null) {
+                return TimestampFormat.parseDateTimeZone(getDefaultTimeZoneId());
+            }
+            else {
+                return null;
+            }
+        }
 
         @Config("column_options")
         @ConfigDefault("{}")
@@ -52,7 +60,16 @@ public class DynamicPageBuilder
 
         @Config("timezone")
         @ConfigDefault("null")
-        public Optional<DateTimeZone> getTimeZone();
+        public Optional<String> getTimeZoneId();
+
+        public default Optional<org.joda.time.DateTimeZone> getTimeZone() {
+            if (getTimeZoneId().isPresent()) {
+                return Optional.of(TimestampFormat.parseDateTimeZone(getTimeZoneId().get()));
+            }
+            else {
+                return Optional.absent();
+            }
+        }
     }
 
     private DynamicPageBuilder(

--- a/embulk-core/src/main/java/org/embulk/spi/util/Inputs.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Inputs.java
@@ -8,7 +8,6 @@ import org.embulk.spi.FileInput;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.time.TimestampFormatter;
-import org.joda.time.DateTimeZone;
 
 public class Inputs
 {

--- a/embulk-core/src/main/ruby/embulk/schema.rb
+++ b/embulk-core/src/main/ruby/embulk/schema.rb
@@ -33,6 +33,9 @@ module Embulk
           when :string
             "record << reader.getString(#{idx})"
           when :timestamp
+            # Constructor of `org.jruby.RubyTime` requires `org.joda.time.DateTime`.
+            # http://jruby.org/apidocs/org/jruby/RubyTime.html#RubyTime(org.jruby.Ruby,%20org.jruby.RubyClass,%20org.joda.time.DateTime)
+            # TODO: Replace `RubyTime.new` to `RubyTime.newTime`.
             "record << (java_timestamp = reader.getTimestamp(#{idx}); ruby_time = Java::org.jruby.RubyTime.new(JRuby.runtime, JRuby.runtime.getClass('Time'), Java::org.joda.time.DateTime.new(java_timestamp.toEpochMilli())).gmtime().to_java(Java::org.jruby.RubyTime); ruby_time.setNSec(java_timestamp.getNano()); ruby_time)"
           when :json
             "record << MessagePack.unpack(String.from_java_bytes((::Java::org.msgpack.core.MessagePack.newDefaultBufferPacker()).packValue(reader.getJson(#{idx})).toMessageBuffer().toByteArray()))"


### PR DESCRIPTION
Users of TimestampFormatter, TimestampParser, and DynamicPageBuidler had to use `org.joda.time.DateTimeZone` since their `Task` subclasses had `DateTimeZone`.

This change enables to intercept its `String` representation, and to interpret the time zone ID representation by themselves.

It introduces a hack in `TaskInvocationHandler` to call default implementations in `Task` interfaces.

@sakama @muga Can you have a look?