### PR TITLE
Split TimestampParser into TimestampParserLegacy

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/LegacyRubyTimeParsed.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/LegacyRubyTimeParsed.java
@@ -1,0 +1,65 @@
+package org.embulk.spi.time;
+
+import java.time.Instant;
+import java.time.ZoneId;
+
+/**
+ * LegacyRubyTimeParsed is a variation of RubyTimeParsed, which is converted to Instant in legacy Embulk's way.
+ */
+class LegacyRubyTimeParsed extends RubyTimeParsed {
+    LegacyRubyTimeParsed(
+            final String originalString,
+
+            final int dayOfMonth,
+            final int weekBasedYear,
+            final int hour,
+            final int dayOfYear,
+            final int nanoOfSecond,
+            final int minuteOfHour,
+            final int monthOfYear,
+            final Instant instantSeconds,
+            final int secondOfMinute,
+            final int weekOfYearStartingWithSunday,
+            final int weekOfYearStartingWithMonday,
+            final int dayOfWeekStartingWithMonday1,
+            final int weekOfWeekBasedYear,
+            final int dayOfWeekStartingWithSunday0,
+            final int year,
+
+            final String timeZoneName,
+
+            final String leftover) {
+        super(originalString,
+
+              dayOfMonth,
+              weekBasedYear,
+              hour,
+              dayOfYear,
+              nanoOfSecond,
+              minuteOfHour,
+              monthOfYear,
+              instantSeconds,
+              secondOfMinute,
+              weekOfYearStartingWithSunday,
+              weekOfYearStartingWithMonday,
+              dayOfWeekStartingWithMonday1,
+              weekOfWeekBasedYear,
+              dayOfWeekStartingWithSunday0,
+              year,
+
+              timeZoneName,
+
+              leftover);
+    }
+
+    @Override
+    Instant toInstant(final int defaultYear,
+                      final int defaultMonthOfYear,
+                      final int defaultDayOfMonth,
+                      final ZoneId defaultZoneId) {
+        return this.toInstantLegacy(defaultYear,
+                                    defaultMonthOfYear,
+                                    defaultDayOfMonth,
+                                    defaultZoneId);
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/time/RubyTimeParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/RubyTimeParser.java
@@ -43,7 +43,7 @@ class RubyTimeParser
         this.format = format;
     }
 
-    public TimeParsed parse(final String text)
+    public RubyTimeParsed parse(final String text)
     {
         return new StringParser(text).parse(this.format);
     }
@@ -74,7 +74,7 @@ class RubyTimeParser
             this.fail = false;
         }
 
