### PR TITLE
Add Java-style ("java:") timestamp format to format timestamps with java.time

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
@@ -38,7 +38,15 @@ public class TimestampFormatter {
     }
 
     public static TimestampFormatter of(final String pattern, final String zoneIdString) {
-        if (pattern.startsWith("ruby:")) {
+        if (pattern.startsWith("java:")) {
+            final ZoneOffset zoneOffset;
+            if (zoneIdString.equals("UTC")) {
+                zoneOffset = ZoneOffset.UTC;
+            } else {
+                zoneOffset = ZoneOffset.of(zoneIdString);
+            }
+            return TimestampFormatterJava.of(pattern.substring(5), zoneOffset);
+        } else if (pattern.startsWith("ruby:")) {
             final ZoneOffset zoneOffset;
             if (zoneIdString.equals("UTC")) {
                 zoneOffset = ZoneOffset.UTC;
@@ -66,7 +74,15 @@ public class TimestampFormatter {
             zoneIdString = task.getDefaultTimeZoneId();
         }
 
-        if (pattern.startsWith("ruby:")) {
+        if (pattern.startsWith("java:")) {
+            final ZoneOffset zoneOffset;
+            if (zoneIdString.equals("UTC")) {
+                zoneOffset = ZoneOffset.UTC;
+            } else {
+                zoneOffset = ZoneOffset.of(zoneIdString);
+            }
+            return TimestampFormatterJava.of(pattern.substring(5), zoneOffset);
+        } else if (pattern.startsWith("ruby:")) {
             final ZoneOffset zoneOffset;
             if (zoneIdString.equals("UTC")) {
                 zoneOffset = ZoneOffset.UTC;

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatterJava.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatterJava.java
@@ -1,0 +1,46 @@
+package org.embulk.spi.time;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Locale;
+
+public class TimestampFormatterJava extends TimestampFormatter {
+    private TimestampFormatterJava(final DateTimeFormatter formatter,
+                                   final ZoneOffset zoneOffset,
+                                   final String pattern) {
+        this.formatter = formatter;
+        this.zoneOffset = zoneOffset;
+        this.pattern = pattern;
+    }
+
+    static TimestampFormatterJava of(final String pattern, final ZoneOffset zoneOffset) {
+        return new TimestampFormatterJava(new DateTimeFormatterBuilder()
+                                              .appendPattern(pattern)
+                                              .toFormatter(Locale.ENGLISH),
+                                          zoneOffset,
+                                          pattern);
+    }
+
+    static TimestampFormatterJava of(final DateTimeFormatter formatter, final ZoneOffset zoneOffset) {
+        return new TimestampFormatterJava(formatter, zoneOffset, "");
+    }
+
+    // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
+    // It won't be removed very soon at least until Embulk v0.10.
+    @Deprecated
+    @Override
+    public org.joda.time.DateTimeZone getTimeZone() {
+        return TimeZoneIds.convertZoneOffsetToJodaDateTimeZone(this.zoneOffset);
+    }
+
+    @Override
+    public String format(final Timestamp value) {
+        return this.formatter.format(OffsetDateTime.ofInstant(value.getInstant(), this.zoneOffset));
+    }
+
+    private final DateTimeFormatter formatter;
+    private final ZoneOffset zoneOffset;
+    private final String pattern;
+}

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatter.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatter.java
@@ -9,6 +9,14 @@ import org.junit.Test;
 
 public class TestTimestampFormatter {
     @Test
+    public void testJava() {
+        testJavaToFormat(OffsetDateTime.of(2017, 2, 28, 2, 0, 45, 0, ZoneOffset.UTC).toInstant(),
+                         "EEE MMM dd HH:mm:ss uuuu XXXXX",
+                         "-07:00",
+                         "Mon Feb 27 19:00:45 2017 -07:00");
+    }
+
+    @Test
     public void testRuby() {
         testRubyToFormat(OffsetDateTime.of(2017, 2, 28, 2, 0, 45, 0, ZoneOffset.UTC).toInstant(),
                          "%Y-%m-%dT%H:%M:%S %Z",
@@ -22,6 +30,15 @@ public class TestTimestampFormatter {
                            "%Y-%m-%dT%H:%M:%S %Z",
                            "Asia/Tokyo",
                            "2017-02-28T11:00:45 JST");
+    }
+
+    private void testJavaToFormat(final Instant instant,
+                                  final String format,
+                                  final String zoneOffset,
+                                  final String expected) {
+        final TimestampFormatter formatter = TimestampFormatter.of("java:" + format, zoneOffset);
+        final String actual = formatter.format(Timestamp.ofInstant(instant));
+        assertEquals(expected, actual);
     }
 
     private void testRubyToFormat(final Instant instant,


### PR DESCRIPTION
After #906, adding Java-style "`java:`" timestamp formatter with `java.time`.

@muga @sakama Can you have a look? More test cases would be added sooner in other PRs.