### PR TITLE
Add an initial contribution guideline (CONTRIBUTING.md)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,31 +7,31 @@ We love your contributions! Before making a Pull Request, please read and follow
 Issue before Pull Request
 --------------------------
 
-Consider filing an Issue at first from https://github.com/embulk/embulk/issues/new before making a Pull Request, even for small fixes, unless you are named an main contributor.
+Consider [filing an Issue at first|https://github.com/embulk/embulk/issues/new] before creating a Pull Request, even for small fixes, unless you are named a primary contributor.
 
 
 License
 --------
 
-By contributing your code and/or statements in the Embulk repository, you agree to license your contribution under the terms of the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+By contributing your code and/or statements to the Embulk repository, you agree to license your contribution under the same license terms of the repository itself, the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 
 Coding Style
 -------------
 
-Our Java code would follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html) except for the following points:
+Embulk's Java code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html) except for the following points:
 
 * +4 spaces for block indentation.
-* 120 characters as a column limit.
+* 120 characters as a columns limit.
 
 
 Commit Messages
 ----------------
 
-Commits in the Embulk repository would basically follow [Git's Commit Guidelines](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project) except for some points. Our guideline is summarized that:
+Commits to the Embulk repository should follow [Git's Commit Guidelines](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project) with minor exceptions. Our guideline is summarized as follows:
 
 * Start your commit message with a single line that describes the changeset concisely.
 * Leave the second line blank, followed by a more detailed explanation from the third line.
 * Have your motivation for the change, and contrast its implementation with previous behavior.
-* Keep every line not so long. 100 characters are acceptable, but worth considering to shorten.
+* Limit the length of each line: 100 characters are acceptable, but it's worth making it shorter.
 * Use imperative present tense in your commit messages, especially in the first line.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+Contributing to Embulk
+=======================
+
+We love your contributions! Before making a Pull Request, please read and follow this contribution guideline.
+
+
+Issue before Pull Request
+--------------------------
+
+Consider filing an Issue at first from https://github.com/embulk/embulk/issues/new before making a Pull Request, even for small fixes, unless you are named an main contributor.
+
+
+License
+--------
+
+By contributing your code and/or statements in the Embulk repository, you agree to license your contribution under the terms of the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+
+Coding Style
+-------------
+
+Our Java code would follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html) except for the following points:
+
+* +4 spaces for block indentation.
+* 120 characters as a column limit.
+
+
+Commit Messages
+----------------
+
+Commits in the Embulk repository would basically follow [Git's Commit Guidelines](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project) except for some points. Our guideline is summarized that:
+
+* Start your commit message with a single line that describes the changeset concisely.
+* Leave the second line blank, followed by a more detailed explanation from the third line.
+* Have your motivation for the change, and contrast its implementation with previous behavior.
+* Keep every line not so long. 100 characters are acceptable, but worth considering to shorten.
+* Use imperative present tense in your commit messages, especially in the first line.


### PR DESCRIPTION
@muga @sakama Before Embulk v0.9, we'd like to have a contribution guideline. Can you have a look?