### PR TITLE
Add Ruby-style ("ruby:") timestamp format to format timestamps in the compatible way with Time.strptime

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatterRuby.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatterRuby.java
@@ -1,0 +1,56 @@
+package org.embulk.spi.time;
+
+import com.google.common.base.Optional;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import org.jruby.util.RubyDateFormat;
+
+public class TimestampFormatterRuby extends TimestampFormatter {
+    private TimestampFormatterRuby(final RubyDateFormat formatter,
+                                   final ZoneOffset zoneOffset,
+                                   final org.joda.time.DateTimeZone jodaDateTimeZone,
+                                   final String formatString) {
+        this.formatter = formatter;
+        this.zoneOffset = zoneOffset;
+        this.jodaDateTimeZone = jodaDateTimeZone;
+        this.formatString = formatString;
+    }
+
+    static TimestampFormatterRuby of(final String formatString, final ZoneOffset zoneOffset) {
+        return new TimestampFormatterRuby(new RubyDateFormat(formatString, Locale.ENGLISH, true),
+                                          zoneOffset,
+                                          TimeZoneIds.convertZoneOffsetToJodaDateTimeZone(zoneOffset),
+                                          formatString);
+    }
+
+    // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
+    // It won't be removed very soon at least until Embulk v0.10.
+    @Deprecated
+    static TimestampFormatterRuby ofLegacy(final String formatString,
+                                           final org.joda.time.DateTimeZone jodaDateTimeZone) {
+        return new TimestampFormatterRuby(new RubyDateFormat(formatString, Locale.ENGLISH, true),
+                                          null,
+                                          jodaDateTimeZone,
+                                          formatString);
+    }
+
+    // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
+    // It won't be removed very soon at least until Embulk v0.10.
+    @Deprecated
+    @Override
+    public org.joda.time.DateTimeZone getTimeZone() {
+        return this.jodaDateTimeZone;
+    }
+
+    public String format(final Timestamp value) {
+        // TODO: Optimize by using reused StringBuilder.
+        this.formatter.setDateTime(new org.joda.time.DateTime(value.getEpochSecond() * 1000, this.jodaDateTimeZone));
+        this.formatter.setNSec(value.getNano());
+        return this.formatter.format(null);
+    }
+
+    private final RubyDateFormat formatter;
+    private final ZoneOffset zoneOffset;  // Nullable
+    private final org.joda.time.DateTimeZone jodaDateTimeZone;  // Not null
+    private final String formatString;
+}

--- a/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
@@ -44,7 +44,7 @@ public class Timestamps
         for (Column column : schema.getColumns()) {
             if (column.getType() instanceof TimestampType) {
                 Optional<TimestampFormatter.TimestampColumnOption> option = Optional.fromNullable(columnOptions.get(column.getName()));
-                formatters[i] = new TimestampFormatter(formatterTask, option);
+                formatters[i] = TimestampFormatter.of(formatterTask, option);
             }
             i++;
         }

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatter.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatter.java
@@ -1,0 +1,44 @@
+package org.embulk.spi.time;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.Test;
+
+public class TestTimestampFormatter {
+    @Test
+    public void testRuby() {
+        testRubyToFormat(OffsetDateTime.of(2017, 2, 28, 2, 0, 45, 0, ZoneOffset.UTC).toInstant(),
+                         "%Y-%m-%dT%H:%M:%S %Z",
+                         "-09:00",
+                         "2017-02-27T17:00:45 -09:00");
+    }
+
+    @Test
+    public void testLegacy() {
+        testLegacyToFormat(OffsetDateTime.of(2017, 2, 28, 2, 0, 45, 0, ZoneOffset.UTC).toInstant(),
+                           "%Y-%m-%dT%H:%M:%S %Z",
+                           "Asia/Tokyo",
+                           "2017-02-28T11:00:45 JST");
+    }
+
+    private void testRubyToFormat(final Instant instant,
+                                  final String format,
+                                  final String zoneOffset,
+                                  final String expected) {
+        final TimestampFormatter formatter = TimestampFormatter.of("ruby:" + format, zoneOffset);
+        final String actual = formatter.format(Timestamp.ofInstant(instant));
+        assertEquals(expected, actual);
+    }
+
+    private void testLegacyToFormat(final Instant instant,
+                                    final String format,
+                                    final String zoneId,
+                                    final String expected) {
+        final TimestampFormatter formatter = TimestampFormatter.of(format, zoneId);
+        final String actual = formatter.format(Timestamp.ofInstant(instant));
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Accepting "ruby:" timestamp formats in `TimestampFormatter` in addition to `TimestampParser` at #905, simply for consistency.

There are not so many differences in formatter, not like parser.

@muga @sakama Can you have a look? More test cases would be added sooner in other PRs.