### PR TITLE
Upgrade shadow Gradle plugin to 2.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
         classpath 'com.github.jruby-gradle:jruby-gradle-jar-plugin:1.5.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }


### PR DESCRIPTION
Once JRuby was upgraded to 9.1.15.0, it turned out that the Gradle `shadowJar` task failed. Found that upgrading the `shadow` Gradle plugin fixes the issue.

@sakama @muga Can you have a look?