### PR TITLE
Use TimestampFormatter.of and TimestampParser.of instead of their constructors

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
@@ -63,8 +63,8 @@ class DynamicColumnSetterFactory {
         } else if (type instanceof DoubleType) {
             return new DoubleColumnSetter(pageBuilder, column, defaultValue);
         } else if (type instanceof StringType) {
-            TimestampFormatter formatter = new TimestampFormatter(
-                    getTimestampFormatForFormatter(column), getJodaDateTimeZone(column));
+            TimestampFormatter formatter = TimestampFormatter.of(
+                    getTimestampFormatForFormatter(column), getTimeZoneId(column));
             return new StringColumnSetter(pageBuilder, column, defaultValue, formatter);
         } else if (type instanceof TimestampType) {
             // TODO use flexible time format like Ruby's Time.parse
@@ -77,8 +77,8 @@ class DynamicColumnSetterFactory {
             }
             return new TimestampColumnSetter(pageBuilder, column, defaultValue, parser);
         } else if (type instanceof JsonType) {
-            TimestampFormatter formatter = new TimestampFormatter(
-                    getTimestampFormatForFormatter(column), getJodaDateTimeZone(column));
+            TimestampFormatter formatter = TimestampFormatter.of(
+                    getTimestampFormatForFormatter(column), getTimeZoneId(column));
             return new JsonColumnSetter(pageBuilder, column, defaultValue, formatter);
         }
         throw new ConfigException("Unknown column type: " + type);

--- a/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
@@ -15,13 +15,32 @@ public class PagePrinter {
     private final TimestampFormatter[] timestampFormatters;
     private final ArrayList<String> record;
 
+    @Deprecated  // To be removed by v0.10 or earlier.
+    @SuppressWarnings("deprecation")
     public PagePrinter(final Schema schema, final DateTimeZone timezone) {
         this.schema = schema;
         this.timestampFormatters = new TimestampFormatter[schema.getColumnCount()];
         for (int i = 0; i < timestampFormatters.length; i++) {
             if (schema.getColumnType(i) instanceof TimestampType) {
                 TimestampType type = (TimestampType) schema.getColumnType(i);
+                // Constructor of TimestampFormatter is deprecated.
                 timestampFormatters[i] = new TimestampFormatter(type.getFormat(), timezone);
+            }
+        }
+
+        this.record = new ArrayList<String>(schema.getColumnCount());
+        for (int i = 0; i < schema.getColumnCount(); i++) {
+            record.add("");
+        }
+    }
+
+    public PagePrinter(final Schema schema, final String timeZoneId) {
+        this.schema = schema;
+        this.timestampFormatters = new TimestampFormatter[schema.getColumnCount()];
+        for (int i = 0; i < timestampFormatters.length; i++) {
+            if (schema.getColumnType(i) instanceof TimestampType) {
+                TimestampType type = (TimestampType) schema.getColumnType(i);
+                timestampFormatters[i] = TimestampFormatter.of(type.getFormat(), timeZoneId);
             }
         }
 

--- a/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
@@ -23,7 +23,7 @@ public class Timestamps {
         for (ColumnConfig column : schema.getColumns()) {
             if (column.getType() instanceof TimestampType) {
                 TimestampColumnOption option = column.getOption().loadConfig(TimestampColumnOption.class);
-                parsers[i] = new TimestampParser(parserTask, option);
+                parsers[i] = TimestampParser.of(parserTask, option);
             }
             i++;
         }

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatterParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatterParser.java
@@ -24,7 +24,7 @@ public class TestTimestampFormatterParser {
                 .set("default_timestamp_format", "%Y-%m-%d %H:%M:%S.%9N %z");  // %Z is OS-dependent
         FormatterTestTask task = config.loadConfig(FormatterTestTask.class);
 
-        TimestampFormatter formatter = new TimestampFormatter(task, Optional.<TimestampFormatter.TimestampColumnOption>absent());
+        TimestampFormatter formatter = TimestampFormatter.of(task, Optional.<TimestampFormatter.TimestampColumnOption>absent());
         assertEquals("2014-11-19 02:46:29.123456000 +0000", formatter.format(Timestamp.ofEpochSecond(1416365189, 123456 * 1000)));
     }
 
@@ -44,7 +44,7 @@ public class TestTimestampFormatterParser {
                 .set("default_timestamp_format", "%s");
 
         FormatterTestTask ftask = config.loadConfig(FormatterTestTask.class);
-        TimestampFormatter formatter = new TimestampFormatter(ftask, Optional.<TimestampFormatter.TimestampColumnOption>absent());
+        TimestampFormatter formatter = TimestampFormatter.of(ftask, Optional.<TimestampFormatter.TimestampColumnOption>absent());
         assertEquals("1416365189", formatter.format(Timestamp.ofEpochSecond(1416365189)));
 
         ParserTestTask ptask = config.loadConfig(ParserTestTask.class);


### PR DESCRIPTION
The use of `TimestampFormatter.of` and `TimestampParser.of` was not thorough. This PR replaces almost all the constructor calls to `.of`.

@sakama @muga Can you have a look?