### PR TITLE
Log Embulk core's version when executing EmbulkEmbed: Fix #882

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -104,13 +104,14 @@ public class EmbulkEmbed {
     }
 
     private final LifeCycleInjector injector;
+    private final org.slf4j.Logger logger;
     private final BulkLoader bulkLoader;
     private final GuessExecutor guessExecutor;
     private final PreviewExecutor previewExecutor;
 
     EmbulkEmbed(ConfigSource systemConfig, LifeCycleInjector injector) {
         this.injector = injector;
-        injector.getInstance(org.slf4j.ILoggerFactory.class);
+        this.logger = injector.getInstance(org.slf4j.ILoggerFactory.class).getLogger(EmbulkEmbed.class.getName());
         this.bulkLoader = injector.getInstance(BulkLoader.class);
         this.guessExecutor = injector.getInstance(GuessExecutor.class);
         this.previewExecutor = injector.getInstance(PreviewExecutor.class);
@@ -133,6 +134,7 @@ public class EmbulkEmbed {
     }
 
     public ConfigDiff guess(ConfigSource config) {
+        this.logger.info("Started Embulk v" + EmbulkVersion.VERSION);
         ExecSession exec = newExecSession(config);
         try {
             return guessExecutor.guess(exec, config);
@@ -142,6 +144,7 @@ public class EmbulkEmbed {
     }
 
     public PreviewResult preview(ConfigSource config) {
+        this.logger.info("Started Embulk v" + EmbulkVersion.VERSION);
         ExecSession exec = newExecSession(config);
         try {
             return previewExecutor.preview(exec, config);
@@ -151,6 +154,7 @@ public class EmbulkEmbed {
     }
 
     public ExecutionResult run(ConfigSource config) {
+        this.logger.info("Started Embulk v" + EmbulkVersion.VERSION);
         ExecSession exec = newExecSession(config);
         try {
             return bulkLoader.run(exec, config);
@@ -173,6 +177,7 @@ public class EmbulkEmbed {
     }
 
     public ResumableResult runResumable(ConfigSource config) {
+        this.logger.info("Started Embulk v" + EmbulkVersion.VERSION);
         ExecSession exec = newExecSession(config);
         try {
             ExecutionResult result;
@@ -199,6 +204,7 @@ public class EmbulkEmbed {
     }
 
     public ResumeStateAction resumeState(ConfigSource config, ConfigSource resumeStateConfig) {
+        this.logger.info("Started Embulk v" + EmbulkVersion.VERSION);
         ResumeState resumeState = resumeStateConfig.loadConfig(ResumeState.class);
         return new ResumeStateAction(config, resumeState);
     }


### PR DESCRIPTION
This tries to address #882 -- logging Embulk's version when executing some methods of `EmbulkEmbed`. Can you have a look? @muga @sakama

The execution log would be like below:

```
2018-01-25 16:07:53.768 +0900 [INFO] (main): BUNDLE_GEMFILE is being set: "/.../Gemfile"
2018-01-25 16:07:53.771 +0900 [INFO] (main): Gem's home and path are being cleared.
2018-01-25 16:07:56.048 +0900 [INFO] (main): Started Embulk v0.9.0-SNAPSHOT
2018-01-25 16:07:56.139 +0900 [INFO] (0001:transaction): Loaded plugin embulk-input-inline (0.1.0)
```
