### PR TITLE
Pick up release document of hotfix v0.8.39

### DIFF
--- a/embulk-docs/src/release.rst
+++ b/embulk-docs/src/release.rst
@@ -4,6 +4,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.8.39
     release/release-0.8.38
     release/release-0.8.37
     release/release-0.8.36

--- a/embulk-docs/src/release/release-0.8.39.rst
+++ b/embulk-docs/src/release/release-0.8.39.rst
@@ -1,0 +1,12 @@
+Release 0.8.39
+==================================
+
+General Changes
+----------------
+
+* Backport hot-fix: Parse time zones in Ruby-style in lower priority than Joda-Time [#864]
+
+
+Release Date
+------------------
+2017-12-06


### PR DESCRIPTION
Salvaging the release document of branched hotfix v0.8.39: https://github.com/embulk/embulk/releases/tag/v0.8.39

@sakama @muga Can you have a look?