### PR TITLE
Remove unnecessary reference of a Java property "java.io.tmpdir"

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/unit/LocalFileSerDe.java
+++ b/embulk-core/src/main/java/org/embulk/spi/unit/LocalFileSerDe.java
@@ -40,18 +40,6 @@ public class LocalFileSerDe
     private static class LocalFileDeserializer
             extends JsonDeserializer<LocalFile>
     {
-        private final File tempDir;
-
-        public LocalFileDeserializer()
-        {
-            this(new File(System.getProperty("java.io.tmpdir")));
-        }
-
-        public LocalFileDeserializer(File tempDir)
-        {
-            this.tempDir = tempDir;
-        }
-
         @Override
         public LocalFile deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException
         {


### PR DESCRIPTION
`org.embulk.spi.unit.LocalFileSerDe$LocalFileDeserializer` refers a Java property `java.io.tmpdir`, but that is never used. Let's remove that.

@sakama Can you have a look? (Cc: @muga)