### PR TITLE
Bump guice-bootstrap to v0.3.0 released in Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 buildscript {
     repositories {
-        jcenter()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
@@ -179,7 +179,6 @@ configure(subprojects.findAll { ['embulk-core', 'embulk-standards', 'embulk-test
 
 repositories {
     mavenCentral()
-    jcenter()  // For org.embulk:guice-bootstrap:0.1.1
 }
 
 dependencies {

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -30,12 +30,11 @@ import com.github.jrubygradle.JRubyPrepare
 
 repositories {
     mavenCentral()
-    jcenter()  // For org.embulk:guice-bootstrap:0.1.1
 }
 
 // determine which dependencies have updates: $ gradle dependencyUpdates
 dependencies {
-    compile 'org.embulk:guice-bootstrap:0.1.1'
+    compile 'org.embulk:guice-bootstrap:0.3.0'
     compile 'com.google.guava:guava:18.0'
     compile 'com.google.inject:guice:4.0'
     compile 'com.google.inject.extensions:guice-multibindings:4.0'

--- a/embulk-standards/build.gradle
+++ b/embulk-standards/build.gradle
@@ -22,7 +22,6 @@ import com.github.jrubygradle.JRubyExec
 
 repositories {
     mavenCentral()
-    jcenter()  // For org.embulk:guice-bootstrap:0.1.1
 }
 
 dependencies {

--- a/embulk-test/build.gradle
+++ b/embulk-test/build.gradle
@@ -6,7 +6,6 @@ ext {
 
 repositories {
     mavenCentral()
-    jcenter()  // For org.embulk:guice-bootstrap:0.1.1
 }
 
 dependencies {


### PR DESCRIPTION
Now, guice-bootstrap has been released in Maven Central: https://github.com/embulk/guice-bootstrap/pull/6 It's cleaner to use only `mavenCentral()` not depending on `jcenter()`.

@sakama Can you have a look?