### PR TITLE
Enable checkstyle for embulk-core's test Java files

### DIFF
--- a/embulk-core/config/checkstyle/suppressions.xml
+++ b/embulk-core/config/checkstyle/suppressions.xml
@@ -5,7 +5,6 @@
     "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
 <suppressions>
-  <suppress checks=".*" files="src[/\\]test[/\\]java[/\\].*" />
   <suppress checks="JavadocMethod" files=".*"/>
   <suppress checks="JavadocParagraph" files=".*"/>
   <suppress checks="JavadocTagContinuationIndentation" files=".*"/>

--- a/embulk-core/src/test/java/org/embulk/GuiceBinder.java
+++ b/embulk-core/src/test/java/org/embulk/GuiceBinder.java
@@ -1,45 +1,39 @@
 package org.embulk;
 
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import com.google.common.collect.ImmutableList;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-import com.google.inject.Module;
 
-public class GuiceBinder
-        implements TestRule
-{
+public class GuiceBinder implements TestRule {
     private final List<Module> baseModules;
     private List<Module> extraModules;
     private Injector injector;
 
-    public GuiceBinder(Module... baseModules)
-    {
+    public GuiceBinder(Module... baseModules) {
         this.baseModules = ImmutableList.copyOf(baseModules);
         reset();
     }
 
-    private void reset()
-    {
+    private void reset() {
         extraModules = new ArrayList<Module>();
         injector = null;
     }
 
-    public synchronized void addModule(Module module)
-    {
+    public synchronized void addModule(Module module) {
         if (injector != null) {
             throw new IllegalStateException("Injector is already initialized. Call addModule before getInjector or getInstance");
         }
         extraModules.add(module);
     }
 
-    public synchronized Injector getInjector()
-    {
+    public synchronized Injector getInjector() {
         if (injector == null) {
             ImmutableList.Builder<Module> modules = ImmutableList.builder();
             modules.addAll(baseModules);
@@ -49,23 +43,18 @@ public class GuiceBinder
         return injector;
     }
 
-    public <T> T getInstance(Class<T> klass)
-    {
+    public <T> T getInstance(Class<T> klass) {
         return getInjector().getInstance(klass);
     }
 
     @Override
-    public Statement apply(Statement base, Description description)
-    {
+    public Statement apply(Statement base, Description description) {
         return new GuceBinderWatcher().apply(base, description);
     }
 
-    private class GuceBinderWatcher
-            extends TestWatcher
-    {
+    private class GuceBinderWatcher extends TestWatcher {
         @Override
-        protected void starting(Description description)
-        {
+        protected void starting(Description description) {
             reset();
         }
     }

--- a/embulk-core/src/test/java/org/embulk/RandomManager.java
+++ b/embulk-core/src/test/java/org/embulk/RandomManager.java
@@ -3,37 +3,31 @@ package org.embulk;
 import java.util.Map;
 import java.util.Random;
 
-public class RandomManager
-{
+public class RandomManager {
     protected long seed;
     protected Random random;
 
-    public RandomManager()
-    {
+    public RandomManager() {
         this(getDefaultSeed());
     }
 
-    public RandomManager(long seed)
-    {
+    public RandomManager(long seed) {
         this.seed = seed;
         this.random = new Random(seed);
-        System.out.println(" Random seed: 0x"+Long.toHexString(seed)+"L");
+        System.out.println(" Random seed: 0x" + Long.toHexString(seed) + "L");
     }
 
-    public long getRandomSeed()
-    {
+    public long getRandomSeed() {
         return seed;
     }
 
-    public void setRandomSeed(long seed)
-    {
+    public void setRandomSeed(long seed) {
         random.setSeed(seed);
         this.seed = seed;
-        System.out.println(" Set random seed: 0x"+Long.toHexString(this.seed)+"L");
+        System.out.println(" Set random seed: 0x" + Long.toHexString(this.seed) + "L");
     }
 
-    public Random getRandom()
-    {
+    public Random getRandom() {
         return random;
     }
 
@@ -41,11 +35,11 @@ public class RandomManager
         Map<String, String> env = System.getenv();
         String s = env.get("RANDOM_SEED");
         try {
-            if(s != null) {
+            if (s != null) {
                 return Long.parseLong(s);
             }
         } catch (NumberFormatException e) {
-            System.out.println("RANDOM_SEED variable is wrong: "+e);
+            System.out.println("RANDOM_SEED variable is wrong: " + e);
         }
 
         return new Random().nextLong();

--- a/embulk-core/src/test/java/org/embulk/TestPluginSourceModule.java
+++ b/embulk-core/src/test/java/org/embulk/TestPluginSourceModule.java
@@ -2,19 +2,16 @@ package org.embulk;
 
 import static org.embulk.plugin.InjectedPluginSource.registerPluginTo;
 
+import com.google.inject.Binder;
+import com.google.inject.Module;
 import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.MockFormatterPlugin;
 import org.embulk.spi.MockParserPlugin;
 import org.embulk.spi.ParserPlugin;
 
-import com.google.inject.Binder;
-import com.google.inject.Module;
-
-public class TestPluginSourceModule implements Module
-{
+public class TestPluginSourceModule implements Module {
     @Override
-    public void configure(Binder binder)
-    {
+    public void configure(Binder binder) {
         registerPluginTo(binder, ParserPlugin.class, "mock",
                 MockParserPlugin.class);
         registerPluginTo(binder, FormatterPlugin.class, "mock",

--- a/embulk-core/src/test/java/org/embulk/TestUtilityModule.java
+++ b/embulk-core/src/test/java/org/embulk/TestUtilityModule.java
@@ -2,12 +2,11 @@ package org.embulk;
 
 //import org.embulk.record.RandomRecordGenerator;
 //import org.embulk.record.RandomSchemaGenerator;
+
 import com.google.inject.Binder;
 import com.google.inject.Module;
 
-public class TestUtilityModule
-        implements Module
-{
+public class TestUtilityModule implements Module {
     @Override
     public void configure(Binder binder) {
         binder.bind(RandomManager.class);

--- a/embulk-core/src/test/java/org/embulk/cli/DummyMain.java
+++ b/embulk-core/src/test/java/org/embulk/cli/DummyMain.java
@@ -19,5 +19,4 @@ public class DummyMain {
             }
         }
     }
-
 }

--- a/embulk-core/src/test/java/org/embulk/cli/SelfrunTest.java
+++ b/embulk-core/src/test/java/org/embulk/cli/SelfrunTest.java
@@ -6,17 +6,16 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.InputStreamReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.List;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -29,18 +28,18 @@ public class SelfrunTest {
         final FileSystem fileSystem = FileSystems.getDefault();
 
         final File thisFolder = new File(
-            SelfrunTest.class.getResource("/org/embulk/cli/SelfrunTest.class").toURI()).getParentFile();
+                SelfrunTest.class.getResource("/org/embulk/cli/SelfrunTest.class").toURI()).getParentFile();
         testSelfrunFile = new File(
-            thisFolder, System.getProperty("file.separator").equals("\\") ? "selfrun.bat" : "selfrun.sh");
+                thisFolder, System.getProperty("file.separator").equals("\\") ? "selfrun.bat" : "selfrun.sh");
 
         final File classpath = thisFolder.getParentFile().getParentFile().getParentFile();
         final String line =
-            new String(Files.readAllBytes(fileSystem.getPath(originalSelfrunFile.getAbsolutePath())),
-                       Charset.defaultCharset())
-            .replaceAll("java ",
-                        "java -classpath "
-                        + classpath.getAbsolutePath().replaceAll("\\\\", "\\\\\\\\")
-                        + " org.embulk.cli.DummyMain ");
+                new String(Files.readAllBytes(fileSystem.getPath(originalSelfrunFile.getAbsolutePath())),
+                           Charset.defaultCharset())
+                .replaceAll("java ",
+                            "java -classpath "
+                                    + classpath.getAbsolutePath().replaceAll("\\\\", "\\\\\\\\")
+                                    + " org.embulk.cli.DummyMain ");
 
         // Modify selfrun so that arguments are written in 'args.txt' .
         Files.write(fileSystem.getPath(testSelfrunFile.getAbsolutePath()),
@@ -202,6 +201,7 @@ public class SelfrunTest {
                      args);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
     public void testJR() throws Exception {
         List<String> args = execute("-Jj1", "-Rr1", "a1", "a2");

--- a/embulk-core/src/test/java/org/embulk/config/TestConfigLoader.java
+++ b/embulk-core/src/test/java/org/embulk/config/TestConfigLoader.java
@@ -1,39 +1,33 @@
 package org.embulk.config;
 
-import java.util.Properties;
-import java.io.InputStream;
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import com.google.inject.Inject;
-import org.embulk.spi.Exec;
-import org.embulk.EmbulkTestRuntime;
 
-public class TestConfigLoader
-{
+public class TestConfigLoader {
     private ConfigLoader loader;
 
     @Before
-    public void setup() throws Exception
-    {
+    public void setup() throws Exception {
         this.loader = new ConfigLoader(new ModelManager(null, new ObjectMapper()));
     }
 
     @Test
-    public void testFromEmptyJson() throws IOException
-    {
+    public void testFromEmptyJson() throws IOException {
         ConfigSource config = loader.fromJson(newInputStream("{\"type\":\"test\",\"data\":1}"));
         assertEquals("test", config.get(String.class, "type"));
         assertEquals(1, (int) config.get(Integer.class, "data"));
     }
 
     @Test
-    public void testFromYamlProperties() throws IOException
-    {
+    public void testFromYamlProperties() throws IOException {
         Properties props = new Properties();
         props.setProperty("type", "test");
         props.setProperty("data", "1");
@@ -44,22 +38,20 @@ public class TestConfigLoader
     }
 
     @Test
-    public void testFromYamlPropertiesNested() throws IOException
-    {
+    public void testFromYamlPropertiesNested() throws IOException {
         Properties props = new Properties();
         props.setProperty("type", "test");
         props.setProperty("columns.k1", "1");
         props.setProperty("values.myval.data", "2");
 
         ConfigSource config = loader.fromPropertiesYamlLiteral(props, "");
-        System.out.println("config: "+config);
+        System.out.println("config: " + config);
         assertEquals("test", config.get(String.class, "type"));
         assertEquals(1, (int) config.getNested("columns").get(Integer.class, "k1"));
         assertEquals(2, (int) config.getNested("values").getNested("myval").get(Integer.class, "data"));
     }
 
-    private static InputStream newInputStream(String string)
-    {
+    private static InputStream newInputStream(String string) {
         byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
         return new ByteArrayInputStream(bytes);
     }

--- a/embulk-core/src/test/java/org/embulk/config/TestConfigSource.java
+++ b/embulk-core/src/test/java/org/embulk/config/TestConfigSource.java
@@ -1,29 +1,25 @@
 package org.embulk.config;
 
-import org.junit.Rule;
-import org.junit.Before;
-import org.junit.Test;
 import static org.junit.Assert.assertEquals;
-import com.google.inject.Inject;
-import org.embulk.spi.Exec;
-import org.embulk.EmbulkTestRuntime;
 
-public class TestConfigSource
-{
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.spi.Exec;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestConfigSource {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
     private ConfigSource config;
 
     @Before
-    public void setup() throws Exception
-    {
+    public void setup() throws Exception {
         config = Exec.newConfigSource();
     }
 
-    private static interface TypeFields
-            extends Task
-    {
+    private static interface TypeFields extends Task {
         @Config("boolean")
         public boolean getBoolean();
 
@@ -41,8 +37,7 @@ public class TestConfigSource
     }
 
     @Test
-    public void testSetGet()
-    {
+    public void testSetGet() {
         config.set("boolean", true);
         config.set("int", 3);
         config.set("double", 0.2);
@@ -57,8 +52,7 @@ public class TestConfigSource
     }
 
     @Test
-    public void testLoadConfig()
-    {
+    public void testLoadConfig() {
         config.set("boolean", true);
         config.set("int", 3);
         config.set("double", 0.2);
@@ -73,16 +67,13 @@ public class TestConfigSource
         assertEquals("sf", task.getString());
     }
 
-    private static interface ValidateFields
-            extends Task
-    {
+    private static interface ValidateFields extends Task {
         @Config("valid")
         public String getValid();
     }
 
     @Test
-    public void testValidatePasses()
-    {
+    public void testValidatePasses() {
         config.set("valid", "data");
         ValidateFields task = config.loadConfig(ValidateFields.class);
         task.validate();
@@ -90,24 +81,20 @@ public class TestConfigSource
     }
 
     @Test(expected = ConfigException.class)
-    public void testDefaultValueValidateFails()
-    {
+    public void testDefaultValueValidateFails() {
         ValidateFields task = config.loadConfig(ValidateFields.class);
         task.validate();
     }
 
     // TODO test Min, Max, and other validations
 
-    private static interface SimpleFields
-            extends Task
-    {
+    private static interface SimpleFields extends Task {
         @Config("type")
         public String getType();
     }
 
     @Test
-    public void testFromJson()
-    {
+    public void testFromJson() {
         String json = "{\"type\":\"test\"}";
         // TODO
     }

--- a/embulk-core/src/test/java/org/embulk/config/TestTaskSource.java
+++ b/embulk-core/src/test/java/org/embulk/config/TestTaskSource.java
@@ -1,33 +1,34 @@
 package org.embulk.config;
 
-import org.junit.Rule;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
-import com.google.inject.Inject;
-import org.embulk.spi.Exec;
-import org.embulk.EmbulkTestRuntime;
+import static org.junit.Assert.assertTrue;
 
-public class TestTaskSource
-{
-    private static interface TypeFields
-            extends Task
-    {
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.spi.Exec;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestTaskSource {
+    private static interface TypeFields extends Task {
         public boolean getBoolean();
+
         public void setBoolean(boolean v);
 
         public double getDouble();
+
         public void setDouble(double v);
 
         public int getInt();
+
         public void setInt(int v);
 
         public long getLong();
+
         public void setLong(long v);
 
         public String getString();
+
         public void setString(String v);
     }
 
@@ -37,8 +38,7 @@ public class TestTaskSource
     private TaskSource taskSource;
 
     @Before
-    public void setup() throws Exception
-    {
+    public void setup() throws Exception {
         taskSource = Exec.newTaskSource();
         taskSource.set("Boolean", false);
         taskSource.set("Double", 0.5);
@@ -48,8 +48,7 @@ public class TestTaskSource
     }
 
     @Test
-    public void testEqualsOfLoadedTasks()
-    {
+    public void testEqualsOfLoadedTasks() {
         TypeFields task = taskSource.loadTask(TypeFields.class);
         task.setBoolean(true);
         task.setDouble(0.2);

--- a/embulk-core/src/test/java/org/embulk/plugin/MockPluginSource.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/MockPluginSource.java
@@ -4,27 +4,22 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.multibindings.Multibinder;
 
-public class MockPluginSource
-        implements PluginSource
-{
+public class MockPluginSource implements PluginSource {
     private final Class<?> expectedIface;
     private final Object plugin;
     private PluginType typeConfig;
 
-    public <T> MockPluginSource(Class<T> expectedIface, T plugin)
-    {
+    public <T> MockPluginSource(Class<T> expectedIface, T plugin) {
         this.expectedIface = expectedIface;
         this.plugin = plugin;
     }
 
-    public PluginType getTypeConfig()
-    {
+    public PluginType getTypeConfig() {
         return typeConfig;
     }
 
     @SuppressWarnings("unchecked")
-    public <T> T newPlugin(Class<T> iface, PluginType typeConfig) throws PluginSourceNotMatchException
-    {
+    public <T> T newPlugin(Class<T> iface, PluginType typeConfig) throws PluginSourceNotMatchException {
         if (expectedIface.equals(iface)) {
             this.typeConfig = typeConfig;
             return (T) plugin;
@@ -33,24 +28,19 @@ public class MockPluginSource
         }
     }
 
-    public static <T> Module newInjectModule(final Class<T> expectedIface, final T plugin)
-    {
+    public static <T> Module newInjectModule(final Class<T> expectedIface, final T plugin) {
         return new InjectModule(expectedIface, plugin);
     }
 
-    public static class InjectModule
-            implements Module
-    {
+    public static class InjectModule implements Module {
         private final PluginSource pluginSource;
 
-        public <T> InjectModule(Class<T> expectedIface, T plugin)
-        {
+        public <T> InjectModule(Class<T> expectedIface, T plugin) {
             this.pluginSource = new MockPluginSource(expectedIface, plugin);
         }
 
         @Override
-        public void configure(Binder binder)
-        {
+        public void configure(Binder binder) {
             Multibinder<PluginSource> multibinder = Multibinder.newSetBinder(binder, PluginSource.class);
             multibinder.addBinding().toInstance(pluginSource);
         }

--- a/embulk-core/src/test/java/org/embulk/plugin/TestPluginType.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/TestPluginType.java
@@ -8,11 +8,9 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import org.junit.Test;
 
-public class TestPluginType
-{
+public class TestPluginType {
     @Test
-    public void testEquals()
-    {
+    public void testEquals() {
         PluginType type = PluginType.createFromStringForTesting("a");
         assertTrue(type instanceof DefaultPluginType);
         assertEquals(PluginSource.Type.DEFAULT, type.getSourceType());
@@ -23,8 +21,7 @@ public class TestPluginType
     }
 
     @Test
-    public void testMapping1()
-    {
+    public void testMapping1() {
         HashMap<String, String> mapping = new HashMap<String, String>();
         mapping.put("source", "default");
         mapping.put("name", "c");
@@ -39,8 +36,7 @@ public class TestPluginType
     }
 
     @Test
-    public void testMapping2()
-    {
+    public void testMapping2() {
         HashMap<String, String> mapping = new HashMap<String, String>();
         mapping.put("source", "maven");
         mapping.put("name", "e");
@@ -60,8 +56,7 @@ public class TestPluginType
     }
 
     @Test
-    public void testMappingMavenWithClassifier()
-    {
+    public void testMappingMavenWithClassifier() {
         HashMap<String, String> mapping = new HashMap<String, String>();
         mapping.put("source", "maven");
         mapping.put("name", "e");

--- a/embulk-core/src/test/java/org/embulk/plugin/TestPluginTypeSerDe.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/TestPluginTypeSerDe.java
@@ -8,39 +8,35 @@ import org.embulk.EmbulkTestRuntime;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class TestPluginTypeSerDe
-{
+public class TestPluginTypeSerDe {
     @Rule
     public EmbulkTestRuntime testRuntime = new EmbulkTestRuntime();
 
     @Test
-    public void testParseTypeString()
-    {
+    public void testParseTypeString() {
         PluginType pluginType = testRuntime.getModelManager().readObjectWithConfigSerDe(
-            PluginType.class,
-            "\"file\"");
+                PluginType.class,
+                "\"file\"");
         assertTrue(pluginType instanceof DefaultPluginType);
         assertEquals(PluginSource.Type.DEFAULT, pluginType.getSourceType());
         assertEquals("file", pluginType.getName());
     }
 
     @Test
-    public void testParseTypeMapping()
-    {
+    public void testParseTypeMapping() {
         PluginType pluginType = testRuntime.getModelManager().readObjectWithConfigSerDe(
-            PluginType.class,
-            "{ \"name\": \"dummy\" }");
+                PluginType.class,
+                "{ \"name\": \"dummy\" }");
         assertTrue(pluginType instanceof DefaultPluginType);
         assertEquals(PluginSource.Type.DEFAULT, pluginType.getSourceType());
         assertEquals("dummy", pluginType.getName());
     }
 
     @Test
-    public void testParseTypeMaven()
-    {
+    public void testParseTypeMaven() {
         PluginType pluginType = testRuntime.getModelManager().readObjectWithConfigSerDe(
-            PluginType.class,
-            "{ \"name\": \"foo\", \"source\": \"maven\", \"group\": \"org.embulk.bar\", \"version\": \"0.1.2\" }");
+                PluginType.class,
+                "{ \"name\": \"foo\", \"source\": \"maven\", \"group\": \"org.embulk.bar\", \"version\": \"0.1.2\" }");
         assertTrue(pluginType instanceof MavenPluginType);
         assertEquals(PluginSource.Type.MAVEN, pluginType.getSourceType());
         MavenPluginType mavenPluginType = (MavenPluginType) pluginType;
@@ -51,11 +47,10 @@ public class TestPluginTypeSerDe
     }
 
     @Test
-    public void testParseTypeMavenWithClassifier()
-    {
+    public void testParseTypeMavenWithClassifier() {
         PluginType pluginType = testRuntime.getModelManager().readObjectWithConfigSerDe(
-            PluginType.class,
-            "{ \"name\": \"foo\", \"source\": \"maven\", \"group\": \"org.embulk.bar\", \"version\": \"0.1.2\", \"classifier\": \"foo\" }");
+                PluginType.class,
+                "{ \"name\": \"foo\", \"source\": \"maven\", \"group\": \"org.embulk.bar\", \"version\": \"0.1.2\", \"classifier\": \"foo\" }");
         assertTrue(pluginType instanceof MavenPluginType);
         assertEquals(PluginSource.Type.MAVEN, pluginType.getSourceType());
         MavenPluginType mavenPluginType = (MavenPluginType) pluginType;

--- a/embulk-core/src/test/java/org/embulk/plugin/jar/ExampleJarSpiV0.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/jar/ExampleJarSpiV0.java
@@ -1,9 +1,7 @@
 package org.embulk.plugin.jar;
 
-public class ExampleJarSpiV0
-{
-    public String getTestString()
-    {
+public class ExampleJarSpiV0 {
+    public String getTestString() {
         return "foobar";
     }
 }

--- a/embulk-core/src/test/java/org/embulk/plugin/jar/JarBuilder.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/jar/JarBuilder.java
@@ -10,17 +10,13 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
-public class JarBuilder
-{
-    public JarBuilder()
-    {
+public class JarBuilder {
+    public JarBuilder() {
         this.manifest = new Manifest();
         this.entries = new HashMap<String, Path>();
     }
 
-    public void build(final Path pathToExistingFile)
-            throws Exception
-    {
+    public void build(final Path pathToExistingFile) throws Exception {
         try (final JarOutputStream output = buildPluginJar(pathToExistingFile, this.manifest)) {
             for (String entryName : new TreeSet<String>(this.entries.keySet())) {
                 final Path pathToRealFile = this.entries.get(entryName);
@@ -31,8 +27,7 @@ public class JarBuilder
                     entry.setCrc(0);
                     output.putNextEntry(entry);
                     output.closeEntry();
-                }
-                else {
+                } else {
                     final JarEntry entry = new JarEntry(entryName);
                     output.putNextEntry(entry);
                     Files.copy(pathToRealFile, output);
@@ -42,9 +37,7 @@ public class JarBuilder
         }
     }
 
-    public void addClass(final Class<?> klass)
-            throws Exception
-    {
+    public void addClass(final Class<?> klass) throws Exception {
         final Path classFileRelativePath = getClassFileRelativePath(klass);
         final Path classFileFullPath = getClassFileFullPath(klass);
         this.addFile(classFileRelativePath.toString(), classFileFullPath);
@@ -56,40 +49,33 @@ public class JarBuilder
         }
     }
 
-    public void addManifestV0(final String embulkPluginMainClass)
-    {
+    public void addManifestV0(final String embulkPluginMainClass) {
         final Attributes attributes = this.manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
         attributes.putValue(MANIFEST_PLUGIN_SPI_VERSION, "0");
         attributes.putValue(MANIFEST_PLUGIN_MAIN_CLASS, embulkPluginMainClass);
     }
 
-    private void addDirectoryIfAbsent(final String name)
-    {
+    private void addDirectoryIfAbsent(final String name) {
         if (!(this.entries.containsKey(name))) {
             this.entries.put(name, null);
         }
     }
 
-    private void addFile(final String name, final Path pathToRealFile)
-    {
+    private void addFile(final String name, final Path pathToRealFile) {
         this.entries.put(name, pathToRealFile);
     }
 
     private JarOutputStream buildPluginJar(final Path pathToExistingFile, final Manifest embeddedManifest)
-            throws Exception
-    {
+            throws Exception {
         return new JarOutputStream(Files.newOutputStream(pathToExistingFile), embeddedManifest);
     }
 
-    private Path getClassFileRelativePath(final Class<?> klass)
-    {
+    private Path getClassFileRelativePath(final Class<?> klass) {
         return Paths.get(klass.getName().replace('.', '/') + ".class");
     }
 
-    private Path getClassFileFullPath(final Class<?> klass)
-            throws Exception
-    {
+    private Path getClassFileFullPath(final Class<?> klass) throws Exception {
         return Paths.get(klass.getClassLoader().getResource(klass.getName().replace('.', '/') + ".class").toURI());
     }
 

--- a/embulk-core/src/test/java/org/embulk/plugin/jar/TestJarPluginLoader.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/jar/TestJarPluginLoader.java
@@ -11,8 +11,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class TestJarPluginLoader
-{
+public class TestJarPluginLoader {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -20,8 +19,7 @@ public class TestJarPluginLoader
     public EmbulkTestRuntime testRuntime = new EmbulkTestRuntime();
 
     @Test
-    public void test() throws Exception
-    {
+    public void test() throws Exception {
         final Path jarPath = createTemporaryJarFile();
 
         final JarBuilder jarBuilder = new JarBuilder();
@@ -42,16 +40,14 @@ public class TestJarPluginLoader
         assertEquals("foobar", instance.getTestString());
     }
 
-    private Path createTemporaryJarFile() throws Exception
-    {
+    private Path createTemporaryJarFile() throws Exception {
         final String temporaryDirectoryString =
-            System.getProperty("org.embulk.plugin.jar.TestJarPluginLoader.temporaryDirectory");
+                System.getProperty("org.embulk.plugin.jar.TestJarPluginLoader.temporaryDirectory");
 
         final Path temporaryDirectoryPath;
         if (temporaryDirectoryString == null) {
             temporaryDirectoryPath = temporaryFolder.getRoot().toPath();
-        }
-        else {
+        } else {
             temporaryDirectoryPath = Paths.get(temporaryDirectoryString);
         }
 

--- a/embulk-core/src/test/java/org/embulk/plugin/maven/TestMavenArtifactFinder.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/maven/TestMavenArtifactFinder.java
@@ -1,35 +1,27 @@
 package org.embulk.plugin.maven;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
-import java.net.URL;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class TestMavenArtifactFinder
-{
+public class TestMavenArtifactFinder {
     @Test
-    public void testArtifacts() throws Exception
-    {
+    public void testArtifacts() throws Exception {
         final Path basePath = getMavenPath();
         final MavenArtifactFinder finder = MavenArtifactFinder.create(basePath);
         assertEquals(buildExpectedPath(basePath, GROUP_DIRECTORY, "embulk-example-maven-artifact", "0.1.2"),
                      finder.findMavenArtifactJar("org.embulk.example", "embulk-example-maven-artifact", null, "0.1.2"));
     }
 
-    private Path getMavenPath() throws URISyntaxException
-    {
+    private Path getMavenPath() throws URISyntaxException {
         return Paths.get(this.getClass().getClassLoader().getResource("m2.test").toURI());
     }
 
     private Path buildExpectedPath(
-            final Path basePath, final Path groupDirectory, final String artifactId, final String version)
-    {
+            final Path basePath, final Path groupDirectory, final String artifactId, final String version) {
         return basePath
             .resolve(groupDirectory)
             .resolve(artifactId)

--- a/embulk-core/src/test/java/org/embulk/spi/MockFileOutput.java
+++ b/embulk-core/src/test/java/org/embulk/spi/MockFileOutput.java
@@ -1,44 +1,36 @@
 package org.embulk.spi;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 
-public class MockFileOutput
-        implements FileOutput
-{
+public class MockFileOutput implements FileOutput {
     private List<List<Buffer>> files = new ArrayList<List<Buffer>>();
     private List<Buffer> lastBuffers = null;
     private boolean finished = false;
     private boolean closed = false;
 
-    public List<List<Buffer>> getFiles()
-    {
+    public List<List<Buffer>> getFiles() {
         return files;
     }
 
-    public List<Buffer> getLastBuffers()
-    {
+    public List<Buffer> getLastBuffers() {
         return lastBuffers;
     }
 
-    public void nextFile()
-    {
+    public void nextFile() {
         lastBuffers = new ArrayList<Buffer>();
         files.add(lastBuffers);
     }
 
-    public boolean isFinished()
-    {
+    public boolean isFinished() {
         return finished;
     }
 
-    public boolean isClosed()
-    {
+    public boolean isClosed() {
         return closed;
     }
 
-    public void add(Buffer buffer)
-    {
+    public void add(Buffer buffer) {
         if (lastBuffers == null) {
             throw new IllegalStateException("FileOutput.nextFile is not called");
         }
@@ -51,13 +43,11 @@ public class MockFileOutput
         lastBuffers.add(buffer);
     }
 
-    public void finish()
-    {
+    public void finish() {
         finished = true;
     }
 
-    public void close()
-    {
+    public void close() {
         closed = true;
     }
 }

--- a/embulk-core/src/test/java/org/embulk/spi/MockFormatterPlugin.java
+++ b/embulk-core/src/test/java/org/embulk/spi/MockFormatterPlugin.java
@@ -2,104 +2,81 @@ package org.embulk.spi;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
-import org.embulk.spi.Column;
-import org.embulk.spi.Schema;
-import org.embulk.spi.ColumnVisitor;
 
-public class MockFormatterPlugin implements FormatterPlugin
-{
+public class MockFormatterPlugin implements FormatterPlugin {
     public static List<List<Object>> records;
 
-    public interface PluginTask extends Task
-    {
-    }
+    public interface PluginTask extends Task {}
 
     @Override
     public void transaction(ConfigSource config, Schema schema,
-            FormatterPlugin.Control control)
-    {
+            FormatterPlugin.Control control) {
         PluginTask task = config.loadConfig(PluginTask.class);
         control.run(task.dump());
     }
 
     @Override
     public PageOutput open(TaskSource taskSource, final Schema schema,
-            FileOutput output)
-    {
-        return new PageOutput()
-        {
-            public void add(Page page)
-            {
+            FileOutput output) {
+        return new PageOutput() {
+            public void add(Page page) {
                 records = readPage(schema, page);
             }
 
             @Override
-            public void finish()
-            {
-            }
+            public void finish() {}
 
             @Override
-            public void close()
-            {
-            }
+            public void close() {}
         };
     }
 
-    public static List<List<Object>> readPage(final Schema schema, Page page)
-    {
+    public static List<List<Object>> readPage(final Schema schema, Page page) {
         List<List<Object>> records = new ArrayList<>();
         try (final PageReader pageReader = new PageReader(schema)) {
             pageReader.setPage(page);
             while (pageReader.nextRecord()) {
                 final List<Object> record = new ArrayList<>();
-                schema.visitColumns(new ColumnVisitor()
-                {
-                    public void booleanColumn(Column column)
-                    {
-                        if (!pageReader.isNull(column)) {
-                            record.add(pageReader.getBoolean(column));
+                schema.visitColumns(new ColumnVisitor() {
+                        public void booleanColumn(Column column) {
+                            if (!pageReader.isNull(column)) {
+                                record.add(pageReader.getBoolean(column));
+                            }
                         }
-                    }
 
-                    public void longColumn(Column column)
-                    {
-                        if (!pageReader.isNull(column)) {
-                            record.add(pageReader.getLong(column));
+                        public void longColumn(Column column) {
+                            if (!pageReader.isNull(column)) {
+                                record.add(pageReader.getLong(column));
+                            }
                         }
-                    }
 
-                    public void doubleColumn(Column column)
-                    {
-                        if (!pageReader.isNull(column)) {
-                            record.add(pageReader.getDouble(column));
+                        public void doubleColumn(Column column) {
+                            if (!pageReader.isNull(column)) {
+                                record.add(pageReader.getDouble(column));
+                            }
                         }
-                    }
 
-                    public void stringColumn(Column column)
-                    {
-                        if (!pageReader.isNull(column)) {
-                            record.add(pageReader.getString(column));
+                        public void stringColumn(Column column) {
+                            if (!pageReader.isNull(column)) {
+                                record.add(pageReader.getString(column));
+                            }
                         }
-                    }
 
-                    public void timestampColumn(Column column)
-                    {
-                        if (!pageReader.isNull(column)) {
-                            record.add(pageReader.getTimestamp(column));
+                        public void timestampColumn(Column column) {
+                            if (!pageReader.isNull(column)) {
+                                record.add(pageReader.getTimestamp(column));
+                            }
                         }
-                    }
 
-                    public void jsonColumn(Column column)
-                    {
-                        if (!pageReader.isNull(column)) {
-                            record.add(pageReader.getJson(column));
+                        public void jsonColumn(Column column) {
+                            if (!pageReader.isNull(column)) {
+                                record.add(pageReader.getJson(column));
+                            }
                         }
-                    }
-                });
+                    });
                 records.add(record);
             }
         }

--- a/embulk-core/src/test/java/org/embulk/spi/MockParserPlugin.java
+++ b/embulk-core/src/test/java/org/embulk/spi/MockParserPlugin.java
@@ -7,32 +7,24 @@ import org.embulk.config.TaskSource;
 import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.type.Type;
-import org.embulk.spi.Column;
-import org.embulk.spi.Schema;
-import org.embulk.spi.SchemaConfig;
-import org.embulk.spi.PageOutput;
 
-public class MockParserPlugin implements ParserPlugin
-{
+public class MockParserPlugin implements ParserPlugin {
     public static boolean raiseException = false;
 
-    public interface PluginTask extends Task
-    {
+    public interface PluginTask extends Task {
         @Config("columns")
         public SchemaConfig getSchemaConfig();
     }
 
     @Override
-    public void transaction(ConfigSource config, Control control)
-    {
+    public void transaction(ConfigSource config, Control control) {
         PluginTask task = config.loadConfig(PluginTask.class);
         control.run(task.dump(), task.getSchemaConfig().toSchema());
     }
 
     @Override
     public void run(TaskSource taskSource, Schema schema,
-            FileInput input, PageOutput output)
-    {
+            FileInput input, PageOutput output) {
         try (final PageBuilder pageBuilder = new PageBuilder(
                 Exec.getBufferAllocator(), schema, output)) {
             while (input.nextFile()) {
@@ -41,31 +33,29 @@ public class MockParserPlugin implements ParserPlugin
                     for (Column column : schema.getColumns()) {
                         Type type = column.getType();
                         switch (type.getName()) {
-                        case "boolean":
-                            pageBuilder.setBoolean(column, true);
-                            break;
-                        case "long":
-                            pageBuilder.setLong(column, 2L);
-                            break;
-                        case "double":
-                            pageBuilder.setDouble(column, 3.0D);
-                            break;
-                        case "string":
-                            pageBuilder.setString(column, "45");
-                            break;
-                        case "timestamp":
-                            pageBuilder.setTimestamp(column,
-                                    Timestamp.ofEpochMilli(678L));
-                            break;
-                        case "json":
-                            pageBuilder.setJson(
-                                column,
-                                new JsonParser().parse("{\"_c1\":true,\"_c2\":10,\"_c3\":\"embulk\",\"_c4\":{\"k\":\"v\"}}")
-                            );
-                            break;
-                        default:
-                            throw new IllegalStateException("Unknown type: "
-                                    + type.getName());
+                            case "boolean":
+                                pageBuilder.setBoolean(column, true);
+                                break;
+                            case "long":
+                                pageBuilder.setLong(column, 2L);
+                                break;
+                            case "double":
+                                pageBuilder.setDouble(column, 3.0D);
+                                break;
+                            case "string":
+                                pageBuilder.setString(column, "45");
+                                break;
+                            case "timestamp":
+                                pageBuilder.setTimestamp(column, Timestamp.ofEpochMilli(678L));
+                                break;
+                            case "json":
+                                pageBuilder.setJson(
+                                        column,
+                                        new JsonParser().parse("{\"_c1\":true,\"_c2\":10,\"_c3\":\"embulk\",\"_c4\":{\"k\":\"v\"}}")
+                                );
+                                break;
+                            default:
+                                throw new IllegalStateException("Unknown type: " + type.getName());
                         }
                     }
                     pageBuilder.addRecord();

--- a/embulk-core/src/test/java/org/embulk/spi/PageTestUtils.java
+++ b/embulk-core/src/test/java/org/embulk/spi/PageTestUtils.java
@@ -1,27 +1,15 @@
 package org.embulk.spi;
 
-import java.util.ArrayList;
 import java.util.List;
-
 import org.embulk.spi.TestPageBuilderReader.MockPageOutput;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.Column;
-import org.embulk.spi.ColumnConfig;
-import org.embulk.spi.Schema;
-import org.embulk.spi.SchemaConfig;
-import org.embulk.spi.ColumnVisitor;
-import org.embulk.spi.type.Type;
 import org.msgpack.value.Value;
-import com.google.common.collect.ImmutableList;
 
-public class PageTestUtils
-{
-    private PageTestUtils()
-    { }
+public class PageTestUtils {
+    private PageTestUtils() {}
 
     public static List<Page> buildPage(BufferAllocator bufferAllocator,
-            Schema schema, Object... values)
-    {
+            Schema schema, Object... values) {
         MockPageOutput output = new MockPageOutput();
         try (PageBuilder builder = new PageBuilder(bufferAllocator, schema,
                 output)) {

--- a/embulk-core/src/test/java/org/embulk/spi/TestBuffer.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestBuffer.java
@@ -1,15 +1,13 @@
 package org.embulk.spi;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 
-public class TestBuffer
-{
+public class TestBuffer {
     @Test
-    public void testEquals() throws Exception
-    {
+    public void testEquals() throws Exception {
         byte[] bytes = new byte[] { 1, 2, 3, 2, 3 };
         Buffer b1 = Buffer.wrap(bytes, 0, 2);  // [1, 2]
         Buffer b2 = Buffer.wrap(bytes, 1, 2);  // [2, 3]

--- a/embulk-core/src/test/java/org/embulk/spi/TestFileInputInputStream.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestFileInputInputStream.java
@@ -2,17 +2,17 @@ package org.embulk.spi;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+
 import java.io.ByteArrayOutputStream;
 import java.util.Random;
-import org.junit.Rule;
-import org.junit.Test;
-import org.embulk.spi.util.ListFileInput;
+import org.embulk.EmbulkTestRuntime;
 import org.embulk.spi.util.FileInputInputStream;
 import org.embulk.spi.util.FileOutputOutputStream;
-import org.embulk.EmbulkTestRuntime;
+import org.embulk.spi.util.ListFileInput;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class TestFileInputInputStream
-{
+public class TestFileInputInputStream {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
@@ -22,21 +22,18 @@ public class TestFileInputInputStream
     private FileInputInputStream in;
     private FileOutputOutputStream out;
 
-    private void newOutputStream()
-    {
+    private void newOutputStream() {
         fileOutput = new MockFileOutput();
         out = new FileOutputOutputStream(fileOutput, runtime.getBufferAllocator(), FileOutputOutputStream.CloseMode.CLOSE);
     }
 
-    private void newInputStream()
-    {
+    private void newInputStream() {
         fileInput = new ListFileInput(fileOutput.getFiles());
         in = new FileInputInputStream(fileInput);
     }
 
     @Test
-    public void testRandomReadWrite() throws Exception
-    {
+    public void testRandomReadWrite() throws Exception {
         newOutputStream();
         out.nextFile();
         ByteArrayOutputStream expectedOut = new ByteArrayOutputStream();
@@ -83,7 +80,6 @@ public class TestFileInputInputStream
         }
 
         @Override
-        public void close() {
-        }
+        public void close() {}
     }
 }

--- a/embulk-core/src/test/java/org/embulk/spi/TestFileOutputRunner.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestFileOutputRunner.java
@@ -1,46 +1,38 @@
 package org.embulk.spi;
 
 import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.embulk.EmbulkTestRuntime;
-import org.embulk.config.TaskReport;
-import org.embulk.config.ConfigSource;
-import org.embulk.config.ConfigDiff;
-import org.embulk.config.Task;
-import org.embulk.config.TaskSource;
-import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.Schema;
-import org.junit.Rule;
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import org.msgpack.value.ImmutableMapValue;
 import static org.msgpack.value.ValueFactory.newBoolean;
 import static org.msgpack.value.ValueFactory.newInteger;
 import static org.msgpack.value.ValueFactory.newMap;
 import static org.msgpack.value.ValueFactory.newString;
 
-public class TestFileOutputRunner
-{
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.List;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.Task;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.time.Timestamp;
+import org.junit.Rule;
+import org.junit.Test;
+import org.msgpack.value.ImmutableMapValue;
+
+public class TestFileOutputRunner {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
-    public interface PluginTask extends Task
-    {
-    }
+    public interface PluginTask extends Task {}
 
-    private static class MockFileOutputPlugin implements FileOutputPlugin
-    {
+    private static class MockFileOutputPlugin implements FileOutputPlugin {
         Boolean transactionCompleted = null;
 
         @Override
         public ConfigDiff transaction(ConfigSource config, int taskCount,
-                FileOutputPlugin.Control control)
-        {
+                FileOutputPlugin.Control control) {
             PluginTask task = config.loadConfig(PluginTask.class);
             control.run(task.dump());
             return Exec.newConfigDiff();
@@ -49,54 +41,39 @@ public class TestFileOutputRunner
         @Override
         public ConfigDiff resume(TaskSource taskSource,
                 int taskCount,
-                FileOutputPlugin.Control control)
-        {
+                FileOutputPlugin.Control control) {
             throw new UnsupportedOperationException();
         }
 
         @Override
         public void cleanup(TaskSource taskSource,
                 int taskCount,
-                List<TaskReport> successTaskReports)
-        {
-        }
+                List<TaskReport> successTaskReports) {}
 
         @Override
         public TransactionalFileOutput open(TaskSource taskSource,
-                final int taskIndex)
-        {
-            return new TransactionalFileOutput()
-            {
+                final int taskIndex) {
+            return new TransactionalFileOutput() {
 
                 @Override
-                public void nextFile()
-                {
-                }
+                public void nextFile() {}
 
                 @Override
-                public void add(Buffer buffer)
-                {
-                }
+                public void add(Buffer buffer) {}
 
                 @Override
-                public void finish()
-                {
-                }
+                public void finish() {}
 
                 @Override
-                public void close()
-                {
-                }
+                public void close() {}
 
                 @Override
-                public void abort()
-                {
+                public void abort() {
                     transactionCompleted = false;
                 }
 
                 @Override
-                public TaskReport commit()
-                {
+                public TaskReport commit() {
                     transactionCompleted = true;
                     return Exec.newTaskReport();
                 }
@@ -105,8 +82,7 @@ public class TestFileOutputRunner
     }
 
     @Test
-    public void testMockFormatterIteration()
-    {
+    public void testMockFormatterIteration() {
         MockFileOutputPlugin fileOutputPlugin = new MockFileOutputPlugin();
         final FileOutputRunner runner = new FileOutputRunner(fileOutputPlugin);
 
@@ -126,10 +102,8 @@ public class TestFileOutputRunner
                 .loadConfig(MockParserPlugin.PluginTask.class)
                 .getSchemaConfig().toSchema();
 
-        runner.transaction(config, schema, 1, new OutputPlugin.Control()
-        {
-            public List<TaskReport> run(final TaskSource outputTask)
-            {
+        runner.transaction(config, schema, 1, new OutputPlugin.Control() {
+            public List<TaskReport> run(final TaskSource outputTask) {
                 TransactionalPageOutput tran = runner.open(outputTask, schema,
                         1);
                 boolean committed = false;
@@ -171,8 +145,7 @@ public class TestFileOutputRunner
     }
 
     @Test
-    public void testTransactionAborted()
-    {
+    public void testTransactionAborted() {
         MockFileOutputPlugin fileOutputPlugin = new MockFileOutputPlugin();
         final FileOutputRunner runner = new FileOutputRunner(fileOutputPlugin);
 
@@ -193,10 +166,8 @@ public class TestFileOutputRunner
                 .getSchemaConfig().toSchema();
 
         try {
-            runner.transaction(config, schema, 1, new OutputPlugin.Control()
-            {
-                public List<TaskReport> run(final TaskSource outputTask)
-                {
+            runner.transaction(config, schema, 1, new OutputPlugin.Control() {
+                public List<TaskReport> run(final TaskSource outputTask) {
                     TransactionalPageOutput tran = runner.open(outputTask,
                             schema, 1);
                     boolean committed = false;
@@ -214,6 +185,7 @@ public class TestFileOutputRunner
                 }
             });
         } catch (NullPointerException npe) {
+            // Just passing through.
         }
 
         assertEquals(false, fileOutputPlugin.transactionCompleted);

--- a/embulk-core/src/test/java/org/embulk/spi/TestInputStreamFileInput.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestInputStreamFileInput.java
@@ -2,23 +2,22 @@ package org.embulk.spi;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import org.junit.Rule;
-import org.junit.Test;
-import com.google.common.collect.ImmutableList;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.spi.util.InputStreamFileInput;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class TestInputStreamFileInput
-{
+public class TestInputStreamFileInput {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
     @Test
-    public void testSingleProvider() throws IOException
-    {
+    public void testSingleProvider() throws IOException {
         InputStreamFileInput subject = new InputStreamFileInput(
                 runtime.getBufferAllocator(),
                 provider(new ByteArrayInputStream("abcdef".getBytes("UTF-8"))));
@@ -29,8 +28,7 @@ public class TestInputStreamFileInput
     }
 
     @Test
-    public void testMultipleProvider() throws IOException
-    {
+    public void testMultipleProvider() throws IOException {
         InputStreamFileInput subject = new InputStreamFileInput(
                 runtime.getBufferAllocator(), provider(
                         new ByteArrayInputStream("abcdef".getBytes("UTF-8")),
@@ -46,8 +44,7 @@ public class TestInputStreamFileInput
     }
 
     @Test
-    public void testEmptyStream() throws IOException
-    {
+    public void testEmptyStream() throws IOException {
         InputStreamFileInput subject = new InputStreamFileInput(
                 runtime.getBufferAllocator(),
                 provider(new ByteArrayInputStream(new byte[0])));
@@ -57,8 +54,7 @@ public class TestInputStreamFileInput
     }
 
     @Test
-    public void testPollFirstException() throws IOException
-    {
+    public void testPollFirstException() throws IOException {
         InputStreamFileInput subject = new InputStreamFileInput(
                 runtime.getBufferAllocator(),
                 provider(new ByteArrayInputStream("abcdef".getBytes("UTF-8"))));
@@ -72,8 +68,7 @@ public class TestInputStreamFileInput
     }
 
     @Test
-    public void testEmptyProvider() throws IOException
-    {
+    public void testEmptyProvider() throws IOException {
         InputStreamFileInput subject = new InputStreamFileInput(
                 runtime.getBufferAllocator(), provider(new InputStream[0]));
         assertEquals(false, subject.nextFile());
@@ -81,21 +76,17 @@ public class TestInputStreamFileInput
     }
 
     @Test
-    public void testProviderOpenNextException()
-    {
+    public void testProviderOpenNextException() {
         InputStreamFileInput subject = new InputStreamFileInput(
                 runtime.getBufferAllocator(),
-                new InputStreamFileInput.Provider()
-                {
+                new InputStreamFileInput.Provider() {
                     @Override
-                    public InputStream openNext() throws IOException
-                    {
+                    public InputStream openNext() throws IOException {
                         throw new IOException("emulated exception");
                     }
 
                     @Override
-                    public void close() throws IOException
-                    {
+                    public void close() throws IOException {
                     }
                 });
 
@@ -109,21 +100,17 @@ public class TestInputStreamFileInput
     }
 
     @Test
-    public void testProviderCloseException()
-    {
+    public void testProviderCloseException() {
         InputStreamFileInput subject = new InputStreamFileInput(
                 runtime.getBufferAllocator(),
-                new InputStreamFileInput.Provider()
-                {
+                new InputStreamFileInput.Provider() {
                     @Override
-                    public InputStream openNext() throws IOException
-                    {
+                    public InputStream openNext() throws IOException {
                         return new ByteArrayInputStream(new byte[0]);
                     }
 
                     @Override
-                    public void close() throws IOException
-                    {
+                    public void close() throws IOException {
                         throw new IOException("emulated exception");
                     }
                 });
@@ -137,28 +124,22 @@ public class TestInputStreamFileInput
     }
 
     @Test
-    public void testInputStreamReadException()
-    {
+    public void testInputStreamReadException() {
         InputStreamFileInput subject = new InputStreamFileInput(
                 runtime.getBufferAllocator(),
-                new InputStreamFileInput.Provider()
-                {
+                new InputStreamFileInput.Provider() {
                     @Override
-                    public InputStream openNext() throws IOException
-                    {
-                        return new InputStream()
-                        {
+                    public InputStream openNext() throws IOException {
+                        return new InputStream() {
                             @Override
-                            public int read() throws IOException
-                            {
+                            public int read() throws IOException {
                                 throw new IOException("emulated exception");
                             }
                         };
                     }
 
                     @Override
-                    public void close() throws IOException
-                    {
+                    public void close() throws IOException {
                     }
                 });
 
@@ -173,14 +154,12 @@ public class TestInputStreamFileInput
     }
 
     private InputStreamFileInput.IteratorProvider provider(
-            InputStream... inputStreams) throws IOException
-    {
+            InputStream... inputStreams) throws IOException {
         return new InputStreamFileInput.IteratorProvider(
                 ImmutableList.copyOf(inputStreams));
     }
 
-    private String bufferToString(Buffer buffer) throws IOException
-    {
+    private String bufferToString(Buffer buffer) throws IOException {
         byte[] buf = new byte[buffer.limit()];
         buffer.getBytes(0, buf, 0, buffer.limit());
         return new String(buf, "UTF-8");

--- a/embulk-core/src/test/java/org/embulk/spi/TestPageBuilderReader.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestPageBuilderReader.java
@@ -9,52 +9,43 @@ import static org.embulk.spi.type.Types.TIMESTAMP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import org.msgpack.value.ImmutableMapValue;
 import static org.msgpack.value.ValueFactory.newBoolean;
 import static org.msgpack.value.ValueFactory.newInteger;
 import static org.msgpack.value.ValueFactory.newMap;
 import static org.msgpack.value.ValueFactory.newString;
+
 import java.util.ArrayList;
 import java.util.List;
-import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.Schema;
 import org.embulk.EmbulkTestRuntime;
-import org.msgpack.value.ImmutableMapValue;
-import org.msgpack.value.Value;
+import org.embulk.spi.time.Timestamp;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.msgpack.value.ImmutableMapValue;
+import org.msgpack.value.Value;
 
-public class TestPageBuilderReader
-{
+public class TestPageBuilderReader {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
-    public static class MockPageOutput implements PageOutput
-    {
+    public static class MockPageOutput implements PageOutput {
         public List<Page> pages;
 
-        public MockPageOutput()
-        {
+        public MockPageOutput() {
             this.pages = new ArrayList<>();
         }
 
         @Override
-        public void add(Page page)
-        {
+        public void add(Page page) {
             pages.add(page);
         }
 
         @Override
-        public void finish()
-        {
-        }
+        public void finish() {}
 
         @Override
-        public void close()
-        {
-        }
+        public void close() {}
     }
 
     private BufferAllocator bufferAllocator;
@@ -62,14 +53,12 @@ public class TestPageBuilderReader
     private PageBuilder builder;
 
     @Before
-    public void setup()
-    {
+    public void setup() {
         this.bufferAllocator = runtime.getBufferAllocator();
     }
 
     @After
-    public void destroy()
-    {
+    public void destroy() {
         if (reader != null) {
             reader.close();
             reader = null;
@@ -81,43 +70,37 @@ public class TestPageBuilderReader
     }
 
     @Test
-    public void testBoolean()
-    {
+    public void testBoolean() {
         check(Schema.builder().add("col1", BOOLEAN).build(),
                 false, true, true);
     }
 
     @Test
-    public void testLong()
-    {
+    public void testLong() {
         check(Schema.builder().add("col1", LONG).build(),
                 1L, Long.MIN_VALUE, Long.MAX_VALUE);
     }
 
     @Test
-    public void testDouble()
-    {
+    public void testDouble() {
         check(Schema.builder().add("col1", DOUBLE).build(),
                 8.1, 3.141592, 4.3);
     }
 
     @Test
-    public void testUniqueStrings()
-    {
+    public void testUniqueStrings() {
         check(Schema.builder().add("col1", STRING).build(),
                 "test1", "test2", "test0");
     }
 
     @Test
-    public void testDuplicateStrings()
-    {
+    public void testDuplicateStrings() {
         check(Schema.builder().add("col1", STRING).build(),
-            "test1", "test1", "test1");
+                "test1", "test1", "test1");
     }
 
     @Test
-    public void testDuplicateStringsMultiColumns()
-    {
+    public void testDuplicateStringsMultiColumns() {
         check(Schema.builder().add("col1", STRING).add("col1", STRING).build(),
                 "test2", "test1",
                 "test1", "test2",
@@ -126,21 +109,18 @@ public class TestPageBuilderReader
     }
 
     @Test
-    public void testTimestamp()
-    {
+    public void testTimestamp() {
         check(Schema.builder().add("col1", TIMESTAMP).build(),
                 Timestamp.ofEpochMilli(0), Timestamp.ofEpochMilli(10));
     }
 
     @Test
-    public void testJson()
-    {
+    public void testJson() {
         check(Schema.builder().add("col1", JSON).build(), getJsonSampleData());
     }
 
     @Test
-    public void testNull()
-    {
+    public void testNull() {
         check(Schema.builder()
                     .add("col3", DOUBLE)
                     .add("col1", STRING)
@@ -154,8 +134,7 @@ public class TestPageBuilderReader
     }
 
     @Test
-    public void testMixedTypes()
-    {
+    public void testMixedTypes() {
         check(Schema.builder()
                     .add("col3", DOUBLE)
                     .add("col1", STRING)
@@ -168,21 +147,18 @@ public class TestPageBuilderReader
                 140.15, "val2", Long.MAX_VALUE, true, Timestamp.ofEpochMilli(10), getJsonSampleData());
     }
 
-    private void check(Schema schema, Object... objects)
-    {
+    private void check(Schema schema, Object... objects) {
         Page page = buildPage(schema, objects);
         checkPage(schema, page, objects);
     }
 
-    private Page buildPage(Schema schema, final Object... objects)
-    {
+    private Page buildPage(Schema schema, final Object... objects) {
         List<Page> pages = buildPages(schema, objects);
         assertEquals(1, pages.size());
         return pages.get(0);
     }
 
-    private List<Page> buildPages(Schema schema, final Object... objects)
-    {
+    private List<Page> buildPages(Schema schema, final Object... objects) {
         MockPageOutput output = new MockPageOutput();
         this.builder = new PageBuilder(bufferAllocator, schema, output);
         int idx = 0;
@@ -216,8 +192,7 @@ public class TestPageBuilderReader
         return output.pages;
     }
 
-    private void checkPage(Schema schema, Page page, final Object... objects)
-    {
+    private void checkPage(Schema schema, Page page, final Object... objects) {
         this.reader = new PageReader(schema);
         reader.setPage(page);
         int idx = 0;
@@ -247,8 +222,7 @@ public class TestPageBuilderReader
         }
     }
 
-    private ImmutableMapValue getJsonSampleData()
-    {
+    private ImmutableMapValue getJsonSampleData() {
         return newMap(
                 newString("_c1"), newBoolean(true),
                 newString("_c2"), newInteger(10),
@@ -258,8 +232,7 @@ public class TestPageBuilderReader
     }
 
     @Test
-    public void testEmptySchema()
-    {
+    public void testEmptySchema() {
         MockPageOutput output = new MockPageOutput();
         this.builder = new PageBuilder(bufferAllocator, Schema.builder().build(), output);
         builder.addRecord();
@@ -275,42 +248,34 @@ public class TestPageBuilderReader
     }
 
     @Test
-    public void testRenewPage()
-    {
-        this.bufferAllocator = new BufferAllocator()
-        {
+    public void testRenewPage() {
+        this.bufferAllocator = new BufferAllocator() {
             @Override
-            public Buffer allocate()
-            {
+            public Buffer allocate() {
                 return Buffer.allocate(1);
             }
 
             @Override
-            public Buffer allocate(int minimumCapacity)
-            {
+            public Buffer allocate(int minimumCapacity) {
                 return Buffer.allocate(minimumCapacity);
             }
         };
         assertEquals(
                 9,
                 buildPages(Schema.builder().add("col1", LONG).build(),
-                    0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L).size());
+                        0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L).size());
     }
 
     @Test
-    public void testRenewPageWithStrings()
-    {
-        this.bufferAllocator = new BufferAllocator()
-        {
+    public void testRenewPageWithStrings() {
+        this.bufferAllocator = new BufferAllocator() {
             @Override
-            public Buffer allocate()
-            {
+            public Buffer allocate() {
                 return Buffer.allocate(1);
             }
 
             @Override
-            public Buffer allocate(int minimumCapacity)
-            {
+            public Buffer allocate(int minimumCapacity) {
                 return Buffer.allocate(minimumCapacity);
             }
         };
@@ -328,8 +293,7 @@ public class TestPageBuilderReader
     }
 
     @Test
-    public void testDoubleWriteStringsToRow()
-    {
+    public void testDoubleWriteStringsToRow() {
         MockPageOutput output = new MockPageOutput();
         Schema schema = Schema.builder()
                 .add("col0", STRING)
@@ -359,8 +323,7 @@ public class TestPageBuilderReader
     }
 
     @Test
-    public void testDoubleWriteJsonsToRow()
-    {
+    public void testDoubleWriteJsonsToRow() {
         MockPageOutput output = new MockPageOutput();
         Schema schema = Schema.builder()
                 .add("col0", JSON)
@@ -390,8 +353,7 @@ public class TestPageBuilderReader
     }
 
     @Test
-    public void testRepeatableClose()
-    {
+    public void testRepeatableClose() {
         MockPageOutput output = new MockPageOutput();
         this.builder = new PageBuilder(bufferAllocator,
                 Schema.builder().add("col1", STRING).build(), output);
@@ -400,8 +362,7 @@ public class TestPageBuilderReader
     }
 
     @Test
-    public void testRepeatableFlush()
-    {
+    public void testRepeatableFlush() {
         MockPageOutput output = new MockPageOutput();
         this.builder = new PageBuilder(bufferAllocator,
                 Schema.builder().add("col1", STRING).build(), output);

--- a/embulk-core/src/test/java/org/embulk/spi/json/TestJsonParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/json/TestJsonParser.java
@@ -1,19 +1,15 @@
 package org.embulk.spi.json;
 
-import org.junit.Test;
-import org.msgpack.value.Value;
-import org.msgpack.value.ValueType;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-public class TestJsonParser
-{
+import org.junit.Test;
+import org.msgpack.value.Value;
+
+public class TestJsonParser {
     @Test
-    public void testString() throws Exception
-    {
+    public void testString() throws Exception {
         final JsonParser parser = new JsonParser();
         final Value msgpackValue = parser.parse("\"foobar\"");
         assertFalse(msgpackValue.getValueType().isNumberType());
@@ -22,15 +18,13 @@ public class TestJsonParser
     }
 
     @Test(expected = JsonParseException.class)
-    public void testStringUnquoted() throws Exception
-    {
+    public void testStringUnquoted() throws Exception {
         final JsonParser parser = new JsonParser();
         parser.parse("foobar");
     }
 
     @Test
-    public void testOrdinaryInteger() throws Exception
-    {
+    public void testOrdinaryInteger() throws Exception {
         final JsonParser parser = new JsonParser();
         final Value msgpackValue = parser.parse("12345");
         assertTrue(msgpackValue.getValueType().isNumberType());
@@ -41,8 +35,7 @@ public class TestJsonParser
     }
 
     @Test
-    public void testExponentialInteger1() throws Exception
-    {
+    public void testExponentialInteger1() throws Exception {
         final JsonParser parser = new JsonParser();
         final Value msgpackValue = parser.parse("12345e3");
         assertTrue(msgpackValue.getValueType().isNumberType());
@@ -57,8 +50,7 @@ public class TestJsonParser
     }
 
     @Test
-    public void testExponentialInteger2() throws Exception
-    {
+    public void testExponentialInteger2() throws Exception {
         final JsonParser parser = new JsonParser();
         final Value msgpackValue = parser.parse("123e2");
         assertTrue(msgpackValue.getValueType().isNumberType());
@@ -73,8 +65,7 @@ public class TestJsonParser
     }
 
     @Test
-    public void testOrdinaryFloat() throws Exception
-    {
+    public void testOrdinaryFloat() throws Exception {
         final JsonParser parser = new JsonParser();
         final Value msgpackValue = parser.parse("12345.12");
         assertTrue(msgpackValue.getValueType().isNumberType());
@@ -87,8 +78,7 @@ public class TestJsonParser
     }
 
     @Test
-    public void testExponentialFloat() throws Exception
-    {
+    public void testExponentialFloat() throws Exception {
         final JsonParser parser = new JsonParser();
         final Value msgpackValue = parser.parse("1.234512E4");
         assertTrue(msgpackValue.getValueType().isNumberType());

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestRubyTimeFormat.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestRubyTimeFormat.java
@@ -352,19 +352,16 @@ public class TestRubyTimeFormat {
         final List<RubyTimeFormatToken> expectedTokens = new ArrayList<>();
         for (final Object expectedElement : expectedTokensInArray) {
             if (expectedElement instanceof RubyTimeFormatToken) {
-                expectedTokens.add((RubyTimeFormatToken)expectedElement);
-            }
-            else if (expectedElement instanceof List) {
-                for (final Object expectedElement2 : (List)expectedElement) {
+                expectedTokens.add((RubyTimeFormatToken) expectedElement);
+            } else if (expectedElement instanceof List) {
+                for (final Object expectedElement2 : (List) expectedElement) {
                     if (expectedElement2 instanceof RubyTimeFormatToken) {
-                        expectedTokens.add((RubyTimeFormatToken)expectedElement2);
-                    }
-                    else {
+                        expectedTokens.add((RubyTimeFormatToken) expectedElement2);
+                    } else {
                         fail();
                     }
                 }
-            }
-            else {
+            } else {
                 fail();
             }
         }

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimeZoneIds.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimeZoneIds.java
@@ -2,15 +2,12 @@ package org.embulk.spi.time;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.TreeSet;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestTimeZoneIds
-{
+public class TestTimeZoneIds {
     @Test
-    public void testParseZoneIdWithJodaAndRubyZoneTab()
-    {
+    public void testParseZoneIdWithJodaAndRubyZoneTab() {
         // TODO: Test more practical equality. (Such as "GMT" v.s. "UTC")
         Assert.assertEquals(ZoneOffset.UTC, TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("Z"));
         Assert.assertEquals(ZoneId.of("Asia/Tokyo"), TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("Asia/Tokyo"));

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestamp.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestamp.java
@@ -6,72 +6,62 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-public class TestTimestamp
-{
+public class TestTimestamp {
     @Test
-    public void testEqualsToTimestamp()
-    {
+    public void testEqualsToTimestamp() {
         assertEqualsMethods(Timestamp.ofEpochSecond(0), Timestamp.ofEpochSecond(0));
         assertEqualsMethods(Timestamp.ofEpochSecond(10), Timestamp.ofEpochSecond(10));
         assertEqualsMethods(Timestamp.ofEpochSecond(10, 2), Timestamp.ofEpochSecond(10, 2));
     }
 
-    private void assertEqualsMethods(Timestamp t1, Timestamp t2)
-    {
+    private void assertEqualsMethods(Timestamp t1, Timestamp t2) {
         assertEquals(t1, t2);
         assertEquals(t1.hashCode(), t2.hashCode());
         assertEquals(0, t1.compareTo(t2));
     }
 
     @Test
-    public void testNotEqualsToTimestamp()
-    {
+    public void testNotEqualsToTimestamp() {
         assertFalse(Timestamp.ofEpochSecond(0).equals(Timestamp.ofEpochSecond(1)));
         assertFalse(Timestamp.ofEpochSecond(10).equals(Timestamp.ofEpochSecond(10, 2)));
         assertFalse(Timestamp.ofEpochSecond(10, 2).equals(Timestamp.ofEpochSecond(20, 2)));
     }
 
     @Test
-    public void testEqualsToNull()
-    {
+    public void testEqualsToNull() {
         assertFalse(Timestamp.ofEpochSecond(0).equals(null));
         assertFalse(Timestamp.ofEpochSecond(1, 2).equals(null));
     }
 
     @Test
-    public void testEqualsOtherClass()
-    {
+    public void testEqualsOtherClass() {
         assertFalse(Timestamp.ofEpochSecond(0).equals(new Object()));
         assertFalse(Timestamp.ofEpochSecond(1, 2).equals("other"));
     }
 
     @Test
-    public void testAdjustMillisToNanos()
-    {
+    public void testAdjustMillisToNanos() {
         Timestamp t = Timestamp.ofEpochMilli(3);  // 3 msec = 3_000 usec == 3_000_000 nsec
         assertEquals(0L, t.getEpochSecond());
         assertEquals(3_000_000, t.getNano());
     }
 
     @Test
-    public void testAdjustMillisToSeconds()
-    {
+    public void testAdjustMillisToSeconds() {
         Timestamp t = Timestamp.ofEpochMilli(3_000);  // 3_000 msec = 3 sec
         assertEquals(3L, t.getEpochSecond());
         assertEquals(0, t.getNano());
     }
 
     @Test
-    public void testAdjustNano()
-    {
+    public void testAdjustNano() {
         Timestamp t = Timestamp.ofEpochSecond(0, 1_000_000_000);  // 1_000_000_000 nsec = 1_000_000 usec = 1_000 msec = 1 sec
         assertEquals(1L, t.getEpochSecond());
         assertEquals(0, t.getNano());
     }
 
     @Test
-    public void testCompareTo()
-    {
+    public void testCompareTo() {
         assertTrue(Timestamp.ofEpochSecond(3).compareTo(Timestamp.ofEpochSecond(4)) < 0);
         assertTrue(Timestamp.ofEpochSecond(3).compareTo(Timestamp.ofEpochSecond(3, 4)) < 0);
         assertTrue(Timestamp.ofEpochSecond(4).compareTo(Timestamp.ofEpochSecond(3)) > 0);
@@ -79,16 +69,15 @@ public class TestTimestamp
     }
 
     @Test
-    public void testToString()
-    {
+    public void testToString() {
         assertEquals("1970-01-01 00:00:00 UTC", Timestamp.ofEpochSecond(0).toString());
         assertEquals("2015-01-19 07:36:10 UTC", Timestamp.ofEpochSecond(1421652970).toString());
-        assertEquals("2015-01-19 07:36:10.100 UTC",       Timestamp.ofEpochSecond(1421652970, 100*1000*1000).toString());
-        assertEquals("2015-01-19 07:36:10.120 UTC",       Timestamp.ofEpochSecond(1421652970, 120*1000*1000).toString());
-        assertEquals("2015-01-19 07:36:10.123 UTC",       Timestamp.ofEpochSecond(1421652970, 123*1000*1000).toString());
-        assertEquals("2015-01-19 07:36:10.123400 UTC",    Timestamp.ofEpochSecond(1421652970, 123400*1000).toString());
-        assertEquals("2015-01-19 07:36:10.123450 UTC",    Timestamp.ofEpochSecond(1421652970, 123450*1000).toString());
-        assertEquals("2015-01-19 07:36:10.123456 UTC",    Timestamp.ofEpochSecond(1421652970, 123456*1000).toString());
+        assertEquals("2015-01-19 07:36:10.100 UTC", Timestamp.ofEpochSecond(1421652970, 100 * 1000 * 1000).toString());
+        assertEquals("2015-01-19 07:36:10.120 UTC", Timestamp.ofEpochSecond(1421652970, 120 * 1000 * 1000).toString());
+        assertEquals("2015-01-19 07:36:10.123 UTC", Timestamp.ofEpochSecond(1421652970, 123 * 1000 * 1000).toString());
+        assertEquals("2015-01-19 07:36:10.123400 UTC", Timestamp.ofEpochSecond(1421652970, 123400 * 1000).toString());
+        assertEquals("2015-01-19 07:36:10.123450 UTC", Timestamp.ofEpochSecond(1421652970, 123450 * 1000).toString());
+        assertEquals("2015-01-19 07:36:10.123456 UTC", Timestamp.ofEpochSecond(1421652970, 123456 * 1000).toString());
         assertEquals("2015-01-19 07:36:10.123456700 UTC", Timestamp.ofEpochSecond(1421652970, 123456700).toString());
         assertEquals("2015-01-19 07:36:10.123456780 UTC", Timestamp.ofEpochSecond(1421652970, 123456780).toString());
         assertEquals("2015-01-19 07:36:10.123456789 UTC", Timestamp.ofEpochSecond(1421652970, 123456789).toString());

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatterParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatterParser.java
@@ -1,45 +1,37 @@
 package org.embulk.spi.time;
 
-import org.junit.Rule;
-import org.junit.Before;
-import org.junit.Test;
-import com.google.common.base.Optional;
 import static org.junit.Assert.assertEquals;
-import org.embulk.config.Task;
-import org.embulk.config.Config;
-import org.embulk.config.ConfigSource;
-import org.embulk.spi.Exec;
-import org.embulk.EmbulkTestRuntime;
 
-public class TestTimestampFormatterParser
-{
+import com.google.common.base.Optional;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.Task;
+import org.embulk.spi.Exec;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestTimestampFormatterParser {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
-    private interface FormatterTestTask
-            extends Task, TimestampFormatter.Task
-    { }
+    private interface FormatterTestTask extends Task, TimestampFormatter.Task {}
 
-    private interface ParserTestTask
-            extends Task, TimestampParser.Task
-    { }
+    private interface ParserTestTask extends Task, TimestampParser.Task {}
 
     @Test
-    public void testSimpleFormat() throws Exception
-    {
+    public void testSimpleFormat() throws Exception {
         ConfigSource config = Exec.newConfigSource()
-            .set("default_timestamp_format", "%Y-%m-%d %H:%M:%S.%9N %z");  // %Z is OS-dependent
+                .set("default_timestamp_format", "%Y-%m-%d %H:%M:%S.%9N %z");  // %Z is OS-dependent
         FormatterTestTask task = config.loadConfig(FormatterTestTask.class);
 
         TimestampFormatter formatter = new TimestampFormatter(task, Optional.<TimestampFormatter.TimestampColumnOption>absent());
-        assertEquals("2014-11-19 02:46:29.123456000 +0000", formatter.format(Timestamp.ofEpochSecond(1416365189, 123456*1000)));
+        assertEquals("2014-11-19 02:46:29.123456000 +0000", formatter.format(Timestamp.ofEpochSecond(1416365189, 123456 * 1000)));
     }
 
     @Test
-    public void testSimpleParse() throws Exception
-    {
+    public void testSimpleParse() throws Exception {
         ConfigSource config = Exec.newConfigSource()
-            .set("default_timestamp_format", "%Y-%m-%d %H:%M:%S %z");  // %Z is OS-dependent
+                .set("default_timestamp_format", "%Y-%m-%d %H:%M:%S %z");  // %Z is OS-dependent
         ParserTestTask task = config.loadConfig(ParserTestTask.class);
 
         TimestampParser parser = TimestampParserLegacy.createTimestampParserForTesting(task);
@@ -47,10 +39,9 @@ public class TestTimestampFormatterParser
     }
 
     @Test
-    public void testUnixtimeFormat() throws Exception
-    {
+    public void testUnixtimeFormat() throws Exception {
         ConfigSource config = Exec.newConfigSource()
-            .set("default_timestamp_format", "%s");
+                .set("default_timestamp_format", "%s");
 
         FormatterTestTask ftask = config.loadConfig(FormatterTestTask.class);
         TimestampFormatter formatter = new TimestampFormatter(ftask, Optional.<TimestampFormatter.TimestampColumnOption>absent());
@@ -62,11 +53,10 @@ public class TestTimestampFormatterParser
     }
 
     @Test
-    public void testDefaultDate() throws Exception
-    {
+    public void testDefaultDate() throws Exception {
         ConfigSource config = Exec.newConfigSource()
-            .set("default_timestamp_format", "%H:%M:%S %Z")
-            .set("default_date", "2016-02-03");
+                .set("default_timestamp_format", "%H:%M:%S %Z")
+                .set("default_date", "2016-02-03");
 
         ParserTestTask ptask = config.loadConfig(ParserTestTask.class);
         TimestampParser parser = TimestampParserLegacy.createTimestampParserForTesting(ptask);

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampSerDe.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampSerDe.java
@@ -3,26 +3,23 @@ package org.embulk.spi.time;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestTimestampSerDe
-{
+public class TestTimestampSerDe {
     @Test
-    public void testCreateTimestampFromString()
-    {
+    public void testCreateTimestampFromString() {
         checkToStringFromString(Timestamp.ofEpochSecond(0));
         checkToStringFromString(Timestamp.ofEpochSecond(1421652970));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 100*1000*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 120*1000*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123*1000*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123400*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123450*1000));
-        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456*1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 100 * 1000 * 1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 120 * 1000 * 1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123 * 1000 * 1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123400 * 1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123450 * 1000));
+        checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456 * 1000));
         checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456700));
         checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456780));
         checkToStringFromString(Timestamp.ofEpochSecond(1421652970, 123456789));
     }
 
-    private void checkToStringFromString(final Timestamp timestamp)
-    {
+    private void checkToStringFromString(final Timestamp timestamp) {
         Assert.assertEquals(timestamp, TimestampSerDe.createTimestampFromStringForTesting(timestamp.toString()));
     }
 }

--- a/embulk-core/src/test/java/org/embulk/spi/type/TestTypeSerDe.java
+++ b/embulk-core/src/test/java/org/embulk/spi/type/TestTypeSerDe.java
@@ -1,42 +1,35 @@
 package org.embulk.spi.type;
 
-import org.junit.Rule;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import com.google.inject.Inject;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.embulk.EmbulkTestRuntime;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class TestTypeSerDe
-{
+public class TestTypeSerDe {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
-    private static class HasType
-    {
+    private static class HasType {
         private Type type;
         // TODO test TimestampType
 
         @JsonCreator
         public HasType(
-                @JsonProperty("type") Type type)
-        {
+                @JsonProperty("type") Type type) {
             this.type = type;
         }
 
         @JsonProperty("type")
-        public Type getType()
-        {
+        public Type getType() {
             return type;
         }
     }
 
     @Test
-    public void testGetType()
-    {
+    public void testGetType() {
         HasType type = new HasType(StringType.STRING);
         String json = runtime.getModelManager().writeObject(type);
         HasType decoded = runtime.getModelManager().readObject(HasType.class, json);

--- a/embulk-core/src/test/java/org/embulk/spi/unit/TestByteSize.java
+++ b/embulk-core/src/test/java/org/embulk/spi/unit/TestByteSize.java
@@ -2,34 +2,31 @@ package org.embulk.spi.unit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import org.junit.Test;
 
-public class TestByteSize
-{
+public class TestByteSize {
     @Test
-    public void testUnitPatterns()
-    {
+    public void testUnitPatterns() {
         assertByteSize(42L, "42");
         assertByteSize(42L, "42B");
-        assertByteSize(42L*(1L << 10), "42KB");
-        assertByteSize(42L*(1L << 20), "42MB");
-        assertByteSize(42L*(1L << 30), "42GB");
-        assertByteSize(42L*(1L << 40), "42TB");
-        assertByteSize(42L*(1L << 50), "42PB");
+        assertByteSize(42L * (1L << 10), "42KB");
+        assertByteSize(42L * (1L << 20), "42MB");
+        assertByteSize(42L * (1L << 30), "42GB");
+        assertByteSize(42L * (1L << 40), "42TB");
+        assertByteSize(42L * (1L << 50), "42PB");
         assertByteSize(42L, "42 B");
-        assertByteSize(42L*(1L << 10), "42 KB");
+        assertByteSize(42L * (1L << 10), "42 KB");
     }
 
     @Test
-    public void testUnknownUnits()
-    {
+    public void testUnknownUnits() {
         assertInvalidByteSize("42XB");
         assertInvalidByteSize("42 XB");
     }
 
     @Test
-    public void testInvalidPatterns()
-    {
+    public void testInvalidPatterns() {
         assertInvalidByteSize(" 42");
         assertInvalidByteSize("42  B");
         assertInvalidByteSize("42 B ");
@@ -40,14 +37,12 @@ public class TestByteSize
     }
 
     @Test
-    public void testInvalidValues()
-    {
+    public void testInvalidValues() {
         assertInvalidByteSize("9223372036854775KB");
     }
 
     @Test
-    public void testToString()
-    {
+    public void testToString() {
         assertByteSizeString("42B", "42 B");
         assertByteSizeString("42KB", "42 KB");
         assertByteSizeString("42MB", "42 MB");
@@ -58,22 +53,20 @@ public class TestByteSize
         assertByteSizeString("42.33KB", "42.33KB");
     }
 
-    private static void assertByteSize(long bytes, String string)
-    {
+    private static void assertByteSize(long bytes, String string) {
         assertEquals(bytes, ByteSize.parseByteSize(string).getBytes());
     }
 
-    private static void assertByteSizeString(String expected, String string)
-    {
+    private static void assertByteSizeString(String expected, String string) {
         assertEquals(expected, ByteSize.parseByteSize(string).toString());
     }
 
-    private static void assertInvalidByteSize(String string)
-    {
+    private static void assertInvalidByteSize(String string) {
         try {
             ByteSize.parseByteSize(string);
             fail();
         } catch (IllegalArgumentException ex) {
+            // Just passing through.
         }
     }
 }

--- a/embulk-core/src/test/java/org/embulk/spi/util/TestLineDecoder.java
+++ b/embulk-core/src/test/java/org/embulk/spi/util/TestLineDecoder.java
@@ -1,30 +1,27 @@
 package org.embulk.spi.util;
 
-import java.util.List;
-import java.util.ArrayList;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
-import com.google.common.collect.ImmutableList;
-import org.junit.Rule;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import org.embulk.config.ConfigSource;
-import org.embulk.spi.Exec;
-import org.embulk.spi.Buffer;
-import org.embulk.spi.util.ListFileInput;
+import java.util.ArrayList;
+import java.util.List;
 import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigSource;
+import org.embulk.spi.Buffer;
+import org.embulk.spi.Exec;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class TestLineDecoder
-{
+public class TestLineDecoder {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
     @Test
-    public void testDefaultValues()
-    {
+    public void testDefaultValues() {
         ConfigSource config = Exec.newConfigSource();
         LineDecoder.DecoderTask task = config.loadConfig(LineDecoder.DecoderTask.class);
         assertEquals(StandardCharsets.UTF_8, task.getCharset());
@@ -32,32 +29,28 @@ public class TestLineDecoder
     }
 
     @Test
-    public void testLoadConfig()
-    {
+    public void testLoadConfig() {
         ConfigSource config = Exec.newConfigSource()
-            .set("charset", "utf-16")
-            .set("newline", "CRLF");
+                .set("charset", "utf-16")
+                .set("newline", "CRLF");
         LineDecoder.DecoderTask task = config.loadConfig(LineDecoder.DecoderTask.class);
         assertEquals(StandardCharsets.UTF_16, task.getCharset());
         assertEquals(Newline.CRLF, task.getNewline());
     }
 
-    private static LineDecoder.DecoderTask getExampleConfig(Charset charset, Newline newline)
-    {
+    private static LineDecoder.DecoderTask getExampleConfig(Charset charset, Newline newline) {
         ConfigSource config = Exec.newConfigSource()
-            .set("charset", charset)
-            .set("newline", newline);
+                .set("charset", charset)
+                .set("newline", newline);
         return config.loadConfig(LineDecoder.DecoderTask.class);
     }
 
-    private static LineDecoder newDecoder(Charset charset, Newline newline, List<Buffer> buffers)
-    {
+    private static LineDecoder newDecoder(Charset charset, Newline newline, List<Buffer> buffers) {
         ListFileInput input = new ListFileInput(ImmutableList.of(buffers));
         return new LineDecoder(input, getExampleConfig(charset, newline));
     }
 
-    private static List<String> doDecode(Charset charset, Newline newline, List<Buffer> buffers)
-    {
+    private static List<String> doDecode(Charset charset, Newline newline, List<Buffer> buffers) {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
         LineDecoder decoder = newDecoder(charset, newline, buffers);
         decoder.nextFile();
@@ -71,8 +64,7 @@ public class TestLineDecoder
         return builder.build();
     }
 
-    private static List<Buffer> bufferList(Charset charset, String... sources) throws UnsupportedCharsetException
-    {
+    private static List<Buffer> bufferList(Charset charset, String... sources) throws UnsupportedCharsetException {
         List<Buffer> buffers = new ArrayList<Buffer>();
         for (String source : sources) {
             ByteBuffer buffer = charset.encode(source);
@@ -83,17 +75,16 @@ public class TestLineDecoder
     }
 
     @Test
-    public void testDecodeBasicAscii() throws Exception
-    {
+    public void testDecodeBasicAscii() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_8, Newline.LF,
                 bufferList(StandardCharsets.UTF_8, "test1\ntest2\ntest3\n"));
         assertEquals(ImmutableList.of("test1", "test2", "test3"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeBasicAsciiCRLF() throws Exception
-    {
+    public void testDecodeBasicAsciiCRLF() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_8, Newline.CRLF,
                 bufferList(StandardCharsets.UTF_8, "test1\r\ntest2\r\ntest3\r\n"));
@@ -101,134 +92,133 @@ public class TestLineDecoder
     }
 
     @Test
-    public void testDecodeBasicAsciiTail() throws Exception
-    {
+    public void testDecodeBasicAsciiTail() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_8, Newline.LF,
                 bufferList(StandardCharsets.UTF_8, "test1"));
         assertEquals(ImmutableList.of("test1"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeChunksLF() throws Exception
-    {
+    public void testDecodeChunksLF() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_8, Newline.LF,
                 bufferList(StandardCharsets.UTF_8, "t", "1", "\n", "t", "2"));
         assertEquals(ImmutableList.of("t1", "t2"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeChunksCRLF() throws Exception
-    {
+    public void testDecodeChunksCRLF() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_8, Newline.CRLF,
                 bufferList(StandardCharsets.UTF_8, "t", "1", "\r\n", "t", "2", "\r", "\n", "t3"));
         assertEquals(ImmutableList.of("t1", "t2", "t3"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeBasicUTF8() throws Exception
-    {
+    public void testDecodeBasicUTF8() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_8, Newline.LF,
                 bufferList(StandardCharsets.UTF_8, "てすと1\nテスト2\nてすと3\n"));
         assertEquals(ImmutableList.of("てすと1", "テスト2", "てすと3"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeBasicUTF8Tail() throws Exception
-    {
+    public void testDecodeBasicUTF8Tail() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_8, Newline.LF,
                 bufferList(StandardCharsets.UTF_8, "てすと1"));
         assertEquals(ImmutableList.of("てすと1"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeChunksUTF8LF() throws Exception
-    {
+    public void testDecodeChunksUTF8LF() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_8, Newline.LF,
                 bufferList(StandardCharsets.UTF_8, "て", "1", "\n", "す", "2"));
         assertEquals(ImmutableList.of("て1", "す2"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeChunksUTF8CRLF() throws Exception
-    {
+    public void testDecodeChunksUTF8CRLF() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_8, Newline.CRLF,
                 bufferList(StandardCharsets.UTF_8, "て", "1", "\r\n", "す", "2", "\r", "\n", "と3"));
         assertEquals(ImmutableList.of("て1", "す2", "と3"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeBasicUTF16LE() throws Exception
-    {
+    public void testDecodeBasicUTF16LE() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_16LE, Newline.LF,
                 bufferList(StandardCharsets.UTF_16LE, "てすと1\nテスト2\nてすと3\n"));
         assertEquals(ImmutableList.of("てすと1", "テスト2", "てすと3"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeBasicUTF16LETail() throws Exception
-    {
+    public void testDecodeBasicUTF16LETail() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_16LE, Newline.LF,
                 bufferList(StandardCharsets.UTF_16LE, "てすと1"));
         assertEquals(ImmutableList.of("てすと1"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeChunksUTF16LELF() throws Exception
-    {
+    public void testDecodeChunksUTF16LELF() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_16LE, Newline.LF,
                 bufferList(StandardCharsets.UTF_16LE, "て", "1", "\n", "す", "2"));
         assertEquals(ImmutableList.of("て1", "す2"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeChunksUTF16LECRLF() throws Exception
-    {
+    public void testDecodeChunksUTF16LECRLF() throws Exception {
         List<String> decoded = doDecode(
                 StandardCharsets.UTF_16LE, Newline.CRLF,
                 bufferList(StandardCharsets.UTF_16LE, "て", "1", "\r\n", "す", "2", "\r", "\n", "と3"));
         assertEquals(ImmutableList.of("て1", "す2", "と3"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeBasicMS932() throws Exception
-    {
+    public void testDecodeBasicMS932() throws Exception {
         List<String> decoded = doDecode(
                 Charset.forName("ms932"), Newline.LF,
                 bufferList(Charset.forName("ms932"), "てすと1\nテスト2\nてすと3\n"));
         assertEquals(ImmutableList.of("てすと1", "テスト2", "てすと3"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeBasicMS932Tail() throws Exception
-    {
+    public void testDecodeBasicMS932Tail() throws Exception {
         List<String> decoded = doDecode(
                 Charset.forName("ms932"), Newline.LF,
                 bufferList(Charset.forName("ms932"), "てすと1"));
         assertEquals(ImmutableList.of("てすと1"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeChunksMS932LF() throws Exception
-    {
+    public void testDecodeChunksMS932LF() throws Exception {
         List<String> decoded = doDecode(
                 Charset.forName("ms932"), Newline.LF,
                 bufferList(Charset.forName("ms932"), "て", "1", "\n", "す", "2"));
         assertEquals(ImmutableList.of("て1", "す2"), decoded);
     }
 
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    public void testDecodeChunksMS932CRLF() throws Exception
-    {
+    public void testDecodeChunksMS932CRLF() throws Exception {
         List<String> decoded = doDecode(
                 Charset.forName("ms932"), Newline.CRLF,
                 bufferList(Charset.forName("ms932"), "て", "1", "\r\n", "す", "2", "\r", "\n", "と3"));

--- a/embulk-core/src/test/java/org/embulk/spi/util/TestLineEncoder.java
+++ b/embulk-core/src/test/java/org/embulk/spi/util/TestLineEncoder.java
@@ -1,42 +1,29 @@
 package org.embulk.spi.util;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.UnsupportedCharsetException;
-import com.google.common.collect.ImmutableList;
-import org.junit.Rule;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.Exec;
-import org.embulk.spi.MockFileOutput;
 import org.embulk.spi.FileOutput;
-import org.embulk.EmbulkTestRuntime;
+import org.embulk.spi.MockFileOutput;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class TestLineEncoder
-{
+public class TestLineEncoder {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
     private LineEncoder newEncoder(String charset, String newline,
-            FileOutput output) throws Exception
-    {
+            FileOutput output) throws Exception {
         ConfigSource config = Exec.newConfigSource()
-            .set("charset", charset)
-            .set("newline", newline);
+                .set("charset", charset)
+                .set("newline", newline);
         return new LineEncoder(output, config.loadConfig(LineEncoder.EncoderTask.class));
     }
 
     @Test
-    public void testAddLine() throws Exception
-    {
+    public void testAddLine() throws Exception {
         try (MockFileOutput output = new MockFileOutput()) {
             LineEncoder encoder = newEncoder("utf-8", "LF", output);
             encoder.nextFile();
@@ -55,8 +42,7 @@ public class TestLineEncoder
     }
 
     @Test
-    public void testAddTextAddNewLine() throws Exception
-    {
+    public void testAddTextAddNewLine() throws Exception {
         try (MockFileOutput output = new MockFileOutput()) {
             LineEncoder encoder = newEncoder("utf-8", "LF", output);
             encoder.nextFile();
@@ -76,8 +62,7 @@ public class TestLineEncoder
     }
 
     @Test
-    public void testNewLine() throws Exception
-    {
+    public void testNewLine() throws Exception {
         try (MockFileOutput output = new MockFileOutput()) {
             LineEncoder encoder = newEncoder("utf-8", "CRLF", output);
             encoder.nextFile();
@@ -96,8 +81,7 @@ public class TestLineEncoder
     }
 
     @Test
-    public void testCharset() throws Exception
-    {
+    public void testCharset() throws Exception {
         try (MockFileOutput output = new MockFileOutput()) {
             LineEncoder encoder = newEncoder("MS932", "CR", output);
             encoder.nextFile();
@@ -116,8 +100,7 @@ public class TestLineEncoder
     }
 
     private String bufferToString(Buffer buffer, String charset)
-            throws UnsupportedEncodingException
-    {
+            throws UnsupportedEncodingException {
         return new String(buffer.array(), buffer.offset(), buffer.limit(), charset);
     }
 }


### PR DESCRIPTION
After #914, enabling checkstyle for embulk-core tests, then.