### PR TITLE
Customize byte size of sample buffer that GuessParserPlugin tries to read

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
@@ -122,12 +122,12 @@ public class GuessExecutor {
         GuessExecutorTask task = execConfig.loadConfig(GuessExecutorTask.class);
         guessPlugins.addAll(task.getGuessPlugins());
         guessPlugins.removeAll(task.getExcludeGuessPlugins());
-        final int parserSampleBufferBytes = task.getSampleBufferBytes();
+        final int guessParserSampleBufferBytes = task.getSampleBufferBytes();
 
-        return guessParserConfig(sample, inputConfig, guessPlugins, parserSampleBufferBytes);
+        return guessParserConfig(sample, inputConfig, guessPlugins, guessParserSampleBufferBytes);
     }
 
-    private ConfigDiff guessParserConfig(Buffer sample, ConfigSource config, List<PluginType> guessPlugins, final int parserSampleBufferBytes) {
+    private ConfigDiff guessParserConfig(Buffer sample, ConfigSource config, List<PluginType> guessPlugins, final int guessParserSampleBufferBytes) {
         // repeat guessing upto 10 times
         ConfigDiff lastGuessed = Exec.newConfigDiff();
         for (int i = 0; i < 10; i++) {
@@ -138,7 +138,7 @@ public class GuessExecutor {
                     .set("type", "system_guess")  // override in.parser.type so that FileInputRunner.run uses GuessParserPlugin
                     .set("guess_plugins", guessPlugins)
                     .set("orig_config", originalConfig)
-                    .set("parser_sample_buffer_bytes", parserSampleBufferBytes);
+                    .set("guess_parser_sample_buffer_bytes", guessParserSampleBufferBytes);
 
             // run FileInputPlugin
             final FileInputRunner input = new FileInputRunner(new BufferFileInputPlugin(sample));
@@ -190,8 +190,8 @@ public class GuessExecutor {
             @Config("orig_config")
             public ConfigSource getOriginalConfig();
 
-            @Config("parser_sample_buffer_bytes")
-            public int getParserSampleBufferBytes();
+            @Config("guess_parser_sample_buffer_bytes")
+            public int getGuessParserSampleBufferBytes();
         }
 
         @Override
@@ -204,10 +204,10 @@ public class GuessExecutor {
         public void run(TaskSource taskSource, Schema schema, FileInput input, PageOutput pageOutput) {
             PluginTask task = taskSource.loadTask(PluginTask.class);
             final ConfigSource originalConfig = task.getOriginalConfig();
-            final int parserSampleBufferBytes = task.getParserSampleBufferBytes();
+            final int guessParserSampleBufferBytes = task.getGuessParserSampleBufferBytes();
 
             // get sample buffer
-            Buffer sample = readSample(input, parserSampleBufferBytes);
+            Buffer sample = readSample(input, guessParserSampleBufferBytes);
 
             // load guess plugins
             ImmutableList.Builder<GuessPlugin> builder = ImmutableList.builder();

--- a/embulk-docs/src/release/release-0.9.0.rst
+++ b/embulk-docs/src/release/release-0.9.0.rst
@@ -86,6 +86,7 @@ General Changes
 * Guess plugins for standard plugins has been moved to ``embulk-standards``.
 * New ``ruby:`` prefixed timestamp format is added.
 * New ``java:`` prefixed timestamp format is added as experimental.
+* Fix ``guess_sample_buffer_bytes`` option so that it enables ``GuessParserPlugin`` to read sample buffer customized by users.
 
 
 Release Date


### PR DESCRIPTION
This PR enables customizing byte size of sample buffer that `GuessParserPlugin` can tries to read. In #609, `guess_sample_buffer_bytes` option was introduced to custom byte size of sample buffer but, in the case of #788, the option could not work expectedly. #609 enables configuring sample buffer bytes for `GuessExecutor` but, `GuessParserPlugin` still tries to read default bytes 32KB that is not configurable by #609. This PR could configure for the sample buffer bytes. 

In this PR, to pass the custom value of `guess_sample_buffer_bytes` option in `GuessExecutor` to `GuessParserPlugin`, `parser_sample_buffer_bytes` option is introduced. Basically `parser_sample_buffer_bytes` value should be same as `guess_sample_buffer_bytes`. 

It fixes https://github.com/embulk/embulk/issues/788. 