### PR TITLE
[WIP] Implement Fluentd Reporter plugin

### DIFF
--- a/embulk-standards/build.gradle
+++ b/embulk-standards/build.gradle
@@ -28,6 +28,7 @@ repositories {
 dependencies {
     compile project(':embulk-core')
     compile 'org.apache.commons:commons-compress:1.10'
+    compile ('org.komamitsu:fluency:1.7.0') { exclude module: 'msgpack-core' }
 
     testCompile 'junit:junit:4.12'
     testCompile project(':embulk-core').sourceSets.test.output

--- a/embulk-standards/src/main/java/org/embulk/standards/FluentdReporterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/FluentdReporterPlugin.java
@@ -1,0 +1,83 @@
+package org.embulk.standards;
+
+import org.embulk.config.Config;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.Task;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.AbstractReporterImpl;
+import org.embulk.spi.ReporterPlugin;
+import org.komamitsu.fluency.EventTime;
+import org.komamitsu.fluency.Fluency;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+import java.util.Map;
+
+public class FluentdReporterPlugin
+        implements ReporterPlugin {
+//    public interface PluginTask {
+//        @Config("max_buffer_size")
+//        String getMaxBufferSize();
+//    }
+
+    @Override
+    public TaskSource configureTaskSource(final ConfigSource config) {
+        return config.loadConfig(Task.class).dump();
+    }
+
+    @Override
+    public AbstractReporterImpl open(final TaskSource taskSource) {
+        this.fluentd = create(taskSource);
+        return new FluentdReporterImpl();
+    }
+
+    @ThreadSafe
+    private static class FluentdReporterImpl
+            extends AbstractReporterImpl {
+        @Override
+        public void report(Level level, Map<String, Object> event) {
+            // TODO
+            String tag = "skip";
+            // TODO
+            EventTime eventTime = EventTime.fromEpochMilli(System.currentTimeMillis());
+            try {
+                fluentd.emit(tag, eventTime, event);
+            } catch (IOException ex) {
+                // TODO
+            }
+        }
+
+        @Override
+        public void close() {
+            try {
+                fluentd.flush();
+                fluentd.close();
+            } catch (IOException ex) {
+                // TODO
+            }
+        }
+
+        @Override
+        public void cleanup() {
+            fluentd.clearBackupFiles();
+        }
+    }
+
+    private Fluency create(final TaskSource taskSource) {
+        //PluginTask task = taskSource.loadTask(PluginTask.class);
+        Fluency fluency = null;
+        try {
+            fluency = Fluency.defaultFluency(
+                new Fluency.Config()
+                        .setBufferChunkInitialSize(4 * 1024 * 1024)
+                        .setBufferChunkRetentionSize(16 * 1024 * 1024)
+                        .setMaxBufferSize(256 * 1024 * 1024L)
+            );
+        } catch (IOException ex) {
+            // TODO
+        }
+        return fluency;
+    }
+
+    private static Fluency fluentd;
+}

--- a/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
@@ -51,6 +51,7 @@ public class StandardPluginModule implements Module {
 
         // reporter plugins
         registerPluginTo(binder, ReporterPlugin.class, "null", NullReporterPlugin.class);
+        registerPluginTo(binder, ReporterPlugin.class, "fluentd", FluentdReporterPlugin.class);
 
         // default guess plugins
         registerDefaultGuessPluginTo(binder, DefaultPluginType.create("gzip"));


### PR DESCRIPTION
Implemented Fluentd Reporter plugin based on #984 

### Requirements

Jackson update in embulk-core is required.
https://github.com/embulk/embulk/blob/master/embulk-core/build.gradle#L43-L48

Fluency 1.7.0 is using Jackson 2.7.1 but embulk-core is using 2.6.7.
I couldn't run without updating Jackson.