### PR TITLE
Get org.jruby.embed.ScriptingContainer injectable again

### DIFF
--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
@@ -26,6 +26,11 @@ public class JRubyScriptingModule implements Module {
     @Override
     public void configure(Binder binder) {
         binder.bind(ScriptingContainerDelegate.class).toProvider(ScriptingContainerProvider.class).in(Scopes.SINGLETON);
+
+        // TODO: Bind org.jruby.embed.ScriptingContainer without Java-level reference to the class.
+        // TODO: Remove this binding finally. https://github.com/embulk/embulk/issues/1007
+        binder.bind(org.jruby.embed.ScriptingContainer.class)
+                .toProvider(RawScriptingContainerProvider.class).in(Scopes.SINGLETON);
     }
 
     private static class ScriptingContainerProvider
@@ -83,5 +88,38 @@ public class JRubyScriptingModule implements Module {
 
         private final boolean useGlobalRubyRuntime;
         private final JRubyInitializer initializer;
+    }
+
+    // TODO: Remove the Java-level reference to org.jruby.embed.ScriptingContainer.
+    // TODO: Remove this inner Provider class finally. https://github.com/embulk/embulk/issues/1007
+    private static class RawScriptingContainerProvider
+            implements ProviderWithDependencies<org.jruby.embed.ScriptingContainer> {
+        @Inject
+        public RawScriptingContainerProvider(final Injector injector, final ScriptingContainerDelegate delegate) {
+            this.delegate = delegate;
+            this.logger = injector.getInstance(ILoggerFactory.class).getLogger("init");
+        }
+
+        @Override  // from |com.google.inject.Provider|
+        public org.jruby.embed.ScriptingContainer get() throws ProvisionException {
+            // TODO: Report this deprecation through a reporter.
+            this.logger.warn("DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.");
+            try {
+                return (org.jruby.embed.ScriptingContainer) this.delegate.getScriptingContainer();
+            } catch (ClassCastException ex) {
+                throw new ProvisionException("Invalid JRuby ScriptingContainer instance.", ex);
+            }
+        }
+
+        @Override  // from |com.google.inject.spi.HasDependencies|
+        public Set<Dependency<?>> getDependencies() {
+            // get() depends on other modules
+            final HashSet<Dependency<?>> built = new HashSet<>();
+            built.add(Dependency.get(Key.get(ScriptingContainerDelegate.class)));
+            return Collections.unmodifiableSet(built);
+        }
+
+        private final ScriptingContainerDelegate delegate;
+        private final org.slf4j.Logger logger;
     }
 }

--- a/embulk-core/src/main/java/org/embulk/jruby/LazyScriptingContainerDelegate.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/LazyScriptingContainerDelegate.java
@@ -198,6 +198,13 @@ public final class LazyScriptingContainerDelegate extends ScriptingContainerDele
         return getInitialized().getRuntime();
     }
 
+    // TODO: Remove this method finally. https://github.com/embulk/embulk/issues/1007
+    // It is intentionally package-private. It should return ScriptingContainer while it is Object in the signature.
+    @Override
+    Object getScriptingContainer() throws JRubyNotLoadedException {
+        return getInitialized().getScriptingContainer();
+    }
+
     synchronized ScriptingContainerDelegateImpl getInitialized() {
         if (this.impl == null) {
             this.impl = ScriptingContainerDelegateImpl.create(

--- a/embulk-core/src/main/java/org/embulk/jruby/ScriptingContainerDelegate.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/ScriptingContainerDelegate.java
@@ -143,4 +143,7 @@ public abstract class ScriptingContainerDelegate {
 
     // It is intentionally private. It should return Runtime while it is Object in the signature.
     abstract Object getRuntime() throws JRubyNotLoadedException;
+
+    // TODO: Remove this method finally. https://github.com/embulk/embulk/issues/1007
+    abstract Object getScriptingContainer() throws JRubyNotLoadedException;
 }

--- a/embulk-core/src/main/java/org/embulk/jruby/ScriptingContainerDelegateImpl.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/ScriptingContainerDelegateImpl.java
@@ -843,6 +843,16 @@ public final class ScriptingContainerDelegateImpl extends ScriptingContainerDele
         }
     }
 
+    // TODO: Remove this method finally. https://github.com/embulk/embulk/issues/1007
+    // It is intentionally package-private. It should return ScriptingContainer while it is Object in the signature.
+    @Override
+    Object getScriptingContainer() throws JRubyNotLoadedException {
+        if (this.scriptingContainer == null) {
+            throw new JRubyNotLoadedException();
+        }
+        return this.scriptingContainer;
+    }
+
     /** Instance of org.jruby.embed.ScriptingContainer. It may be created lazily. */
     private final Object scriptingContainer;
 


### PR DESCRIPTION
`org.jruby.embed.ScriptingContainer` could not be injected since v0.9.0 as `ScriptingContainer` was indirected by `ScriptingContainerDelegate`. But, found that some plugins are injecting it, especially in constructing instances. We at least need to keep this injectable for a while.

https://github.com/embulk/embulk-executor-mapreduce/blob/v0.4.0/embulk-executor-mapreduce/src/main/java/org/embulk/executor/mapreduce/MapReduceExecutor.java#L71

It will be dropped after a while -- maybe in the next major version.

@sakama Can you have a look?