### PR TITLE
Revert "Remove @Config indirection by default implemantations": Fix #964

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/TaskInvocationHandler.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskInvocationHandler.java
@@ -2,6 +2,8 @@ package org.embulk.config;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -32,7 +34,9 @@ class TaskInvocationHandler implements InvocationHandler {
         for (Method method : iface.getMethods()) {
             String methodName = method.getName();
             String fieldName = getterFieldNameOrNull(methodName);
-            if (fieldName != null && hasExpectedArgumentLength(method, 0)) {
+            if (fieldName != null && hasExpectedArgumentLength(method, 0)
+                    && (!method.isDefault() || method.getAnnotation(Config.class) != null)) {
+                // If the method has default implementation, and @Config is not annotated there, the method is kept.
                 builder.put(fieldName, method);
             }
         }
@@ -122,6 +126,52 @@ class TaskInvocationHandler implements InvocationHandler {
                 String fieldName;
                 fieldName = getterFieldNameOrNull(methodName);
                 if (fieldName != null) {
+                    if (method.isDefault() && !this.objects.containsKey(fieldName)) {
+                        // If and only if the method has default implementation, and @Config is not annotated there,
+                        // it is tried to call the default implementation directly without proxying.
+                        //
+                        // methodWithDefaultImpl.invoke(proxy) without this hack would cause infinite recursive calls.
+                        //
+                        // See hints:
+                        // https://rmannibucau.wordpress.com/2014/03/27/java-8-default-interface-methods-and-jdk-dynamic-proxies/
+                        // https://stackoverflow.com/questions/22614746/how-do-i-invoke-java-8-default-methods-reflectively
+                        //
+                        // This hack is required to support `org.joda.time.DateTimeZone` in some Tasks, for example
+                        // TimestampParser.Task and TimestampParser.TimestampColumnOption.
+                        //
+                        // TODO: Remove the hack once a cleaner way is found, or Joda-Time is finally removed.
+                        // https://github.com/embulk/embulk/issues/890
+                        if (CONSTRUCTOR_MethodHandles_Lookup != null) {
+                            synchronized (CONSTRUCTOR_MethodHandles_Lookup) {
+                                boolean hasSetAccessible = false;
+                                try {
+                                    CONSTRUCTOR_MethodHandles_Lookup.setAccessible(true);
+                                    hasSetAccessible = true;
+                                } catch (SecurityException ex) {
+                                    // Skip handling default implementation in case of errors.
+                                }
+
+                                if (hasSetAccessible) {
+                                    try {
+                                        return CONSTRUCTOR_MethodHandles_Lookup
+                                                .newInstance(
+                                                        method.getDeclaringClass(),
+                                                        MethodHandles.Lookup.PUBLIC
+                                                                | MethodHandles.Lookup.PRIVATE
+                                                                | MethodHandles.Lookup.PROTECTED
+                                                                | MethodHandles.Lookup.PACKAGE)
+                                                .unreflectSpecial(method, method.getDeclaringClass())
+                                                .bindTo(proxy)
+                                                .invokeWithArguments();
+                                    } catch (Throwable ex) {
+                                        // Skip handling default implementation in case of errors.
+                                    } finally {
+                                        CONSTRUCTOR_MethodHandles_Lookup.setAccessible(false);
+                                    }
+                                }
+                            }
+                        }
+                    }
                     checkArgumentLength(method, 0, methodName);
                     return invokeGetter(method, fieldName);
                 }
@@ -161,4 +211,18 @@ class TaskInvocationHandler implements InvocationHandler {
                     String.format("Method '%s' expected %d argument but got %d arguments", methodName, expected, method.getParameterTypes().length));
         }
     }
+
+    static {
+        Constructor<MethodHandles.Lookup> constructorMethodHandlesLookupTemporary = null;
+        try {
+            constructorMethodHandlesLookupTemporary =
+                    MethodHandles.Lookup.class.getDeclaredConstructor(Class.class, int.class);
+        } catch (NoSuchMethodException | SecurityException ex) {
+            constructorMethodHandlesLookupTemporary = null;
+        } finally {
+            CONSTRUCTOR_MethodHandles_Lookup = constructorMethodHandlesLookupTemporary;
+        }
+    }
+
+    private static final Constructor<MethodHandles.Lookup> CONSTRUCTOR_MethodHandles_Lookup;
 }

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
@@ -104,9 +104,13 @@ public class TimestampFormatter {
         // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
         // It won't be removed very soon at least until Embulk v0.10.
         @Deprecated
-        @Config("default_timezone")
-        @ConfigDefault("\"UTC\"")
-        public org.joda.time.DateTimeZone getDefaultTimeZone();
+        public default org.joda.time.DateTimeZone getDefaultTimeZone() {
+            if (getDefaultTimeZoneId() != null) {
+                return TimeZoneIds.parseJodaDateTimeZone(getDefaultTimeZoneId());
+            } else {
+                return null;
+            }
+        }
 
         @Config("default_timestamp_format")
         @ConfigDefault("\"%Y-%m-%d %H:%M:%S.%6N %z\"")
@@ -121,9 +125,13 @@ public class TimestampFormatter {
         // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
         // It won't be removed very soon at least until Embulk v0.10.
         @Deprecated
-        @Config("timezone")
-        @ConfigDefault("null")
-        public Optional<org.joda.time.DateTimeZone> getTimeZone();
+        public default Optional<org.joda.time.DateTimeZone> getTimeZone() {
+            if (getTimeZoneId().isPresent()) {
+                return Optional.of(TimeZoneIds.parseJodaDateTimeZone(getTimeZoneId().get()));
+            } else {
+                return Optional.absent();
+            }
+        }
 
         @Config("format")
         @ConfigDefault("null")

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
@@ -164,9 +164,13 @@ public class TimestampParser {
         // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
         // It won't be removed very soon at least until Embulk v0.10.
         @Deprecated
-        @Config("default_timezone")
-        @ConfigDefault("\"UTC\"")
-        public org.joda.time.DateTimeZone getDefaultTimeZone();
+        public default org.joda.time.DateTimeZone getDefaultTimeZone() {
+            if (getDefaultTimeZoneId() != null) {
+                return TimeZoneIds.parseJodaDateTimeZone(getDefaultTimeZoneId());
+            } else {
+                return null;
+            }
+        }
 
         @Config("default_timestamp_format")
         @ConfigDefault("\"%Y-%m-%d %H:%M:%S.%N %z\"")
@@ -185,7 +189,13 @@ public class TimestampParser {
         // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
         // It won't be removed very soon at least until Embulk v0.10.
         @Deprecated
-        public Optional<org.joda.time.DateTimeZone> getTimeZone();
+        public default Optional<org.joda.time.DateTimeZone> getTimeZone() {
+            if (getTimeZoneId().isPresent()) {
+                return Optional.of(TimeZoneIds.parseJodaDateTimeZone(getTimeZoneId().get()));
+            } else {
+                return Optional.absent();
+            }
+        }
 
         @Config("format")
         @ConfigDefault("null")

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicPageBuilder.java
@@ -14,6 +14,7 @@ import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
+import org.embulk.spi.time.TimeZoneIds;
 import org.embulk.spi.util.dynamic.SkipColumnSetter;
 
 public class DynamicPageBuilder implements AutoCloseable {
@@ -30,9 +31,13 @@ public class DynamicPageBuilder implements AutoCloseable {
         // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
         // It won't be removed very soon at least until Embulk v0.10.
         @Deprecated
-        @Config("default_timezone")
-        @ConfigDefault("\"UTC\"")
-        public org.joda.time.DateTimeZone getDefaultTimeZone();
+        public default org.joda.time.DateTimeZone getDefaultTimeZone() {
+            if (getDefaultTimeZoneId() != null) {
+                return TimeZoneIds.parseJodaDateTimeZone(getDefaultTimeZoneId());
+            } else {
+                return null;
+            }
+        }
 
         @Config("column_options")
         @ConfigDefault("{}")
@@ -49,9 +54,9 @@ public class DynamicPageBuilder implements AutoCloseable {
         // org.embulk.spi.time.TimestampFormat is deprecated, but the getter returns TimestampFormat for compatibility.
         // It won't be removed very soon at least until Embulk v0.10.
         @Deprecated
-        @Config("timestamp_format")
-        @ConfigDefault("\"%Y-%m-%d %H:%M:%S.%N\"")
-        public org.embulk.spi.time.TimestampFormat getTimestampFormat();
+        public default org.embulk.spi.time.TimestampFormat getTimestampFormat() {
+            return new org.embulk.spi.time.TimestampFormat(getTimestampFormatString());
+        }
 
         @Config("timezone")
         @ConfigDefault("null")
@@ -60,9 +65,13 @@ public class DynamicPageBuilder implements AutoCloseable {
         // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
         // It won't be removed very soon at least until Embulk v0.10.
         @Deprecated
-        @Config("timezone")
-        @ConfigDefault("null")
-        public Optional<org.joda.time.DateTimeZone> getTimeZone();
+        public default Optional<org.joda.time.DateTimeZone> getTimeZone() {
+            if (getTimeZoneId().isPresent()) {
+                return Optional.of(TimeZoneIds.parseJodaDateTimeZone(getTimeZoneId().get()));
+            } else {
+                return Optional.absent();
+            }
+        }
     }
 
     private DynamicPageBuilder(

--- a/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
@@ -14,6 +14,7 @@ import org.embulk.spi.Page;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
+import org.embulk.spi.time.TimeZoneIds;
 import org.embulk.spi.util.PagePrinter;
 
 public class StdoutOutputPlugin implements OutputPlugin {

--- a/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StdoutOutputPlugin.java
@@ -26,9 +26,13 @@ public class StdoutOutputPlugin implements OutputPlugin {
         // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
         // It won't be removed very soon at least until Embulk v0.10.
         @Deprecated
-        @Config("timezone")
-        @ConfigDefault("\"UTC\"")
-        public org.joda.time.DateTimeZone getTimeZone();
+        public default org.joda.time.DateTimeZone getTimeZone() {
+            if (getTimeZoneId() != null) {
+                return TimeZoneIds.parseJodaDateTimeZone(getTimeZoneId());
+            } else {
+                return null;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
The removal in v0.9.1 did not work perfectly as reported in #964... Reverting the removal would fix the issue.

@sakama @muga Can you have a look?