### PR TITLE
Fix StdoutOutputPlugin broken by stopping @Config indirection by default implementation at: #956

### DIFF
--- a/embulk-docs/src/release/release-0.9.1.rst
+++ b/embulk-docs/src/release/release-0.9.1.rst
@@ -6,7 +6,7 @@ General Changes
 
 * Fix .pom files of embulk-core and embulk-standards which didn't contain dependencies. [#953] [#955]
 * Fix error messages when plugins are not found. [#943] [#948]
-* Allow duplicated @Config confugration names. [#949] [#951] [#956]
+* Allow duplicated @Config confugration names. [#949] [#951] [#956] [#960]
 
 
 Release Date

--- a/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
@@ -26,13 +26,9 @@ public class StdoutOutputPlugin implements OutputPlugin {
         // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
         // It won't be removed very soon at least until Embulk v0.10.
         @Deprecated
-        public default org.joda.time.DateTimeZone getTimeZone() {
-            if (getTimeZoneId() != null) {
-                return TimeZoneIds.parseJodaDateTimeZone(getTimeZoneId());
-            } else {
-                return null;
-            }
-        }
+        @Config("timezone")
+        @ConfigDefault("\"UTC\"")
+        public org.joda.time.DateTimeZone getTimeZone();
     }
 
     @Override

--- a/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
@@ -14,7 +14,6 @@ import org.embulk.spi.Page;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
-import org.embulk.spi.time.TimeZoneIds;
 import org.embulk.spi.util.PagePrinter;
 
 public class StdoutOutputPlugin implements OutputPlugin {


### PR DESCRIPTION
The default implementation has been introduced at: #931, and it's to be a kind of reverted as well in addition to #956.

@sakama @muga Can you have a look?