### PR TITLE
Add Java-style ("java:") timestamp format to parse timestamps

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimeZoneIds.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimeZoneIds.java
@@ -25,6 +25,13 @@ public class TimeZoneIds
     }
 
     /**
+     * Converts java.time.ZoneOffset to its corresponding org.joda.time.DateTimeZone.
+     */
+    public static org.joda.time.DateTimeZone convertZoneOffsetToJodaDateTimeZone(final ZoneOffset zoneOffset) {
+        return org.joda.time.DateTimeZone.forOffsetMillis(zoneOffset.getTotalSeconds() * 1000);
+    }
+
+    /**
      * Parses time zone ID to java.time.ZoneId as compatible with the time zone parser of Embulk v0.8 as possible.
      *
      * It recognizes time zone IDs in the following priority.

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParseException.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParseException.java
@@ -9,4 +9,14 @@ public class TimestampParseException
     {
         super(message);
     }
+
+    public TimestampParseException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public TimestampParseException(Throwable cause)
+    {
+        super(cause);
+    }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParserJava.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParserJava.java
@@ -1,0 +1,181 @@
+package org.embulk.spi.time;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+import java.util.Locale;
+
+/**
+ * TimestampParserJava parses a String to org.embulk.spi.time.Timestamp with java.time.format.DateTimeFormatter.
+ */
+class TimestampParserJava extends TimestampParser {
+    private TimestampParserJava(final DateTimeFormatter formatter,
+                                final ZoneOffset defaultZoneOffset,
+                                final String pattern) {
+        this.formatter = formatter;
+        this.defaultZoneOffset = defaultZoneOffset;
+        this.pattern = pattern;
+    }
+
+    static TimestampParserJava of(final String pattern, final ZoneOffset defaultZoneOffset) {
+        // Default parsers from patterns accept strings case-insensitively.
+        return new TimestampParserJava(new DateTimeFormatterBuilder()
+                                           .parseCaseInsensitive()
+                                           .appendPattern(pattern)
+                                           .toFormatter(Locale.ENGLISH)
+                                           .withResolverStyle(ResolverStyle.STRICT),
+                                       defaultZoneOffset,
+                                       pattern);
+    }
+
+    static TimestampParserJava of(final DateTimeFormatter formatter, final ZoneOffset defaultZoneOffset) {
+        return new TimestampParserJava(formatter, defaultZoneOffset, "");
+    }
+
+    @Deprecated
+    @Override
+    public org.joda.time.DateTimeZone getDefaultTimeZone() {
+        return TimeZoneIds.convertZoneOffsetToJodaDateTimeZone(this.defaultZoneOffset);
+    }
+
+    @Override
+    Instant parseInternal(final String text) throws TimestampParseException {
+        final TemporalAccessor temporal;
+        try {
+            temporal = this.formatter.parse(text);
+        } catch (DateTimeParseException ex) {
+            throw new TimestampParseException(ex);
+        }
+
+        return this.buildOffsetDateTime(temporal).toInstant();
+    }
+
+    private OffsetDateTime buildOffsetDateTime(final TemporalAccessor given) throws TimestampParseException {
+        // Non-offset (string-ish) time zone IDs are intentionally rejected by TimestampParserJava
+        // because their meanings are not stable per the tz database.
+        final ZoneId givenZoneId = given.query(TemporalQueries.zoneId());
+        if (givenZoneId != null) {
+            throw new TimestampParseException("Non-offset zone IDs are unaccepted in 'java:' formats: " + this.pattern);
+        }
+
+        final ZoneOffset givenZoneOffset = given.query(TemporalQueries.offset());
+        if (given.isSupported(ChronoField.EPOCH_DAY) && given.isSupported(ChronoField.NANO_OF_DAY)) {
+            // Normal fastest cases: Embulk expects the record has full date and time information in most cases.
+            if (givenZoneOffset != null) {
+                return OffsetDateTime.from(given);
+            } else {
+                return OffsetDateTime.of(LocalDateTime.from(given), this.defaultZoneOffset);
+            }
+        }
+
+        // Exceptional cases: the record does not have full date and time information.
+        final LocalDate dateFromDefault;
+        if (given.isSupported(ChronoField.EPOCH_DAY)) {
+            dateFromDefault = LocalDate.from(given);
+        } else {
+            final int year;
+            if (given.isSupported(ChronoField.YEAR)) {
+                year = given.get(ChronoField.YEAR);
+            } else if (given.isSupported(ChronoField.YEAR_OF_ERA)) {
+                year = given.get(ChronoField.YEAR_OF_ERA);
+            } else {
+                year = 1970;
+            }
+
+            if (given.isSupported(ChronoField.DAY_OF_YEAR)) {
+                dateFromDefault = LocalDate.ofYearDay(year, given.get(ChronoField.DAY_OF_YEAR));
+            } else {
+                final int month;
+                if (given.isSupported(ChronoField.MONTH_OF_YEAR)) {
+                    month = given.get(ChronoField.MONTH_OF_YEAR);
+                } else {
+                    month = 1;
+                }
+                final int dayOfMonth;
+                if (given.isSupported(ChronoField.DAY_OF_MONTH)) {
+                    dayOfMonth = given.get(ChronoField.DAY_OF_MONTH);
+                } else {
+                    dayOfMonth = 1;
+                }
+                dateFromDefault = LocalDate.of(year, month, dayOfMonth);
+            }
+        }
+
+        final LocalTime timeFromDefault;
+        if (given.isSupported(ChronoField.NANO_OF_DAY)) {
+            timeFromDefault = LocalTime.from(given);
+        } else {
+            if (given.isSupported(ChronoField.NANO_OF_DAY)) {
+                timeFromDefault = LocalTime.ofNanoOfDay(given.getLong(ChronoField.NANO_OF_DAY));
+            } else if (given.isSupported(ChronoField.MILLI_OF_DAY)) {
+                timeFromDefault = LocalTime.ofNanoOfDay(given.getLong(ChronoField.MILLI_OF_DAY) * 1000000L);
+            } else if (given.isSupported(ChronoField.SECOND_OF_DAY)) {
+                timeFromDefault = LocalTime.ofSecondOfDay(given.getLong(ChronoField.SECOND_OF_DAY));
+            } else if (given.isSupported(ChronoField.MINUTE_OF_DAY)) {
+                timeFromDefault = LocalTime.ofSecondOfDay(given.getLong(ChronoField.MINUTE_OF_DAY) * 60L);
+            } else {
+                final int hourOfDay;
+                if (given.isSupported(ChronoField.HOUR_OF_DAY)) {
+                    hourOfDay = given.get(ChronoField.HOUR_OF_DAY);
+                } else if (given.isSupported(ChronoField.CLOCK_HOUR_OF_DAY)) {
+                    hourOfDay = given.get(ChronoField.CLOCK_HOUR_OF_DAY) % 24;
+                } else if (given.isSupported(ChronoField.AMPM_OF_DAY)) {
+                    final int ampmOfDay = given.get(ChronoField.AMPM_OF_DAY) * 12;
+                    if (given.isSupported(ChronoField.HOUR_OF_AMPM)) {
+                        hourOfDay = given.get(ChronoField.HOUR_OF_AMPM) + ampmOfDay;
+                    } else if (given.isSupported(ChronoField.CLOCK_HOUR_OF_AMPM)) {
+                        hourOfDay = given.get(ChronoField.CLOCK_HOUR_OF_AMPM) + ampmOfDay;
+                    } else {
+                        hourOfDay = 0;
+                    }
+                } else {
+                    hourOfDay = 0;
+                }
+                final int minuteOfHour;
+                if (given.isSupported(ChronoField.MINUTE_OF_HOUR)) {
+                    minuteOfHour = given.get(ChronoField.MINUTE_OF_HOUR);
+                } else {
+                    minuteOfHour = 0;
+                }
+                final int secondOfMinute;
+                if (given.isSupported(ChronoField.SECOND_OF_MINUTE)) {
+                    secondOfMinute = given.get(ChronoField.SECOND_OF_MINUTE);
+                } else {
+                    secondOfMinute = 0;
+                }
+                final int nanoOfSecond;
+                if (given.isSupported(ChronoField.NANO_OF_SECOND)) {
+                    nanoOfSecond = given.get(ChronoField.NANO_OF_SECOND);
+                } else if (given.isSupported(ChronoField.MICRO_OF_SECOND)) {
+                    nanoOfSecond = given.get(ChronoField.MICRO_OF_SECOND) * 1000;
+                } else if (given.isSupported(ChronoField.MILLI_OF_SECOND)) {
+                    nanoOfSecond = given.get(ChronoField.MILLI_OF_SECOND) * 1000000;
+                } else {
+                    nanoOfSecond = 0;
+                }
+                timeFromDefault = LocalTime.of(hourOfDay, minuteOfHour, secondOfMinute, nanoOfSecond);
+            }
+        }
+
+        if (givenZoneOffset != null) {
+            return OffsetDateTime.of(dateFromDefault, timeFromDefault, givenZoneOffset);
+        } else {
+            return OffsetDateTime.of(dateFromDefault, timeFromDefault, this.defaultZoneOffset);
+        }
+    }
+
+    private final DateTimeFormatter formatter;
+    private final String pattern;
+    private final ZoneOffset defaultZoneOffset;
+}

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -15,6 +15,30 @@ import org.junit.Test;
  */
 public class TestTimestampParser {
     @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaIso8601() {
+        testJavaToParse("2001-02-03", "yyyy-MM-dd", 981158400L);
+        testJavaToParse("2001-02-03", "uuuu-MM-dd", 981158400L);
+
+        // "Java" timestamp parser does not accept second = 60 for the time being.
+
+        testJavaToParse("2001-02-03T23:59:59", "yyyy-MM-dd'T'HH:mm:ss", 981244799L);
+        testJavaToParse("2001-02-03T23:59:59", "uuuu-MM-dd'T'HH:mm:ss", 981244799L);
+        testJavaToParse("2001-02-03T23:59:59+09:00", "yyyy-MM-dd'T'HH:mm:ssXXXXX", 981212399L);
+        testJavaToParse("2001-02-03T23:59:59+09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", 981212399L);
+
+        // "yyyy" is Year of Era, which does not accept negative years for AD.
+        failJavaToParse("-2001-02-03T23:59:59+09:00", "yyyy-MM-dd'T'HH:mm:ssXXXXX");
+        testJavaToParse("-2001-02-03T23:59:59+09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", -125309754001L);
+
+        testJavaToParse("+012345-02-03T23:59:59+09:00", "yyyy-MM-dd'T'HH:mm:ssXXXXX", 327406287599L);
+        testJavaToParse("+012345-02-03T23:59:59+09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", 327406287599L);
+
+        // "yyyy" is Year of Era, which does not accept negative years for AD.
+        failJavaToParse("-012345-02-03T23:59:59+09:00", "yyyy-MM-dd'T'HH:mm:ssXXXXX");
+        testJavaToParse("-012345-02-03T23:59:59+09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", -451734829201L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
     public void test__strptime__3_iso8601() {
         testToParse("2001-02-03", "%Y-%m-%d", 981158400L);
         testToParse("2001-02-03T23:59:60", "%Y-%m-%dT%H:%M:%S", 981244799L);
@@ -25,9 +49,47 @@ public class TestTimestampParser {
     }
 
     @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaAsctime() {
+        testJavaToParse("Thu Jul 29 14:47:19 1999", "EEE MMM dd HH:mm:ss uuuu", 933259639L);
+
+        // JFYI: Jul 29 -1999 is Sunday, not Thursday.
+        testJavaToParse("Sun Jul 29 14:47:19 -1999", "EEE MMM dd HH:mm:ss uuuu", -125231389961L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
     public void test__strptime__3_ctime3_asctime3() {
         testToParse("Thu Jul 29 14:47:19 1999", "%c", 933259639L);
         testToParse("Thu Jul 29 14:47:19 -1999", "%c", -125231389961L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaTimeZones() {
+        testJavaToParse("Thu Jul 29 16:39:41 -05:00 1999", "EEE MMM dd HH:mm:ss XXXXX uuuu", 933284381L);
+
+        // The short time zone IDs "EST", "MET", "AMT", "AST", and "DST" are not accepted in Java parser.
+        failJavaToParse("Thu Jul 29 16:39:41 EST 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 MET DST 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 AMT 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 AMT -1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 AST 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 AST -1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+
+        // All "GMT", "GMT+..." and "GMT-..." are not accepted in Java parser.
+        failJavaToParse("Thu Jul 29 16:39:41 GMT 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT+09 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT+0908 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT+090807 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT-09 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT-09:08 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT-09:08:07 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT-3.5 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT-3,5 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+
+        // String-ish time zone IDs are not accepted in Java parser.
+        failJavaToParse("Thu Jul 29 16:39:41 Mountain Daylight Time 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 E. Australia Standard Time 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+
+        failJavaToParse("Thu Jul 29 16:39:41 UTC 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
     }
 
     @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
@@ -48,6 +110,22 @@ public class TestTimestampParser {
         testToParse("Thu Jul 29 16:39:41 GMT-3,5 1999", "%a %b %d %H:%M:%S %Z %Y", 933278981L);
         testToParse("Thu Jul 29 16:39:41 Mountain Daylight Time 1999", "%a %b %d %H:%M:%S %Z %Y", 933287981L);
         testToParse("Thu Jul 29 16:39:41 E. Australia Standard Time 1999", "%a %b %d %H:%M:%S %Z %Y", 933230381L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaRfc822() {
+        // String-ish time zone IDs such as "UT", "GMT", "PDT", and "z" are not accepted in Java parser.
+        failJavaToParse("Thu, 29 Jul 1999 09:54:21 UT", "EEE, dd MMM uuuu HH:mm:ss ZZZ");
+        failJavaToParse("Thu, 29 Jul 1999 09:54:21 GMT", "EEE, dd MMM uuuu HH:mm:ss ZZZ");
+        failJavaToParse("Thu, 29 Jul 1999 09:54:21 PDT", "EEE, dd MMM uuuu HH:mm:ss ZZZ");
+        failJavaToParse("Thu, 29 Jul 1999 09:54:21 z", "EEE, dd MMM uuuu HH:mm:ss ZZZ");
+
+        testJavaToParse("Thu, 29 Jul 1999 09:54:21 +0900", "EEE, dd MMM uuuu HH:mm:ss ZZZ", 933209661L);
+        testJavaToParse("Thu, 29 Jul 1999 09:54:21 +0430", "EEE, dd MMM uuuu HH:mm:ss ZZZ", 933225861L);
+        testJavaToParse("Thu, 29 Jul 1999 09:54:21 -0430", "EEE, dd MMM uuuu HH:mm:ss ZZZ", 933258261L);
+
+        // JFYI: Jul 29 -1999 is Sunday, not Thursday.
+        testJavaToParse("Sun, 29 Jul -1999 09:54:21 -0430", "EEE, dd MMM uuuu HH:mm:ss ZZZ", -125231391339L);
     }
 
     @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
@@ -78,6 +156,53 @@ public class TestTimestampParser {
     }
 
     @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaEtc() {
+        // "uu" always parses two-digit years into 2000s in Java parser. ("99" goes to "2099".)
+        testJavaToParse("06-DEC-99", "dd-MMM-uu", 4100198400L);
+
+        // JFYI: October 31, 2001 is Wednesday, not Sunday.
+        testJavaToParse("wEdnesDay oCtoBer 31 01", "EEEE MMMM dd uu", 1004486400L);
+
+        // "uu" always parses two-digit years into 2000s in Java parser. ("99" goes to "2099".)
+        // Whitespaces are not parsed just with " " in Java parser.
+        // Their "\u000b" are actually "\v" in Ruby v2.3.1's tests. "\v" is not recognized as a character in Java.
+        testJavaToParse("October\t\n\u000b\f\r 15,\t\n\u000b\f\r99", "MMMM\t\n\u000b\f\r dd,\t\n\u000b\f\ruu",
+                        4095705600L);
+
+        // Default dates are always 1970-01-01 in Java parser.
+        testJavaToParse("09:02:11 AM", "KK:mm:ss a", 32531L);
+        // "A.M." (with dots) is not accepted in Java parser.
+        failJavaToParse("09:02:11 A.M.", "KK:mm:ss a");
+        testJavaToParse("09:02:11 PM", "KK:mm:ss a", 75731L);
+        // "P.M." (with dots) is not accepted in Java parser.
+        failJavaToParse("09:02:11 P.M.", "KK:mm:ss a");
+
+        // Default dates are always 1970-01-01 in Java parser.
+        // Results differ between "hh" (HOUR_OF_AMPM) and "KK" (CLOCK_HOUR_OF_AMPM) in case the hour is 12.
+        testJavaToParse("12:33:44 AM", "hh:mm:ss a", 2024L);
+        testJavaToParse("12:33:44 AM", "KK:mm:ss a", 45224L);
+        testJavaToParse("01:33:44 AM", "hh:mm:ss a", 5624L);
+        testJavaToParse("01:33:44 AM", "KK:mm:ss a", 5624L);
+        testJavaToParse("11:33:44 AM", "hh:mm:ss a", 41624L);
+        testJavaToParse("11:33:44 AM", "KK:mm:ss a", 41624L);
+        testJavaToParse("12:33:44 PM", "hh:mm:ss a", 45224L);
+        failJavaToParse("12:33:44 PM", "KK:mm:ss a");
+        testJavaToParse("01:33:44 PM", "hh:mm:ss a", 48824L);
+        testJavaToParse("01:33:44 PM", "KK:mm:ss a", 48824L);
+        testJavaToParse("11:33:44 PM", "hh:mm:ss a", 84824L);
+        testJavaToParse("11:33:44 PM", "KK:mm:ss a", 84824L);
+
+        // Their time zones are "AMT" actually in Ruby v2.3.1's tests, but "-04:00" is used here instead.
+        // "AMT" is not recognized even by Ruby v2.3.1's zonetab.
+        testJavaToParse("11:33:44 PM -04:00", "KK:mm:ss a XXXXX", 99224L);
+        failJavaToParse("11:33:44 P.M. -04:00", "KK:mm:ss a XXXXX");
+
+        // Just "+5" is not acceptable as a time zone offset in Java parser.
+        // JFYI: February 1, 2003 is Saturday, not Friday.
+        testJavaToParse("sat1feb034pm+0500", "EEEdMMMuuhaX", 1044097200L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
     public void test__strptime__3_etc() {
         testToParse("06-DEC-99", "%d-%b-%y", 944438400L);
         testToParse("sUnDay oCtoBer 31 01", "%A %B %d %y", 1004486400L);
@@ -103,6 +228,55 @@ public class TestTimestampParser {
         testToParse("11:33:44 P.M. AST", "%I:%M:%S %p %Z", 81955424024L);
 
         testToParse("fri1feb034pm+5", "%a%d%b%y%H%p%Z", 1044097200L);
+    }
+
+    @Test  // Imported from test__strptime__width in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaWidth() {
+        // "uu" always parses two-digit years into 2000s in Java parser. ("99" goes to "2099".)
+        // Default dates are always 1970-01-01 in Java parser.
+        testJavaToParse("99", "uu", 4070908800L);
+        testJavaToParse("01", "uu", 978307200L);
+
+        // Centuries are not accepted in Java parser.
+        // testToParse("19 99", "%C %y", 917049600L);
+        // testToParse("20 01", "%C %y", 980208000L);
+        // testToParse("30 99", "%C %y", 35629718400L);
+        // testToParse("30 01", "%C %y", 32537116800L);
+        // testToParse("1999", "%C%y", 917049600L);
+        // testToParse("2001", "%C%y", 980208000L);
+        // testToParse("3099", "%C%y", 35629718400L);
+        // testToParse("3001", "%C%y", 32537116800L);
+
+        // Default dates are always 1970-01-01 in Java parser.
+        testJavaToParse("20060806", "uuuuuuuu", 632995724851200L);
+        testJavaToParse("20060806", "uuuuMMdd", 1154822400L);
+        // They are not accepted in Java parser.
+        failJavaToParse("2006908906", "uuuu9MM9dd");
+        failJavaToParse("2006908906", "uuuu'9'MM'9'dd");
+        testJavaToParse("12006 08 06", "uuuuu MM dd", 316724342400L);
+        testJavaToParse("12006-08-06", "uuuuu-MM-dd", 316724342400L);
+        testJavaToParse("200608 6", "uuuuMM[ ]d", 1154822400L);
+
+        testJavaToParse("2006333", "uuuuDDD", 1164758400L);
+        // They are not accepted in Java parser.
+        failJavaToParse("20069333", "uuuu9DDD");
+        failJavaToParse("20069333", "uuuu'9'DDD");
+        testJavaToParse("12006 333", "uuuuu DDD", 316734278400L);
+        testJavaToParse("12006-333", "uuuuu-DDD", 316734278400L);
+
+        testJavaToParse("232425", "HHmmss", 84265L);
+        failJavaToParse("23924925", "%H9%M9%S");
+        failJavaToParse("23924925", "%H'9'%M'9'%S");
+        testJavaToParse("23 24 25", "HH mm ss", 84265L);
+        testJavaToParse("23:24:25", "HH:mm:ss", 84265L);
+        testJavaToParse(" 32425", "[ ]hmmss", 1465L);
+        testJavaToParse(" 32425", "[ ]Kmmss", 1465L);
+
+        // They are intentionally skipped as a month and a day of week are not sufficient to build a timestamp.
+        // [['FriAug', '%a%b'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FriAug', '%A%B'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FridayAugust', '%A%B'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FridayAugust', '%a%b'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
     }
 
     @Test  // Imported from test__strptime__width in Ruby v2.3.1's test/date/test_date_strptime.rb.
@@ -145,6 +319,8 @@ public class TestTimestampParser {
         // [['FridayAugust', '%A%B'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
         // [['FridayAugust', '%a%b'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
     }
+
+    // test__strptime__fail is skipped for Java parser.
 
     @Test  // Imported from test__strptime__fail in Ruby v2.3.1's test/date/test_date_strptime.rb.
     public void test__strptime__fail() {
@@ -207,12 +383,26 @@ public class TestTimestampParser {
     }
 
     @Test  // Imported partially from test_strptime in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJava() {
+        // 'Z' is not accepted in Java parser. Tested with "+00:00" instead.
+        testJavaToParse("2002-03-14T11:22:33+00:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", 1016104953L);
+        testJavaToParse("2002-03-14T11:22:33+09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", 1016072553L);
+        testJavaToParse("2002-03-14T11:22:33-09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", 1016137353L);
+        testJavaToParse("2002-03-14T11:22:33.123456789-09:00", "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSXXXXX",
+                        1016137353L, 123456789);
+        testJavaToParse("2002-03-14T11:22:33.123456789-09:00", "uuuu-MM-dd'T'HH:mm:ss.nnnnnnnnnXXXXX",
+                        1016137353L, 123456789);
+    }
+
+    @Test  // Imported partially from test_strptime in Ruby v2.3.1's test/date/test_date_strptime.rb.
     public void test_strptime() {
         testToParse("2002-03-14T11:22:33Z", "%Y-%m-%dT%H:%M:%S%Z", 1016104953L);
         testToParse("2002-03-14T11:22:33+09:00", "%Y-%m-%dT%H:%M:%S%Z", 1016072553L);
         testToParse("2002-03-14T11:22:33-09:00", "%FT%T%Z", 1016137353L);
         testToParse("2002-03-14T11:22:33.123456789-09:00", "%FT%T.%N%Z", 1016137353L, 123456789);
     }
+
+    // Epoch (nano) seconds are not accepted in Java parser.
 
     @Test  // Imported from test_strptime__minus in Ruby v2.3.1's test/date/test_date_strptime.rb.
     public void test_strptime__minus() {
@@ -223,6 +413,27 @@ public class TestTimestampParser {
         // -0.9s is represented like -1s + 100ms.
         testToParse("-999", "%Q", -1L, 1000000);
         testToParse("-1000", "%Q", -1L);
+    }
+
+    private void testJavaToParse(final String string, final String format, final long second, final int nanoOfSecond) {
+        final TimestampParser parser = TimestampParser.of("java:" + format, "UTC");
+        final Timestamp timestamp = parser.parse(string);
+        assertEquals(second, timestamp.getEpochSecond());
+        assertEquals(nanoOfSecond,timestamp.getNano());
+    }
+
+    private void testJavaToParse(final String string, final String format, final long second) {
+        testJavaToParse(string, format, second, 0);
+    }
+
+    private void failJavaToParse(final String string, final String format) {
+        final TimestampParser parser = TimestampParser.of("java:" + format, "UTC");
+        try {
+            parser.parse(string);
+        } catch (TimestampParseException ex) {
+            return;
+        }
+        fail();
     }
 
     private void testToParse(final String string, final String format, final long second, final int nanoOfSecond) {


### PR DESCRIPTION
It additionally accepts new-style timestamp formats prefixed by `"java:"` and composed from `java.time.DateTimeFormatter`'s format style, such as `"java:EEE, dd MMM uuuu HH:mm:ss ZZZ"`. Some cases could not be supported in the Java-version parser, though.

The spec is at:
https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns
https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatterBuilder.html#appendPattern-java.lang.String-

@muga @sakama What do you think?
  