-        private TimeParsed parse(final RubyTimeFormat format)
+        private RubyTimeParsed parse(final RubyTimeFormat format)
         {
             final RubyTimeParsed.Builder builder = TimeParsed.rubyBuilder(this.text);
 

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimeParsed.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimeParsed.java
@@ -2,29 +2,21 @@ package org.embulk.spi.time;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Map;
 
 /**
  * TimeParsed is a container of date/time information parsed from a string.
  */
 abstract class TimeParsed {  // to extend java.time.temporal.TemporalAccessor in Java 8
-    static abstract class Builder {
-        abstract TimeParsed build();
-    }
-
     static RubyTimeParsed.Builder rubyBuilder(final String originalString) {
         return new RubyTimeParsed.Builder(originalString);
     }
 
-    abstract Instant toInstantLegacy(final int defaultYear,
-                                     final int defaultMonthOfYear,
-                                     final int defaultDayOfMonth,
-                                     final ZoneId defaultZoneId);
+    abstract Instant toInstant(final ZoneOffset defaultZoneOffset);
 
-    abstract Timestamp toTimestampLegacy(final int defaultYear,
-                                         final int defaultMonthOfYear,
-                                         final int defaultDayOfMonth,
-                                         final ZoneId defaultZoneId);
-
-    abstract Map<String, Object> asMapLikeRubyHash();
+    abstract Instant toInstant(final int defaultYear,
+                               final int defaultMonthOfYear,
+                               final int defaultDayOfMonth,
+                               final ZoneId defaultZoneId);
 }

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParserLegacy.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParserLegacy.java
@@ -1,0 +1,104 @@
+package org.embulk.spi.time;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import org.embulk.config.ConfigException;
+
+public class TimestampParserLegacy extends TimestampParser {
+    private TimestampParserLegacy(final String formatString,
+                                  final ZoneId defaultZoneId,
+                                  final org.joda.time.DateTimeZone defaultJodaDateTimeZone,
+                                  final int defaultYear,
+                                  final int defaultMonthOfYear,
+                                  final int defaultDayOfMonth) {
+        this.formatString = formatString;
+        this.parser = new RubyTimeParser(RubyTimeFormat.compile(formatString));
+        this.defaultJodaDateTimeZone = defaultJodaDateTimeZone;
+        this.defaultZoneId = defaultZoneId;
+        this.defaultYear = defaultYear;
+        this.defaultMonthOfYear = defaultMonthOfYear;
+        this.defaultDayOfMonth = defaultDayOfMonth;
+    }
+
+    static TimestampParserLegacy of(final String formatString,
+                                    final ZoneId defaultZoneId,
+                                    final org.joda.time.DateTimeZone defaultJodaDateTimeZone,
+                                    final int defaultYear,
+                                    final int defaultMonthOfYear,
+                                    final int defaultDayOfMonth) {
+        return new TimestampParserLegacy(formatString,
+                                         defaultZoneId,
+                                         defaultJodaDateTimeZone,
+                                         defaultYear,
+                                         defaultMonthOfYear,
+                                         defaultDayOfMonth);
+    }
+
+    static TimestampParserLegacy of(final String formatString,
+                                    final ZoneId defaultZoneId,
+                                    final org.joda.time.DateTimeZone defaultJodaDateTimeZone,
+                                    final String defaultDateString) {
+        final LocalDate defaultDate = parseDateForDefault(defaultDateString);
+        return of(formatString,
+                  defaultZoneId,
+                  defaultJodaDateTimeZone,
+                  defaultDate.getYear(),
+                  defaultDate.getMonthValue(),
+                  defaultDate.getDayOfMonth());
+    }
+
+    @VisibleForTesting
+    static TimestampParser createTimestampParserForTesting(final TimestampParser.Task task) {
+        return of(task.getDefaultTimestampFormat(),
+                  TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab(task.getDefaultTimeZoneId()),
+                  TimeZoneIds.parseJodaDateTimeZone(task.getDefaultTimeZoneId()),
+                  task.getDefaultDate());
+    }
+
+    // Using Joda-Time is deprecated, but the method return org.joda.time.DateTimeZone for plugin compatibility.
+    // It won't be removed very soon at least until Embulk v0.10.
+    @Deprecated
+    @Override
+    public org.joda.time.DateTimeZone getDefaultTimeZone() {
+        return defaultJodaDateTimeZone;
+    }
+
+    @Override
+    Instant parseInternal(final String text) throws TimestampParseException {
+        if (Strings.isNullOrEmpty(text)) {
+            throw new TimestampParseException("text is null or empty string.");
+        }
+
+        final RubyTimeParsed parsed = this.parser.parse(text);
+        if (parsed == null) {
+            throw new TimestampParseException("Cannot parse '" + text + "' by '" + this.formatString + "'");
+        }
+        return parsed.toLegacy().toInstant(this.defaultYear,
+                                           this.defaultMonthOfYear,
+                                           this.defaultDayOfMonth,
+                                           this.defaultZoneId);
+    }
+
+    private static LocalDate parseDateForDefault(final String defaultDate) {
+        try {
+            return LocalDate.parse(defaultDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        } catch (DateTimeParseException ex) {
+            throw new ConfigException("Invalid date format. Expected yyyy-MM-dd: " + defaultDate, ex);
+        }
+    }
+
+    private final String formatString;
+    private final RubyTimeParser parser;
+
+    private final org.joda.time.DateTimeZone defaultJodaDateTimeZone;
+    private final ZoneId defaultZoneId;
+
+    private final int defaultYear;
+    private final int defaultMonthOfYear;
+    private final int defaultDayOfMonth;
+}

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatterParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatterParser.java
@@ -42,7 +42,7 @@ public class TestTimestampFormatterParser
             .set("default_timestamp_format", "%Y-%m-%d %H:%M:%S %z");  // %Z is OS-dependent
         ParserTestTask task = config.loadConfig(ParserTestTask.class);
 
-        TimestampParser parser = TimestampParser.createTimestampParserForTesting(task);
+        TimestampParser parser = TimestampParserLegacy.createTimestampParserForTesting(task);
         assertEquals(Timestamp.ofEpochSecond(1416365189, 0), parser.parse("2014-11-19 02:46:29 +0000"));
     }
 
@@ -57,7 +57,7 @@ public class TestTimestampFormatterParser
         assertEquals("1416365189", formatter.format(Timestamp.ofEpochSecond(1416365189)));
 
         ParserTestTask ptask = config.loadConfig(ParserTestTask.class);
-        TimestampParser parser = TimestampParser.createTimestampParserForTesting(ptask);
+        TimestampParser parser = TimestampParserLegacy.createTimestampParserForTesting(ptask);
         assertEquals(Timestamp.ofEpochSecond(1416365189), parser.parse("1416365189"));
     }
 
@@ -69,7 +69,7 @@ public class TestTimestampFormatterParser
             .set("default_date", "2016-02-03");
 
         ParserTestTask ptask = config.loadConfig(ParserTestTask.class);
-        TimestampParser parser = TimestampParser.createTimestampParserForTesting(ptask);
+        TimestampParser parser = TimestampParserLegacy.createTimestampParserForTesting(ptask);
         assertEquals(Timestamp.ofEpochSecond(1454467589, 0), parser.parse("02:46:29 +0000"));
     }
 }


### PR DESCRIPTION
It's preparation for adding `"java:"` and `"ruby:"` timestamp formats. Can you have a look? @muga @sakama 