### PR TITLE
Bump to v0.9.8-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'com.jfrog.bintray'
 
-version = '0.9.7-SNAPSHOT'
+version = '0.9.8-SNAPSHOT'
 
 description = 'Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control.'
 


### PR DESCRIPTION
v0.9.7 has been released. We're on v0.9.8-SNAPSHOT.