### PR TITLE
Accept "embulk bundle --version" to run "bundle --version"

### DIFF
--- a/embulk-core/src/main/java/org/embulk/cli/EmbulkArguments.java
+++ b/embulk-core/src/main/java/org/embulk/cli/EmbulkArguments.java
@@ -20,9 +20,9 @@ public class EmbulkArguments {
                 subcommand = EmbulkSubcommand.of(argument);
             } else if (subcommand == null && (argument.equals("-b") || argument.equals("--bundle"))) {
                 throw new EmbulkCommandLineException("\"-b\" or \"--bundle\" before a subcommand is not supported.");
-            } else if (argument.equals("-version")) {
+            } else if (subcommand == null && argument.equals("-version")) {
                 return new EmbulkArguments(EmbulkSubcommand.VERSION_ERR, new ArrayList<String>());
-            } else if (argument.equals("--version")) {
+            } else if (subcommand == null && argument.equals("--version")) {
                 return new EmbulkArguments(EmbulkSubcommand.VERSION_OUT, new ArrayList<String>());
             } else {
                 subcommandArguments.add(argument);


### PR DESCRIPTION
A small fix. Until v0.9.4, `embulk bundle --version` has been considered the same as `embulk --version`. We has had no way to show Bundler's versions. This PR fixes it.

Can you have a look?