### PR TITLE
Make TimeParsed and RubyTimeParsed package-private

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/RubyTimeParsed.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/RubyTimeParsed.java
@@ -89,7 +89,7 @@ class RubyTimeParsed extends TimeParsed {
         }
 
         @Override
-        public TimeParsed build() {
+        TimeParsed build() {
             // Merge week-based year and century as MRI (Matz' Ruby Implementation) does before generating a hash.
             // See: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l676
             final int weekBasedYearWithCentury;
@@ -637,7 +637,7 @@ class RubyTimeParsed extends TimeParsed {
     }
 
     @Override
-    public Map<String, Object> asMapLikeRubyHash() {
+    Map<String, Object> asMapLikeRubyHash() {
         final HashMap<String, Object> hash = new HashMap<>();
 
         putIntIfValid(hash, "mday", this.dayOfMonth);

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimeParsed.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimeParsed.java
@@ -8,12 +8,11 @@ import java.util.Map;
  * TimeParsed is a container of date/time information parsed from a string.
  */
 abstract class TimeParsed {  // to extend java.time.temporal.TemporalAccessor in Java 8
-    public static abstract class Builder {
-        public abstract TimeParsed build();
+    static abstract class Builder {
+        abstract TimeParsed build();
     }
 
-    public static RubyTimeParsed.Builder rubyBuilder(final String originalString)
-    {
+    static RubyTimeParsed.Builder rubyBuilder(final String originalString) {
         return new RubyTimeParsed.Builder(originalString);
     }
 
@@ -27,5 +26,5 @@ abstract class TimeParsed {  // to extend java.time.temporal.TemporalAccessor in
                                          final int defaultDayOfMonth,
                                          final ZoneId defaultZoneId);
 
-    abstract public Map<String, Object> asMapLikeRubyHash();
+    abstract Map<String, Object> asMapLikeRubyHash();
 }


### PR DESCRIPTION
They don't need to be `public`...