### PR TITLE
Bump to v0.9.6-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'com.jfrog.bintray'
 
-version = '0.9.5-SNAPSHOT'
+version = '0.9.6-SNAPSHOT'
 
 description = 'Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control.'
 


### PR DESCRIPTION
v0.9.5 has been released. Bumping up to v0.9.6-SNAPSHOT.