### PR TITLE
Load non-JRuby plugins without JRuby by deprioritizing JRuby-based plugins

### DIFF
--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyPluginSource.java
@@ -1,6 +1,5 @@
 package org.embulk.jruby;
 
-import com.google.inject.Inject;
 import org.embulk.plugin.PluginSource;
 import org.embulk.plugin.PluginSourceNotMatchException;
 import org.embulk.plugin.PluginType;
@@ -16,17 +15,9 @@ import org.embulk.spi.ParserPlugin;
 
 public class JRubyPluginSource implements PluginSource {
     private final ScriptingContainerDelegate jruby;
-    private final Object rubyPluginManager;
 
-    @Inject
     public JRubyPluginSource(ScriptingContainerDelegate jruby) {
         this.jruby = jruby;
-
-        // get Embulk::Plugin
-        //this.rubyPluginManager = ((RubyModule) jruby.get("Embulk")).const_get(
-        //        RubySymbol.newSymbol(
-        //            jruby.getProvider().getRuntime(), "Plugin"));
-        this.rubyPluginManager = jruby.runScriptlet("Embulk::Plugin");
     }
 
     public <T> T newPlugin(Class<T> iface, PluginType type) throws PluginSourceNotMatchException {
@@ -62,6 +53,11 @@ public class JRubyPluginSource implements PluginSource {
 
         String methodName = "new_java_" + category;
         try {
+            // get Embulk::Plugin
+            //this.rubyPluginManager = ((RubyModule) jruby.get("Embulk")).const_get(
+            //        RubySymbol.newSymbol(
+            //            jruby.getProvider().getRuntime(), "Plugin"));
+            final Object rubyPluginManager = jruby.runScriptlet("Embulk::Plugin");
             return jruby.callMethod(rubyPluginManager, methodName, name, iface);
         } catch (JRubyInvokeFailedException ex) {
             throw new PluginSourceNotMatchException(ex.getCause().getCause());

--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
@@ -7,7 +7,6 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.ProvisionException;
 import com.google.inject.Scopes;
-import com.google.inject.multibindings.Multibinder;
 import com.google.inject.spi.Dependency;
 import com.google.inject.spi.ProviderWithDependencies;
 import java.util.ArrayList;
@@ -18,7 +17,6 @@ import java.util.Set;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.ModelManager;
 import org.embulk.exec.ForSystemConfig;
-import org.embulk.plugin.PluginSource;
 import org.embulk.spi.BufferAllocator;
 import org.slf4j.ILoggerFactory;
 
@@ -28,9 +26,6 @@ public class JRubyScriptingModule implements Module {
     @Override
     public void configure(Binder binder) {
         binder.bind(ScriptingContainerDelegate.class).toProvider(ScriptingContainerProvider.class).in(Scopes.SINGLETON);
-
-        Multibinder<PluginSource> multibinder = Multibinder.newSetBinder(binder, PluginSource.class);
-        multibinder.addBinding().to(JRubyPluginSource.class);
     }
 
     private static class ScriptingContainerProvider

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginManager.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginManager.java
@@ -7,11 +7,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.embulk.config.ConfigException;
+import org.embulk.jruby.JRubyPluginSource;
+import org.embulk.jruby.ScriptingContainerDelegate;
 import org.embulk.plugin.compat.PluginWrappers;
 import org.embulk.spi.InputPlugin;
 
 public class PluginManager {
     private final List<PluginSource> sources;
+    private final JRubyPluginSource jrubySource;
     private final Injector injector;
 
     // Set<PluginSource> is injected by BuiltinPluginSourceModule or extensions
@@ -19,6 +22,7 @@ public class PluginManager {
     @Inject
     public PluginManager(Set<PluginSource> pluginSources, Injector injector) {
         this.sources = ImmutableList.copyOf(pluginSources);
+        this.jrubySource = new JRubyPluginSource(injector.getInstance(ScriptingContainerDelegate.class));
         this.injector = injector;
     }
 
@@ -49,6 +53,12 @@ public class PluginManager {
             } catch (PluginSourceNotMatchException e) {
                 exceptions.add(e);
             }
+        }
+
+        try {
+            return this.jrubySource.newPlugin(iface, type);
+        } catch (PluginSourceNotMatchException e) {
+            exceptions.add(e);
         }
 
         throw buildPluginNotFoundException(iface, type, exceptions);


### PR DESCRIPTION
Finally! It makes Embulk's startup really fast when JRuby-based plugins are not used.

@sakama @muga Can you have a look?

It stops using Guice for `JRubyPluginSource`. Much controversy may exist over using DI (Guice), but  I think we may want to use Guice less in Embulk...