### PR TITLE
Allow the same @Config configuration names: Fix #949

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/TaskInvocationHandler.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskInvocationHandler.java
@@ -1,6 +1,7 @@
 package org.embulk.config;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
@@ -24,10 +25,12 @@ class TaskInvocationHandler implements InvocationHandler {
     }
 
     /**
-     * fieldName = Method of the getter
+     * Returns a Multimap from fieldName Strings to their getter Methods.
+     *
+     * It expects to be called only from TaskSerDe. Multimap is used inside org.embulk.config.
      */
-    public static Map<String, Method> fieldGetters(Class<?> iface) {
-        ImmutableMap.Builder<String, Method> builder = ImmutableMap.builder();
+    static Multimap<String, Method> fieldGetters(Class<?> iface) {
+        ImmutableMultimap.Builder<String, Method> builder = ImmutableMultimap.builder();
         for (Method method : iface.getMethods()) {
             String methodName = method.getName();
             String fieldName = getterFieldNameOrNull(methodName);

--- a/embulk-core/src/main/java/org/embulk/config/TaskSerDe.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskSerDe.java
@@ -154,7 +154,14 @@ class TaskSerDe {
                             throw new JsonMappingException("Setting null to a task field is not allowed. Use Optional<T> (com.google.common.base.Optional) to represent null.");
                         }
                         objects.put(field.getName(), value);
-                        unusedMappings.remove(key, field);
+                        if (!unusedMappings.remove(key, field)) {
+                            throw new JsonMappingException(String.format(
+                                    "FATAL: Expected to be a bug in Embulk. Mapping \"%s: (%s) %s\" might have already been processed, or not in %s.",
+                                    key,
+                                    field.getType().toString(),
+                                    field.getName(),
+                                    this.iface.toString()));
+                        }
                     }
                 }
             }

--- a/embulk-core/src/main/java/org/embulk/config/TaskSerDe.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskSerDe.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -146,8 +147,9 @@ class TaskSerDe {
                 if (fields.isEmpty()) {
                     jp.skipChildren();
                 } else {
+                    final JsonNode children = nestedObjectMapper.readValue(jp, JsonNode.class);
                     for (final FieldEntry field : fields) {
-                        final Object value = nestedObjectMapper.readValue(jp, new GenericTypeReference(field.getType()));
+                        final Object value = nestedObjectMapper.convertValue(children, new GenericTypeReference(field.getType()));
                         if (value == null) {
                             throw new JsonMappingException("Setting null to a task field is not allowed. Use Optional<T> (com.google.common.base.Optional) to represent null.");
                         }


### PR DESCRIPTION
This PR is a trial to fix #949, but it changes the behavior of `@Config`. It allows to have duplicated configuration names of `@Config("name")`.

Can I have your thoughts, @muga, @sakama?