### PR TITLE
Show test logs in standard streams

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,10 @@ configure(subprojects.findAll { ['embulk-core', 'embulk-standards', 'embulk-test
 
     tasks.withType(Test) {
         systemProperties System.properties.findAll { it.key.startsWith("org.embulk") }
+        testLogging {
+            outputs.upToDateWhen { false }
+            showStandardStreams = true
+        }
     }
 
     tasks.withType(Checkstyle) {


### PR DESCRIPTION
To see test outputs not only in report html pages, but also in standard output/error in real time.