### PR TITLE
Deprecate new things to be deprecated, and suppress uses of deprecated things

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ configure(subprojects.findAll { ['embulk-core', 'embulk-standards', 'embulk-test
     version = "${rootProject.version}"
 
     tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint:unchecked" //<< "-Xlint:deprecation"
+        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
     }
 
     tasks.withType(Test) {

--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -84,6 +84,8 @@ public class EmbulkEmbed {
         }
 
         private EmbulkEmbed build(boolean destroyOnShutdownHook) {
+            // TODO: Replace use of EmbulkService.
+            @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/932
             org.embulk.guice.Bootstrap bootstrap = new org.embulk.guice.Bootstrap()
                     .requireExplicitBindings(false)
                     .addModules(EmbulkService.standardModuleList(systemConfig));

--- a/embulk-core/src/main/java/org/embulk/EmbulkService.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkService.java
@@ -16,7 +16,8 @@ import org.embulk.plugin.BuiltinPluginSourceModule;
 import org.embulk.plugin.PluginClassLoaderModule;
 import org.embulk.plugin.maven.MavenPluginSourceModule;
 
-@Deprecated
+// Use EmbulkEmbed instead. To be removed by v0.10 or earlier.
+@Deprecated  // https://github.com/embulk/embulk/issues/932
 public class EmbulkService {
     private final ConfigSource systemConfig;
 

--- a/embulk-core/src/main/java/org/embulk/config/CommitReport.java
+++ b/embulk-core/src/main/java/org/embulk/config/CommitReport.java
@@ -1,7 +1,11 @@
 package org.embulk.config;
 
-/** Simply replaced by TaskReport. */
-@Deprecated
+/**
+ * Simply replaced by TaskReport.
+ *
+ * To be removed by v0.10 or earlier.
+ */
+@Deprecated  // https://github.com/embulk/embulk/issues/933
 public interface CommitReport extends TaskReport {
     @Override
     CommitReport getNested(String attrName);

--- a/embulk-core/src/main/java/org/embulk/config/ConfigLoader.java
+++ b/embulk-core/src/main/java/org/embulk/config/ConfigLoader.java
@@ -78,7 +78,8 @@ public class ConfigLoader {
         }
     }
 
-    @Deprecated
+    // To be removed by v0.10. Not used from Embulk core.
+    @Deprecated  // https://github.com/embulk/embulk/issues/934
     @SuppressWarnings("checkstyle:OverloadMethodsDeclarationOrder")
     public ConfigSource fromJson(JsonParser parser) throws IOException {
         // TODO check parsed.isObject()

--- a/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
+++ b/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
@@ -9,6 +9,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+// TODO: Stop implementing CommitReport by v0.10 or earlier.
+@SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/933
 public class DataSourceImpl
         implements ConfigSource, TaskSource, TaskReport, /* Deprecated */ CommitReport, ConfigDiff {
     protected final ObjectNode data;

--- a/embulk-core/src/main/java/org/embulk/config/DataSourceSerDe.java
+++ b/embulk-core/src/main/java/org/embulk/config/DataSourceSerDe.java
@@ -33,6 +33,8 @@ public class DataSourceSerDe {
             addSerializer(TaskReport.class, new DataSourceSerializer<TaskReport>());
             addDeserializer(TaskReport.class, new DataSourceDeserializer<TaskReport>(model));
 
+            // TODO: Remove this registration by v0.10 or earlier.
+            // https://github.com/embulk/embulk/issues/933
             // CommitReport (Deprecated)
             addSerializer(CommitReport.class, new DataSourceSerializer<CommitReport>());
             addDeserializer(CommitReport.class, new DataSourceDeserializer<CommitReport>(model));

--- a/embulk-core/src/main/java/org/embulk/exec/ResumeState.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ResumeState.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import java.util.List;
-import org.embulk.config.CommitReport;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
@@ -68,10 +67,11 @@ public class ResumeState {
         return inputTaskReports;
     }
 
-    @Deprecated
+    // To be removed by v0.10 or earlier.
+    @Deprecated  // https://github.com/embulk/embulk/issues/933
     @JsonIgnore
-    @SuppressWarnings("unchecked")
-    public List<Optional<CommitReport>> getInputCommitReports() {
+    @SuppressWarnings({"deprecation", "unchecked"})
+    public List<Optional<org.embulk.config.CommitReport>> getInputCommitReports() {
         return (List) inputTaskReports;  // the only implementation of TaskReport is DataSourceImpl which implements CommitReport
     }
 
@@ -80,10 +80,11 @@ public class ResumeState {
         return outputTaskReports;
     }
 
-    @Deprecated
+    // To be removed by v0.10 or earlier.
+    @Deprecated  // https://github.com/embulk/embulk/issues/933
     @JsonIgnore
-    @SuppressWarnings("unchecked")
-    public List<Optional<CommitReport>> getOutputCommitReports() {
+    @SuppressWarnings({"deprecation", "unchecked"})
+    public List<Optional<org.embulk.config.CommitReport>> getOutputCommitReports() {
         return (List) outputTaskReports;  // the only implementation of TaskReport is DataSourceImpl which implements CommitReport;
     }
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/compat/InputPluginWrapper.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/compat/InputPluginWrapper.java
@@ -4,7 +4,6 @@ import com.google.common.base.Throwables;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
-import org.embulk.config.CommitReport;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
@@ -22,10 +21,12 @@ public class InputPluginWrapper implements InputPlugin {
         return object;
     }
 
+    // TODO: Remove the CommitReport case by v0.10 or earlier.
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/933
     private static Method wrapRunMethod(InputPlugin object) {
         try {
             Method m = object.getClass().getMethod("run", TaskSource.class, Schema.class, int.class, PageOutput.class);
-            if (m.getReturnType().equals(CommitReport.class)) {
+            if (m.getReturnType().equals(org.embulk.config.CommitReport.class)) {
                 return m;
             } else {
                 return null;

--- a/embulk-core/src/main/java/org/embulk/plugin/compat/TransactionalFileInputWrapper.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/compat/TransactionalFileInputWrapper.java
@@ -3,7 +3,6 @@ package org.embulk.plugin.compat;
 import com.google.common.base.Throwables;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import org.embulk.config.CommitReport;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.TransactionalFileInput;
@@ -21,10 +20,12 @@ public class TransactionalFileInputWrapper implements TransactionalFileInput {
         return object;
     }
 
+    // TODO: Remove the CommitReport case by v0.10 or earlier.
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/933
     private static Method wrapCommitMethod(TransactionalFileInput object) {
         try {
             Method m = object.getClass().getMethod("commit");
-            if (m.getReturnType().equals(CommitReport.class)) {
+            if (m.getReturnType().equals(org.embulk.config.CommitReport.class)) {
                 return m;
             } else {
                 return null;

--- a/embulk-core/src/main/java/org/embulk/plugin/compat/TransactionalFileOutputWrapper.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/compat/TransactionalFileOutputWrapper.java
@@ -3,7 +3,6 @@ package org.embulk.plugin.compat;
 import com.google.common.base.Throwables;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import org.embulk.config.CommitReport;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.TransactionalFileOutput;
@@ -21,10 +20,12 @@ public class TransactionalFileOutputWrapper implements TransactionalFileOutput {
         return object;
     }
 
+    // TODO: Remove the CommitReport case by v0.10 or earlier.
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/933
     private static Method wrapCommitMethod(TransactionalFileOutput object) {
         try {
             Method m = object.getClass().getMethod("commit");
-            if (m.getReturnType().equals(CommitReport.class)) {
+            if (m.getReturnType().equals(org.embulk.config.CommitReport.class)) {
                 return m;
             } else {
                 return null;

--- a/embulk-core/src/main/java/org/embulk/plugin/compat/TransactionalPageOutputWrapper.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/compat/TransactionalPageOutputWrapper.java
@@ -3,7 +3,6 @@ package org.embulk.plugin.compat;
 import com.google.common.base.Throwables;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import org.embulk.config.CommitReport;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.Page;
 import org.embulk.spi.TransactionalPageOutput;
@@ -21,10 +20,12 @@ public class TransactionalPageOutputWrapper implements TransactionalPageOutput {
         return object;
     }
 
+    // TODO: Remove the CommitReport case by v0.10 or earlier.
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/933
     private static Method wrapCommitMethod(TransactionalPageOutput object) {
         try {
             Method m = object.getClass().getMethod("commit");
-            if (m.getReturnType().equals(CommitReport.class)) {
+            if (m.getReturnType().equals(org.embulk.config.CommitReport.class)) {
                 return m;
             } else {
                 return null;

--- a/embulk-core/src/main/java/org/embulk/spi/ColumnConfig.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ColumnConfig.java
@@ -62,6 +62,8 @@ public class ColumnConfig {
         return option.get(String.class, "format", null);
     }
 
+    // TODO: Stop using TimestampType.withFormat.
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/935
     public Column toColumn(int index) {
         String format = option.get(String.class, "format", null);
         if (type instanceof TimestampType && format != null) {

--- a/embulk-core/src/main/java/org/embulk/spi/Exec.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Exec.java
@@ -2,7 +2,6 @@ package org.embulk.spi;
 
 import com.google.inject.Injector;
 import java.util.concurrent.ExecutionException;
-import org.embulk.config.CommitReport;  // Deprecated
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.ModelManager;
@@ -68,8 +67,10 @@ public class Exec {
         return session().newTaskReport();
     }
 
-    @Deprecated
-    public static CommitReport newCommitReport() {
+    // To be removed by v0.10 or earlier.
+    @Deprecated  // https://github.com/embulk/embulk/issues/933
+    @SuppressWarnings("deprecation")
+    public static org.embulk.config.CommitReport newCommitReport() {
         return session().newCommitReport();
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -2,7 +2,6 @@ package org.embulk.spi;
 
 import com.google.common.base.Optional;
 import com.google.inject.Injector;
-import org.embulk.config.CommitReport;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -17,7 +16,6 @@ import org.embulk.plugin.PluginManager;
 import org.embulk.plugin.PluginType;
 import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.time.TimestampFormatter;
-import org.joda.time.DateTimeZone;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 
@@ -153,8 +151,10 @@ public class ExecSession {
         return new DataSourceImpl(modelManager);
     }
 
-    @Deprecated
-    public CommitReport newCommitReport() {
+    // To be removed by v0.10 or earlier.
+    @Deprecated  // https://github.com/embulk/embulk/issues/933
+    @SuppressWarnings("deprecation")
+    public org.embulk.config.CommitReport newCommitReport() {
         return new DataSourceImpl(modelManager);
     }
 
@@ -170,7 +170,10 @@ public class ExecSession {
         return new DataSourceImpl(modelManager);
     }
 
-    public TimestampFormatter newTimestampFormatter(String format, DateTimeZone timezone) {
+    // To be removed by v0.10 or earlier.
+    @Deprecated  // https://github.com/embulk/embulk/issues/936
+    @SuppressWarnings("deprecation")
+    public TimestampFormatter newTimestampFormatter(String format, org.joda.time.DateTimeZone timezone) {
         return new TimestampFormatter(format, timezone);
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/TaskState.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TaskState.java
@@ -1,7 +1,6 @@
 package org.embulk.spi;
 
 import com.google.common.base.Optional;
-import org.embulk.config.CommitReport;
 import org.embulk.config.TaskReport;
 
 public class TaskState {
@@ -24,8 +23,10 @@ public class TaskState {
         this.taskReport = Optional.of(taskReport);
     }
 
-    @Deprecated
-    public void setCommitReport(CommitReport commitReport) {
+    // To be removed by v0.10 or earlier.
+    @Deprecated  // https://github.com/embulk/embulk/issues/933
+    @SuppressWarnings("deprecation")
+    public void setCommitReport(org.embulk.config.CommitReport commitReport) {
         this.started = true;
         this.taskReport = Optional.<TaskReport>of(commitReport);
     }
@@ -56,9 +57,10 @@ public class TaskState {
         return taskReport;
     }
 
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    public Optional<CommitReport> getCommitReport() {
+    // To be removed by v0.10 or earlier.
+    @Deprecated  // https://github.com/embulk/embulk/issues/933
+    @SuppressWarnings({"deprecation", "unchecked"})
+    public Optional<org.embulk.config.CommitReport> getCommitReport() {
         return (Optional) taskReport;  // the only implementation of TaskReport is DataSourceImpl which implements CommitReport;
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatterRuby.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatterRuby.java
@@ -2,10 +2,10 @@ package org.embulk.spi.time;
 
 import java.time.ZoneOffset;
 import java.util.Locale;
-import org.jruby.util.RubyDateFormat;
 
 public class TimestampFormatterRuby extends TimestampFormatter {
-    private TimestampFormatterRuby(final RubyDateFormat formatter,
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/830
+    private TimestampFormatterRuby(final org.jruby.util.RubyDateFormat formatter,
                                    final ZoneOffset zoneOffset,
                                    final org.joda.time.DateTimeZone jodaDateTimeZone,
                                    final String formatString) {
@@ -15,8 +15,9 @@ public class TimestampFormatterRuby extends TimestampFormatter {
         this.formatString = formatString;
     }
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/830
     static TimestampFormatterRuby of(final String formatString, final ZoneOffset zoneOffset) {
-        return new TimestampFormatterRuby(new RubyDateFormat(formatString, Locale.ENGLISH, true),
+        return new TimestampFormatterRuby(new org.jruby.util.RubyDateFormat(formatString, Locale.ENGLISH, true),
                                           zoneOffset,
                                           TimeZoneIds.convertZoneOffsetToJodaDateTimeZone(zoneOffset),
                                           formatString);
@@ -24,10 +25,10 @@ public class TimestampFormatterRuby extends TimestampFormatter {
 
     // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
     // It won't be removed very soon at least until Embulk v0.10.
-    @Deprecated
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/830
     static TimestampFormatterRuby ofLegacy(final String formatString,
                                            final org.joda.time.DateTimeZone jodaDateTimeZone) {
-        return new TimestampFormatterRuby(new RubyDateFormat(formatString, Locale.ENGLISH, true),
+        return new TimestampFormatterRuby(new org.jruby.util.RubyDateFormat(formatString, Locale.ENGLISH, true),
                                           null,
                                           jodaDateTimeZone,
                                           formatString);
@@ -48,7 +49,8 @@ public class TimestampFormatterRuby extends TimestampFormatter {
         return this.formatter.format(null);
     }
 
-    private final RubyDateFormat formatter;
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/830
+    private final org.jruby.util.RubyDateFormat formatter;
     private final ZoneOffset zoneOffset;  // Nullable
     private final org.joda.time.DateTimeZone jodaDateTimeZone;  // Not null
     private final String formatString;

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
@@ -71,7 +71,9 @@ class DynamicColumnSetterFactory {
             final TimestampParser parser;
             if (this.useColumnForTimestampMetadata) {
                 final TimestampType timestampType = (TimestampType) type;
-                parser = TimestampParser.of(timestampType.getFormat(), getTimeZoneId(column));
+                // https://github.com/embulk/embulk/issues/935
+                parser = TimestampParser.of(getFormatFromTimestampTypeWithDepracationSuppressed(timestampType),
+                                            getTimeZoneId(column));
             } else {
                 parser = TimestampParser.of(getTimestampFormatForParser(column), getTimeZoneId(column));
             }
@@ -122,5 +124,11 @@ class DynamicColumnSetterFactory {
         } else {
             return null;
         }
+    }
+
+    // TODO: Stop using TimestampType.getFormat.
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/935
+    private String getFormatFromTimestampTypeWithDepracationSuppressed(final TimestampType timestampType) {
+        return timestampType.getFormat();
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
@@ -22,7 +22,6 @@ import org.embulk.spi.util.dynamic.LongColumnSetter;
 import org.embulk.spi.util.dynamic.NullDefaultValueSetter;
 import org.embulk.spi.util.dynamic.StringColumnSetter;
 import org.embulk.spi.util.dynamic.TimestampColumnSetter;
-import org.joda.time.DateTimeZone;
 
 class DynamicColumnSetterFactory {
     private final DefaultValueSetter defaultValue;
@@ -111,10 +110,6 @@ class DynamicColumnSetterFactory {
         } else {
             return task.getDefaultTimeZoneId();
         }
-    }
-
-    private DateTimeZone getJodaDateTimeZone(Column column) {
-        return TimeZoneIds.parseJodaDateTimeZone(this.getTimeZoneId(column));
     }
 
     private DynamicPageBuilder.ColumnOption getColumnOption(Column column) {

--- a/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
@@ -15,7 +15,8 @@ public class PagePrinter {
     private final TimestampFormatter[] timestampFormatters;
     private final ArrayList<String> record;
 
-    @Deprecated  // To be removed by v0.10 or earlier.
+    // To be removed by v0.10 or earlier.
+    @Deprecated  // https://github.com/embulk/embulk/issues/937
     @SuppressWarnings("deprecation")
     public PagePrinter(final Schema schema, final DateTimeZone timezone) {
         this.schema = schema;
@@ -24,7 +25,8 @@ public class PagePrinter {
             if (schema.getColumnType(i) instanceof TimestampType) {
                 TimestampType type = (TimestampType) schema.getColumnType(i);
                 // Constructor of TimestampFormatter is deprecated.
-                timestampFormatters[i] = new TimestampFormatter(type.getFormat(), timezone);
+                timestampFormatters[i] = new TimestampFormatter(
+                        getFormatFromTimestampTypeWithDeprecationSuppressed(type), timezone);
             }
         }
 
@@ -40,7 +42,8 @@ public class PagePrinter {
         for (int i = 0; i < timestampFormatters.length; i++) {
             if (schema.getColumnType(i) instanceof TimestampType) {
                 TimestampType type = (TimestampType) schema.getColumnType(i);
-                timestampFormatters[i] = TimestampFormatter.of(type.getFormat(), timeZoneId);
+                timestampFormatters[i] = TimestampFormatter.of(
+                        getFormatFromTimestampTypeWithDeprecationSuppressed(type), timeZoneId);
             }
         }
 
@@ -108,5 +111,11 @@ public class PagePrinter {
         public void jsonColumn(Column column) {
             string = reader.getJson(column).toString();
         }
+    }
+
+    // TODO: Stop using TimestampType.getFormat.
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/935
+    private String getFormatFromTimestampTypeWithDeprecationSuppressed(final TimestampType timestampType) {
+        return timestampType.getFormat();
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
@@ -8,7 +8,6 @@ import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.type.TimestampType;
-import org.joda.time.DateTimeZone;
 
 public class PagePrinter {
     private final Schema schema;
@@ -18,7 +17,7 @@ public class PagePrinter {
     // To be removed by v0.10 or earlier.
     @Deprecated  // https://github.com/embulk/embulk/issues/937
     @SuppressWarnings("deprecation")
-    public PagePrinter(final Schema schema, final DateTimeZone timezone) {
+    public PagePrinter(final Schema schema, final org.joda.time.DateTimeZone timezone) {
         this.schema = schema;
         this.timestampFormatters = new TimestampFormatter[schema.getColumnCount()];
         for (int i = 0; i < timestampFormatters.length; i++) {

--- a/embulk-standards/src/test/java/org/embulk/standards/TestCsvFormatterPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestCsvFormatterPlugin.java
@@ -11,7 +11,6 @@ import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.Exec;
 import org.embulk.spi.util.Newline;
-import org.joda.time.DateTimeZone;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -32,7 +31,7 @@ public class TestCsvFormatterPlugin {
         assertEquals(CsvFormatterPlugin.QuotePolicy.MINIMAL, task.getQuotePolicy());
         assertEquals(false, task.getEscapeChar().isPresent());
         assertEquals("", task.getNullString());
-        assertEquals(DateTimeZone.UTC, task.getDefaultTimeZone());
+        assertEquals(org.joda.time.DateTimeZone.UTC, task.getDefaultTimeZone());
         assertEquals("%Y-%m-%d %H:%M:%S.%6N %z", task.getDefaultTimestampFormat());
         assertEquals(Newline.LF, task.getNewlineInField());
     }


### PR DESCRIPTION
@sakama @muga We're going to deprecate old unused things explicitly by the chance of v0.9. Do you have any other candidates to deprecate?

This PR enables the `-Xlint:deprecation` check, and annotates `@SuppressWarnings("deprecation")` explicitly, and comments with GitHub Issues, as well.