### PR TITLE
Prepare for v0.9.7

### DIFF
--- a/embulk-docs/src/release.rst
+++ b/embulk-docs/src/release.rst
@@ -4,6 +4,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.9.7
     release/release-0.9.6
     release/release-0.9.5
     release/release-0.9.4

--- a/embulk-docs/src/release/release-0.9.7.rst
+++ b/embulk-docs/src/release/release-0.9.7.rst
@@ -1,0 +1,11 @@
+Release 0.9.7
+==================================
+
+General Changes
+----------------
+
+* Get org.jruby.embed.ScriptingContainer injectable again [#1006]
+
+Release Date
+------------------
+2018-04-16


### PR DESCRIPTION
Releasing v0.9.7 just with #1006 because it's an important fix, and #1008 can be impactful. #1008 will be included in the next version v0.9.8.