### PR TITLE
[WIP] Implemnt API to register external Reporter plugin

### DIFF
--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyPluginSource.java
@@ -12,6 +12,7 @@ import org.embulk.spi.GuessPlugin;
 import org.embulk.spi.InputPlugin;
 import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.ParserPlugin;
+import org.embulk.spi.ReporterPlugin;
 
 public class JRubyPluginSource implements PluginSource {
     private final ScriptingContainerDelegate jruby;
@@ -42,6 +43,8 @@ public class JRubyPluginSource implements PluginSource {
             category = "encoder";
         } else if (FilterPlugin.class.isAssignableFrom(iface)) {
             category = "filter";
+        } else if (ReporterPlugin.class.isAssignableFrom(iface)) {
+            category = "reporter";
         } else if (GuessPlugin.class.isAssignableFrom(iface)) {
             category = "guess";
         } else if (ExecutorPlugin.class.isAssignableFrom(iface)) {

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
@@ -26,6 +26,7 @@ import org.embulk.spi.GuessPlugin;
 import org.embulk.spi.InputPlugin;
 import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.ParserPlugin;
+import org.embulk.spi.ReporterPlugin;
 
 public class MavenPluginSource implements PluginSource {
     @Inject
@@ -52,6 +53,8 @@ public class MavenPluginSource implements PluginSource {
             category = "encoder";
         } else if (FilterPlugin.class.isAssignableFrom(pluginInterface)) {
             category = "filter";
+        } else if (ReporterPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "reporter";
         } else if (GuessPlugin.class.isAssignableFrom(pluginInterface)) {
             category = "guess";
         } else if (ExecutorPlugin.class.isAssignableFrom(pluginInterface)) {

--- a/embulk-core/src/main/ruby/embulk/java/imports.rb
+++ b/embulk-core/src/main/ruby/embulk/java/imports.rb
@@ -50,6 +50,7 @@ module Embulk::Java
   java_import 'org.embulk.spi.GuessPlugin'
   java_import 'org.embulk.spi.OutputPlugin'
   java_import 'org.embulk.spi.FilterPlugin'
+  java_import 'org.embulk.spi.ReporterPlugin'
   java_import 'org.embulk.spi.InputPlugin'
   java_import 'org.embulk.spi.ParserPlugin'
   java_import 'org.embulk.spi.FormatterPlugin'

--- a/embulk-core/src/main/ruby/embulk/java_plugin.rb
+++ b/embulk-core/src/main/ruby/embulk/java_plugin.rb
@@ -25,6 +25,11 @@ module Embulk
       Plugin.register_java_filter(name, java_class)
     end
 
+    def self.register_reporter(name, class_fqdn, jar_dir)
+      java_class = classloader(jar_dir).loadClass(class_fqdn)
+      Plugin.register_java_reporter(name, java_class)
+    end
+
     def self.register_parser(name, class_fqdn, jar_dir)
       java_class = classloader(jar_dir).loadClass(class_fqdn)
       Plugin.register_java_parser(name, java_class)

--- a/embulk-core/src/main/ruby/embulk/plugin.rb
+++ b/embulk-core/src/main/ruby/embulk/plugin.rb
@@ -8,6 +8,7 @@ module Embulk
   require 'embulk/output_plugin'
   require 'embulk/file_output_plugin'
   require 'embulk/filter_plugin'
+  require 'embulk/reporter_plugin'
   require 'embulk/parser_plugin'
   require 'embulk/formatter_plugin'
   require 'embulk/decoder_plugin'
@@ -20,7 +21,7 @@ module Embulk
   class PluginManager
     def initialize
       @registries = {}
-      %w[input output parser formatter decoder encoder line_filter filter guess executor].each do |category|
+      %w[input output parser formatter decoder encoder line_filter filter reporter guess executor].each do |category|
         @registries[category.to_sym] = PluginRegistry.new(category, "embulk/#{category}/")
       end
     end
@@ -37,6 +38,11 @@ module Embulk
     def register_filter(type, klass)
       register_plugin(:filter, type, klass, FilterPlugin)
     end
+
+    ## TODO ReporterPlugin JRuby API is not written by anyone yet
+    # def register_reporter(type, klass)
+    #   register_plugin(:reporter, type, klass, FilterPlugin)
+    # end
 
     def register_parser(type, klass)
       register_plugin(:parser, type, klass, ParserPlugin)
@@ -74,6 +80,11 @@ module Embulk
     # TODO FilterPlugin::RubyAdapter is not written by anyone yet
     #def get_filter(type)
     #  lookup(:filter, type)
+    #end
+
+    # TODO ReporterPlugin::RubyAdapter is not written by anyone yet
+    #def get_reporter(type)
+    #  lookup(:reporter, type)
     #end
 
     # TODO FilterPlugin::RubyAdapter is not written by anyone yet
@@ -121,6 +132,11 @@ module Embulk
                            "org.embulk.spi.FilterPlugin" => FilterPlugin)
     end
 
+    def register_java_reporter(type, klass)
+      register_java_plugin(:reporter, type, klass,
+                           "org.embulk.spi.ReporterPlugin" => ReporterPlugin)
+    end
+
     def register_java_parser(type, klass)
       register_java_plugin(:parser, type, klass,
                            "org.embulk.spi.ParserPlugin" => ParserPlugin)
@@ -161,6 +177,10 @@ module Embulk
 
     def new_java_filter(type)
       lookup(:filter, type).new_java
+    end
+
+    def new_java_reporter(type)
+      lookup(:reporter, type).new_java
     end
 
     def new_java_parser(type)
@@ -229,6 +249,7 @@ module Embulk
         :register_input, :get_input, :register_java_input, :new_java_input,
         :register_output, :get_output, :register_java_output, :new_java_output,
         :register_filter, :get_filter, :register_java_filter, :new_java_filter,
+        :register_reporter, :get_reporter, :register_java_reporter, :new_java_reporter,
         :register_parser, :get_parser, :register_java_parser, :new_java_parser,
         :register_formatter, :get_formatter, :register_java_formatter, :new_java_formatter,
         :register_decoder, :get_decoder, :register_java_decoder, :new_java_decoder,

--- a/embulk-core/src/main/ruby/embulk/reporter_plugin.rb
+++ b/embulk-core/src/main/ruby/embulk/reporter_plugin.rb
@@ -1,0 +1,17 @@
+module Embulk
+
+  require 'embulk/data_source'
+
+  class ReporterPlugin
+    def self.from_java(java_class)
+      JavaPlugin.ruby_adapter_class(java_class, ReporterPlugin, RubyAdapter)
+    end
+
+    module RubyAdapter
+      module ClassMethods
+      end
+      # TODO
+    end
+  end
+
+end


### PR DESCRIPTION
Related and based on #984 
This PR provides API to register external Reporter plugin.
We can execute external Reporter plugins as same as other type of plugins(Input, Output, Filter, etc).