### PR TITLE
Use java.util.Optional more than com.google.common.base.Optional #1: Config and internal use

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-core:2.6.7'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.6.7'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7'
+    compile 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7'
     compile 'com.fasterxml.jackson.module:jackson-module-guice:2.6.7'
     compile 'ch.qos.logback:logback-classic:1.1.3'

--- a/embulk-core/src/main/java/org/embulk/config/TaskSerDe.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskSerDe.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.Deserializers;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.google.common.base.Optional;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
@@ -30,6 +29,7 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 class TaskSerDe {
@@ -93,12 +93,12 @@ class TaskSerDe {
 
                 Type fieldType = getterMethod.getGenericReturnType();
 
-                Optional<String> jsonKey = getJsonKey(getterMethod, fieldName);
+                final Optional<String> jsonKey = getJsonKey(getterMethod, fieldName);
                 if (!jsonKey.isPresent()) {
                     // skip this field
                     continue;
                 }
-                Optional<String> defaultJsonString = getDefaultJsonString(getterMethod);
+                final Optional<String> defaultJsonString = getDefaultJsonString(getterMethod);
                 builder.put(jsonKey.get(), new FieldEntry(fieldName, fieldType, defaultJsonString));
             }
             return builder.build();
@@ -118,12 +118,12 @@ class TaskSerDe {
             return builder.build();
         }
 
-        protected Optional<String> getJsonKey(Method getterMethod, String fieldName) {
+        protected Optional<String> getJsonKey(final Method getterMethod, final String fieldName) {
             return Optional.of(fieldName);
         }
 
-        protected Optional<String> getDefaultJsonString(Method getterMethod) {
-            return Optional.absent();
+        protected Optional<String> getDefaultJsonString(final Method getterMethod) {
+            return Optional.empty();
         }
 
         @Override
@@ -151,7 +151,7 @@ class TaskSerDe {
                     for (final FieldEntry field : fields) {
                         final Object value = nestedObjectMapper.convertValue(children, new GenericTypeReference(field.getType()));
                         if (value == null) {
-                            throw new JsonMappingException("Setting null to a task field is not allowed. Use Optional<T> (com.google.common.base.Optional) to represent null.");
+                            throw new JsonMappingException("Setting null to a task field is not allowed. Use Optional<T> to represent null.");
                         }
                         objects.put(field.getName(), value);
                         if (!unusedMappings.remove(key, field)) {
@@ -172,7 +172,7 @@ class TaskSerDe {
                 if (field.getDefaultJsonString().isPresent()) {
                     Object value = nestedObjectMapper.readValue(field.getDefaultJsonString().get(), new GenericTypeReference(field.getType()));
                     if (value == null) {
-                        throw new JsonMappingException("Setting null to a task field is not allowed. Use Optional<T> (com.google.common.base.Optional) to represent null.");
+                        throw new JsonMappingException("Setting null to a task field is not allowed. Use Optional<T> to represent null.");
                     }
                     objects.put(field.getName(), value);
                 } else {
@@ -249,18 +249,18 @@ class TaskSerDe {
         }
 
         @Override
-        protected Optional<String> getJsonKey(Method getterMethod, String fieldName) {
-            Config a = getterMethod.getAnnotation(Config.class);
+        protected Optional<String> getJsonKey(final Method getterMethod, final String fieldName) {
+            final Config a = getterMethod.getAnnotation(Config.class);
             if (a != null) {
                 return Optional.of(a.value());
             } else {
-                return Optional.absent();  // skip this field
+                return Optional.empty();  // skip this field
             }
         }
 
         @Override
-        public Optional<String> getDefaultJsonString(Method getterMethod) {
-            ConfigDefault a = getterMethod.getAnnotation(ConfigDefault.class);
+        protected Optional<String> getDefaultJsonString(final Method getterMethod) {
+            final ConfigDefault a = getterMethod.getAnnotation(ConfigDefault.class);
             if (a != null && !a.value().isEmpty()) {
                 return Optional.of(a.value());
             }

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -3,6 +3,7 @@ package org.embulk.exec;
 import static org.embulk.plugin.InjectedPluginSource.registerPluginTo;
 
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.module.guice.ObjectMapperModule;
 import com.google.common.base.Preconditions;
@@ -45,6 +46,7 @@ public class ExecModule implements Module {
         CharsetSerDe.configure(mapper);
         LocalFileSerDe.configure(mapper);
         mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
+        mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
         mapper.registerModule(new JodaModule());  // jackson-datatype-joda
         mapper.configure(binder);
     }

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -1,7 +1,7 @@
 package org.embulk.spi;
 
-import com.google.common.base.Optional;
 import com.google.inject.Injector;
+import java.util.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -33,9 +33,10 @@ public class ExecSession {
 
     @Deprecated
     public interface SessionTask extends Task {
+        // It is kept as Guava's Optional since already @Deprecated.
         @Config("transaction_time")
         @ConfigDefault("null")
-        Optional<Timestamp> getTransactionTime();
+        com.google.common.base.Optional<Timestamp> getTransactionTime();
     }
 
     public static class Builder {
@@ -66,7 +67,7 @@ public class ExecSession {
             if (transactionTime == null) {
                 transactionTime = Timestamp.ofEpochMilli(System.currentTimeMillis());  // TODO get nanoseconds for default
             }
-            return new ExecSession(injector, transactionTime, Optional.fromNullable(loggerFactory));
+            return new ExecSession(injector, transactionTime, Optional.ofNullable(loggerFactory));
         }
     }
 
@@ -84,7 +85,7 @@ public class ExecSession {
 
     private ExecSession(Injector injector, Timestamp transactionTime, Optional<ILoggerFactory> loggerFactory) {
         this.injector = injector;
-        this.loggerFactory = loggerFactory.or(injector.getInstance(ILoggerFactory.class));
+        this.loggerFactory = loggerFactory.orElse(injector.getInstance(ILoggerFactory.class));
         this.modelManager = injector.getInstance(ModelManager.class);
         this.pluginManager = injector.getInstance(PluginManager.class);
         this.bufferAllocator = injector.getInstance(BufferAllocator.class);

--- a/embulk-core/src/main/java/org/embulk/spi/unit/ToString.java
+++ b/embulk-core/src/main/java/org/embulk/spi/unit/ToString.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
-import com.google.common.base.Optional;
+import java.util.Optional;
 
 public class ToString {
     private final String string;
@@ -14,9 +14,23 @@ public class ToString {
         this.string = string;
     }
 
-    @JsonCreator
-    public ToString(Optional<JsonNode> option) throws JsonMappingException {
+    // This constructor with com.google.common.base.Optional is kept for compatibility for direct callers.
+    @Deprecated
+    public ToString(com.google.common.base.Optional<JsonNode> option) throws JsonMappingException {
         JsonNode node = option.or(NullNode.getInstance());
+        if (node.isTextual()) {
+            this.string = node.textValue();
+        } else if (node.isValueNode()) {
+            this.string = node.toString();
+        } else {
+            throw new JsonMappingException(String.format("Arrays and objects are invalid: '%s'", node));
+        }
+    }
+
+    // This @JsonCreator constructor with java.util.Optional is called through Jackson's databind.
+    @JsonCreator
+    public ToString(final Optional<JsonNode> option) throws JsonMappingException {
+        final JsonNode node = option.orElse(NullNode.getInstance());
         if (node.isTextual()) {
             this.string = node.textValue();
         } else if (node.isValueNode()) {

--- a/embulk-core/src/test/java/org/embulk/config/TestConfigSource.java
+++ b/embulk-core/src/test/java/org/embulk/config/TestConfigSource.java
@@ -1,6 +1,8 @@
 package org.embulk.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.spi.Exec;
@@ -35,6 +37,16 @@ public class TestConfigSource {
 
         @Config("string")
         public String getString();
+    }
+
+    private static interface OptionalFields extends Task {
+        @Config("guava_optional")
+        @ConfigDefault("null")
+        public com.google.common.base.Optional<String> getGuavaOptional();
+
+        @Config("java_util_optional")
+        @ConfigDefault("null")
+        public java.util.Optional<String> getJavaUtilOptional();
     }
 
     private static interface DuplicationParent extends Task {
@@ -74,6 +86,25 @@ public class TestConfigSource {
         assertEquals(0.2, (double) config.get(double.class, "double"), 0.001);
         assertEquals(Long.MAX_VALUE, (long) config.get(long.class, "long"));
         assertEquals("sf", config.get(String.class, "string"));
+    }
+
+    @Test
+    public void testOptionalPresent() {
+        config.set("guava_optional", "Guava");
+        config.set("java_util_optional", "JavaUtil");
+
+        final OptionalFields loaded = config.loadConfig(OptionalFields.class);
+        assertTrue(loaded.getGuavaOptional().isPresent());
+        assertEquals("Guava", loaded.getGuavaOptional().get());
+        assertTrue(loaded.getJavaUtilOptional().isPresent());
+        assertEquals("JavaUtil", loaded.getJavaUtilOptional().get());
+    }
+
+    @Test
+    public void testOptionalAbsent() {
+        final OptionalFields loaded = config.loadConfig(OptionalFields.class);
+        assertFalse(loaded.getGuavaOptional().isPresent());
+        assertFalse(loaded.getJavaUtilOptional().isPresent());
     }
 
     @Test


### PR DESCRIPTION
Trying to start using `java.util.Optional` of Java 8, in addition to / instead of Guava's `Optional`.

Can you have a look, @sakama, and @muga as it's related to the basement portions?

In plugins' `Task` interfaces: both `java.util.Optional` and Guava's can be used like https://github.com/embulk/embulk/pull/997/commits/3e24e20dca5b57b441cd81bccb82f2df4eef8aab#diff-828bcc9d321473fc4a546d301ede851bR42 thanks to `Jdk8Module`.

In `TaskSerDe`: `TaskDeserializer` and `ConfigTaskDeserializer` should not be extended from plugins. The `protected` methods `getJsonKey` and `getDefaultJsonString` can be modified to return `java.util.Optional`.

In `ExecSession`: The only method using `Optional` is a `private` constructor, and only `ExecSession.Builder#build` is calling the constructor internally. It can be replaced to `java.util.Optional` safely.

In `ToString`: Guava's `Optional` has been used in its `public` constructor with `@JsonCreator`. The Guava-version should be kept for compatibility for direct callers of the constructor (although deprecated). At the same time, `@JsonCreator` method can switch to `java.util.Optional` safely since Jackson databind handles that.