### PR TITLE
Cleanup various parts around TimestampParser and org.joda.time.DateTimeZone

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/DateTimeZoneSerDe.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/DateTimeZoneSerDe.java
@@ -1,31 +1,30 @@
 package org.embulk.spi.time;
 
-import java.io.IOException;
-import org.joda.time.DateTimeZone;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.module.guice.ObjectMapperModule;
+import java.io.IOException;
 
 public class DateTimeZoneSerDe
 {
     public static void configure(ObjectMapperModule mapper)
     {
         SimpleModule module = new SimpleModule();
-        module.addSerializer(DateTimeZone.class, new DateTimeZoneSerializer());
-        module.addDeserializer(DateTimeZone.class, new DateTimeZoneDeserializer());
+        module.addSerializer(org.joda.time.DateTimeZone.class, new DateTimeZoneSerializer());
+        module.addDeserializer(org.joda.time.DateTimeZone.class, new DateTimeZoneDeserializer());
         mapper.registerModule(module);
     }
 
     public static class DateTimeZoneSerializer
-            extends JsonSerializer<DateTimeZone>
+            extends JsonSerializer<org.joda.time.DateTimeZone>
     {
         @Override
-        public void serialize(DateTimeZone value, JsonGenerator jgen, SerializerProvider provider)
+        public void serialize(org.joda.time.DateTimeZone value, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException
         {
             jgen.writeString(value.getID());
@@ -33,18 +32,18 @@ public class DateTimeZoneSerDe
     }
 
     public static class DateTimeZoneDeserializer
-            extends FromStringDeserializer<DateTimeZone>
+            extends FromStringDeserializer<org.joda.time.DateTimeZone>
     {
         public DateTimeZoneDeserializer()
         {
-            super(DateTimeZone.class);
+            super(org.joda.time.DateTimeZone.class);
         }
 
         @Override
-        protected DateTimeZone _deserialize(String value, DeserializationContext context)
+        protected org.joda.time.DateTimeZone _deserialize(String value, DeserializationContext context)
                 throws JsonMappingException
         {
-            DateTimeZone parsed = TimestampFormat.parseDateTimeZone(value);
+            org.joda.time.DateTimeZone parsed = TimeZoneIds.parseJodaDateTimeZone(value);
             if (parsed == null) {
                 // TODO include link to a document to the message for the list of supported time zones
                 throw new JsonMappingException(String.format("Unknown time zone name '%s'", value));

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimeZoneIds.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimeZoneIds.java
@@ -11,7 +11,7 @@ import java.util.Set;
 /**
  * TimeZoneIds is a utility class for operating with time zones.
  */
-class TimeZoneIds
+public class TimeZoneIds
 {
     private TimeZoneIds() {
         // No instantiation.

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
@@ -4,7 +4,6 @@ import java.util.Locale;
 import com.google.common.base.Optional;
 import org.jruby.util.RubyDateFormat;
 import org.embulk.config.Config;
-import org.embulk.config.ConfigInject;
 import org.embulk.config.ConfigDefault;
 import org.embulk.spi.util.LineEncoder;
 
@@ -16,6 +15,9 @@ public class TimestampFormatter
         @ConfigDefault("\"UTC\"")
         public String getDefaultTimeZoneId();
 
+        // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
+        // It won't be removed very soon at least until Embulk v0.10.
+        @Deprecated
         public default org.joda.time.DateTimeZone getDefaultTimeZone() {
             if (getDefaultTimeZoneId() != null) {
                 return TimestampFormat.parseDateTimeZone(getDefaultTimeZoneId());
@@ -36,6 +38,9 @@ public class TimestampFormatter
         @ConfigDefault("null")
         public Optional<String> getTimeZoneId();
 
+        // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
+        // It won't be removed very soon at least until Embulk v0.10.
+        @Deprecated
         public default Optional<org.joda.time.DateTimeZone> getTimeZone() {
             if (getTimeZoneId().isPresent()) {
                 return Optional.of(TimestampFormat.parseDateTimeZone(getTimeZoneId().get()));
@@ -70,6 +75,9 @@ public class TimestampFormatter
         this.dateFormat = new RubyDateFormat(format, Locale.ENGLISH, true);
     }
 
+    // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
+    // It won't be removed very soon at least until Embulk v0.10.
+    @Deprecated
     public org.joda.time.DateTimeZone getTimeZone()
     {
         return timeZone;

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
@@ -86,17 +86,17 @@ public class TimestampParser
              defaultDate);
     }
 
-    public static TimestampParser create(final String formatString,
-                                         final String defaultTimeZoneId,
-                                         final String defaultDate) {
+    public static TimestampParser of(final String formatString,
+                                     final String defaultTimeZoneId,
+                                     final String defaultDate) {
         return new TimestampParser(formatString,
                                    TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab(defaultTimeZoneId),
                                    TimeZoneIds.parseJodaDateTimeZone(defaultTimeZoneId),
                                    defaultDate);
     }
 
-    public static TimestampParser create(final String formatString,
-                                         final String defaultTimeZoneId) {
+    public static TimestampParser of(final String formatString,
+                                     final String defaultTimeZoneId) {
         return new TimestampParser(formatString,
                                    TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab(defaultTimeZoneId),
                                    TimeZoneIds.parseJodaDateTimeZone(defaultTimeZoneId),

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
-import org.embulk.config.ConfigInject;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.spi.Schema;
@@ -15,8 +14,6 @@ import org.embulk.spi.Column;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.PageOutput;
-import org.embulk.spi.time.TimestampFormatter;
-import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.time.TimestampFormat;
 import org.embulk.spi.util.dynamic.SkipColumnSetter;
 
@@ -35,6 +32,9 @@ public class DynamicPageBuilder
         @ConfigDefault("\"UTC\"")
         public String getDefaultTimeZoneId();
 
+        // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
+        // It won't be removed very soon at least until Embulk v0.10.
+        @Deprecated
         public default org.joda.time.DateTimeZone getDefaultTimeZone() {
             if (getDefaultTimeZoneId() != null) {
                 return TimestampFormat.parseDateTimeZone(getDefaultTimeZoneId());
@@ -62,6 +62,9 @@ public class DynamicPageBuilder
         @ConfigDefault("null")
         public Optional<String> getTimeZoneId();
 
+        // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
+        // It won't be removed very soon at least until Embulk v0.10.
+        @Deprecated
         public default Optional<org.joda.time.DateTimeZone> getTimeZone() {
             if (getTimeZoneId().isPresent()) {
                 return Optional.of(TimestampFormat.parseDateTimeZone(getTimeZoneId().get()));

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/SkipColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/SkipColumnSetter.java
@@ -1,10 +1,6 @@
 package org.embulk.spi.util.dynamic;
 
-import org.embulk.spi.PageBuilder;
-import org.embulk.spi.Column;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.time.TimestampParser;
-import org.embulk.spi.time.TimestampParseException;
 import org.msgpack.value.Value;
 
 public class SkipColumnSetter

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -226,7 +226,7 @@ public class TestTimestampParser {
     }
 
     private void testToParse(final String string, final String format, final long second, final int nanoOfSecond) {
-        final TimestampParser parser = TimestampParser.create(format, "UTC", "4567-01-23");
+        final TimestampParser parser = TimestampParser.of(format, "UTC", "4567-01-23");
         final Timestamp timestamp = parser.parse(string);
         assertEquals(second, timestamp.getEpochSecond());
         assertEquals(nanoOfSecond,timestamp.getNano());
@@ -237,7 +237,7 @@ public class TestTimestampParser {
     }
 
     private void failToParse(final String string, final String format) {
-        final TimestampParser parser = TimestampParser.create(format, "UTC", "4567-01-23");
+        final TimestampParser parser = TimestampParser.of(format, "UTC", "4567-01-23");
         try {
             parser.parse(string);
         } catch (TimestampParseException ex) {

--- a/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestCsvParserPlugin.java
@@ -1,13 +1,13 @@
 package org.embulk.standards;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Rule;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
 import java.nio.charset.Charset;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.joda.time.DateTimeZone;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
@@ -36,7 +36,7 @@ public class TestCsvParserPlugin
         assertEquals(",", task.getDelimiter());
         assertEquals(Optional.of(new CsvParserPlugin.QuoteCharacter('\"')), task.getQuoteChar());
         assertEquals(false, task.getAllowOptionalColumns());
-        assertEquals(DateTimeZone.UTC, task.getDefaultTimeZone());
+        assertEquals("UTC", task.getDefaultTimeZoneId());
         assertEquals("%Y-%m-%d %H:%M:%S.%N %z", task.getDefaultTimestampFormat());
     }
 


### PR DESCRIPTION
Cleanups, comments, renames, and annotations around `TimestampParser` and `org.joda.time.DateTimeZone`. Can you have a look?