### PR TITLE
Upgrade the embedded JRuby to 9.1.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ version = '0.9.0-SNAPSHOT'
 description = 'Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control.'
 
 ext {
-    jrubyVersion = '9.1.13.0'
+    jrubyVersion = '9.1.15.0'
     summary = 'Embulk, a plugin-based parallel bulk data loader'
 }
 


### PR DESCRIPTION
Forgot this... Let's upgrade the embedded JRuby in Embulk 0.9.0 to the latest 9.1.15.0. Can you have a look? @sakama @muga 