### PR TITLE
Reimplement TimestampParser, TimeParsed, and RubyTimeParsed with java.time.ZoneId

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimeParsed.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimeParsed.java
@@ -1,5 +1,7 @@
 package org.embulk.spi.time;
 
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Map;
 
 /**
@@ -15,12 +17,15 @@ abstract class TimeParsed {  // to extend java.time.temporal.TemporalAccessor in
         return new RubyTimeParsed.Builder(originalString);
     }
 
-    // TODO: Have java.time.Instant toInstant() in Java 8.
+    abstract Instant toInstantLegacy(final int defaultYear,
+                                     final int defaultMonthOfYear,
+                                     final int defaultDayOfMonth,
+                                     final ZoneId defaultZoneId);
 
-    abstract public Timestamp toTimestamp(final int defaultYear,
-                                          final int defaultMonthOfYear,
-                                          final int defaultDayOfMonth,
-                                          final org.joda.time.DateTimeZone defaultTimeZone);
+    abstract Timestamp toTimestampLegacy(final int defaultYear,
+                                         final int defaultMonthOfYear,
+                                         final int defaultDayOfMonth,
+                                         final ZoneId defaultZoneId);
 
     abstract public Map<String, Object> asMapLikeRubyHash();
 }

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
@@ -18,7 +18,9 @@ public class TimestampFormat
         return this.format;
     }
 
-    // To be deprecated.
+    // Using Joda-Time is deprecated, but the parser returns org.joda.time.DateTimeZone for plugin compatibility.
+    // It won't be removed very soon at least until Embulk v0.10.
+    @Deprecated
     public static org.joda.time.DateTimeZone parseDateTimeZone(final String timeZoneName)
     {
         return TimeZoneIds.parseJodaDateTimeZone(timeZoneName);

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimeZoneIds.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimeZoneIds.java
@@ -14,7 +14,7 @@ public class TestTimeZoneIds
         // TODO: Test more practical equality. (Such as "GMT" v.s. "UTC")
         Assert.assertEquals(ZoneOffset.UTC, TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("Z"));
         Assert.assertEquals(ZoneId.of("Asia/Tokyo"), TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("Asia/Tokyo"));
-        Assert.assertEquals(ZoneId.of("America/New_York"), TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("EST"));
+        Assert.assertEquals(ZoneId.of("-05:00"), TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("EST"));
         Assert.assertEquals(ZoneId.of("-10:00"), TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("HST"));
         Assert.assertEquals(ZoneId.of("Asia/Taipei"), TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("ROC"));
     }

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -3,7 +3,6 @@ package org.embulk.spi.time;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 /**
@@ -227,7 +226,7 @@ public class TestTimestampParser {
     }
 
     private void testToParse(final String string, final String format, final long second, final int nanoOfSecond) {
-        final TimestampParser parser = new TimestampParser(format, DateTimeZone.UTC, "4567-01-23");
+        final TimestampParser parser = TimestampParser.create(format, "UTC", "4567-01-23");
         final Timestamp timestamp = parser.parse(string);
         assertEquals(second, timestamp.getEpochSecond());
         assertEquals(nanoOfSecond,timestamp.getNano());
@@ -238,7 +237,7 @@ public class TestTimestampParser {
     }
 
     private void failToParse(final String string, final String format) {
-        final TimestampParser parser = new TimestampParser(format, DateTimeZone.UTC, "4567-01-23");
+        final TimestampParser parser = TimestampParser.create(format, "UTC", "4567-01-23");
         try {
             parser.parse(string);
         } catch (TimestampParseException ex) {


### PR DESCRIPTION
This comes after #893 and #894. It deprecates and reduces the usage of `org.joda.time.DateTimeZone`.

@muga @sakama Can you have a look?