### PR TITLE
Deprecate org.embulk.spi.time.TimestampFormat

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Set;
 
+// org.embulk.spi.time.TimestampFormat is deprecated.
+// It won't be removed very soon at least until Embulk v0.10.
+@Deprecated
 public class TimestampFormat
 {
     @JsonCreator

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
@@ -20,7 +20,7 @@ public class TimestampFormatter
         @Deprecated
         public default org.joda.time.DateTimeZone getDefaultTimeZone() {
             if (getDefaultTimeZoneId() != null) {
-                return TimestampFormat.parseDateTimeZone(getDefaultTimeZoneId());
+                return TimeZoneIds.parseJodaDateTimeZone(getDefaultTimeZoneId());
             }
             else {
                 return null;
@@ -43,7 +43,7 @@ public class TimestampFormatter
         @Deprecated
         public default Optional<org.joda.time.DateTimeZone> getTimeZone() {
             if (getTimeZoneId().isPresent()) {
-                return Optional.of(TimestampFormat.parseDateTimeZone(getTimeZoneId().get()));
+                return Optional.of(TimeZoneIds.parseJodaDateTimeZone(getTimeZoneId().get()));
             }
             else {
                 return Optional.absent();

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
@@ -120,7 +120,7 @@ public class TimestampParser
         @Deprecated
         public default org.joda.time.DateTimeZone getDefaultTimeZone() {
             if (getDefaultTimeZoneId() != null) {
-                return TimestampFormat.parseDateTimeZone(getDefaultTimeZoneId());
+                return TimeZoneIds.parseJodaDateTimeZone(getDefaultTimeZoneId());
             }
             else {
                 return null;
@@ -146,7 +146,7 @@ public class TimestampParser
         @Deprecated
         public default Optional<org.joda.time.DateTimeZone> getTimeZone() {
             if (getTimeZoneId().isPresent()) {
-                return Optional.of(TimestampFormat.parseDateTimeZone(getTimeZoneId().get()));
+                return Optional.of(TimeZoneIds.parseJodaDateTimeZone(getTimeZoneId().get()));
             }
             else {
                 return Optional.absent();

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
@@ -20,7 +20,6 @@ import org.embulk.spi.util.dynamic.DefaultValueSetter;
 import org.embulk.spi.util.dynamic.NullDefaultValueSetter;
 import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.time.TimestampParser;
-import org.embulk.spi.time.TimestampFormat;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.config.ConfigException;
@@ -71,7 +70,7 @@ class DynamicColumnSetterFactory
             return new DoubleColumnSetter(pageBuilder, column, defaultValue);
         } else if (type instanceof StringType) {
             TimestampFormatter formatter = new TimestampFormatter(
-                    getTimestampFormatForFormatter(column).getFormat(), getJodaDateTimeZone(column));
+                    getTimestampFormatForFormatter(column), getJodaDateTimeZone(column));
             return new StringColumnSetter(pageBuilder, column, defaultValue, formatter);
         } else if (type instanceof TimestampType) {
             // TODO use flexible time format like Ruby's Time.parse
@@ -81,34 +80,34 @@ class DynamicColumnSetterFactory
                 parser = TimestampParser.of(timestampType.getFormat(), getTimeZoneId(column));
             }
             else {
-                parser = TimestampParser.of(getTimestampFormatForParser(column).getFormat(), getTimeZoneId(column));
+                parser = TimestampParser.of(getTimestampFormatForParser(column), getTimeZoneId(column));
             }
             return new TimestampColumnSetter(pageBuilder, column, defaultValue, parser);
         } else if (type instanceof JsonType) {
             TimestampFormatter formatter = new TimestampFormatter(
-                    getTimestampFormatForFormatter(column).getFormat(), getJodaDateTimeZone(column));
+                    getTimestampFormatForFormatter(column), getJodaDateTimeZone(column));
             return new JsonColumnSetter(pageBuilder, column, defaultValue, formatter);
         }
         throw new ConfigException("Unknown column type: "+type);
     }
 
-    private TimestampFormat getTimestampFormatForFormatter(Column column)
+    private String getTimestampFormatForFormatter(Column column)
     {
         DynamicPageBuilder.ColumnOption option = getColumnOption(column);
         if (option != null) {
-            return option.getTimestampFormat();
+            return option.getTimestampFormatString();
         } else {
-            return new TimestampFormat("%Y-%m-%d %H:%M:%S.%6N");
+            return "%Y-%m-%d %H:%M:%S.%6N";
         }
     }
 
-    private TimestampFormat getTimestampFormatForParser(Column column)
+    private String getTimestampFormatForParser(Column column)
     {
         DynamicPageBuilder.ColumnOption option = getColumnOption(column);
         if (option != null) {
-            return option.getTimestampFormat();
+            return option.getTimestampFormatString();
         } else {
-            return new TimestampFormat("%Y-%m-%d %H:%M:%S.%N");
+            return "%Y-%m-%d %H:%M:%S.%N";
         }
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java
@@ -14,7 +14,7 @@ import org.embulk.spi.Column;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.PageOutput;
-import org.embulk.spi.time.TimestampFormat;
+import org.embulk.spi.time.TimeZoneIds;
 import org.embulk.spi.util.dynamic.SkipColumnSetter;
 
 public class DynamicPageBuilder
@@ -37,7 +37,7 @@ public class DynamicPageBuilder
         @Deprecated
         public default org.joda.time.DateTimeZone getDefaultTimeZone() {
             if (getDefaultTimeZoneId() != null) {
-                return TimestampFormat.parseDateTimeZone(getDefaultTimeZoneId());
+                return TimeZoneIds.parseJodaDateTimeZone(getDefaultTimeZoneId());
             }
             else {
                 return null;
@@ -56,7 +56,14 @@ public class DynamicPageBuilder
         // Ruby's strptime does not accept numeric prefixes in specifiers such as "%6N".
         @Config("timestamp_format")
         @ConfigDefault("\"%Y-%m-%d %H:%M:%S.%N\"")
-        public TimestampFormat getTimestampFormat();
+        public String getTimestampFormatString();
+
+        // org.embulk.spi.time.TimestampFormat is deprecated, but the getter returns TimestampFormat for compatibility.
+        // It won't be removed very soon at least until Embulk v0.10.
+        @Deprecated
+        public default org.embulk.spi.time.TimestampFormat getTimestampFormat() {
+            return new org.embulk.spi.time.TimestampFormat(getTimestampFormatString());
+        }
 
         @Config("timezone")
         @ConfigDefault("null")
@@ -67,7 +74,7 @@ public class DynamicPageBuilder
         @Deprecated
         public default Optional<org.joda.time.DateTimeZone> getTimeZone() {
             if (getTimeZoneId().isPresent()) {
-                return Optional.of(TimestampFormat.parseDateTimeZone(getTimeZoneId().get()));
+                return Optional.of(TimeZoneIds.parseJodaDateTimeZone(getTimeZoneId().get()));
             }
             else {
                 return Optional.absent();


### PR DESCRIPTION
`org.embulk.spi.time.TimestampFormat` is essentially just a `String`. We don't need it eventually.

@muga @sakama Can you have a look?