### PR TITLE
Load a Maven-based plugin JAR with its "direct" dependencies

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
@@ -127,6 +127,32 @@ public class PluginClassLoader extends URLClassLoader {
     }
 
     /**
+     * Creates PluginClassLoader for plugins with dependency JARs embedded in the plugin JAR itself, and even external.
+     *
+     * @param parentClassLoader  the parent ClassLoader of this PluginClassLoader instance
+     * @param oneNestedJarFileUrl  "file:" URL of the plugin JAR file
+     * @param embeddedJarPathsInNestedJar  collection of resource names of embedded dependency JARs in the plugin JAR
+     * @param dependencyJarUrls  collection of "file:" URLs of dependency JARs out of the plugin JAR
+     * @param parentFirstPackages  collection of package names that are to be loaded first before the plugin's
+     * @param parentFirstResources  collection of resource names that are to be loaded first before the plugin's
+     */
+    public static PluginClassLoader createForNestedJar(
+            final ClassLoader parentClassLoader,
+            final URL oneNestedJarFileUrl,
+            final Collection<String> embeddedJarPathsInNestedJar,
+            final Collection<URL> dependencyJarUrls,
+            final Collection<String> parentFirstPackages,
+            final Collection<String> parentFirstResources) {
+        return new PluginClassLoader(
+                parentClassLoader,
+                oneNestedJarFileUrl,
+                embeddedJarPathsInNestedJar,
+                dependencyJarUrls,
+                parentFirstPackages,
+                parentFirstResources);
+    }
+
+    /**
      * Adds the specified path to the list of URLs (for {@code URLClassLoader}) to search for classes and resources.
      *
      * It internally calls {@code URLClassLoader#addURL}.

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactory.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactory.java
@@ -13,4 +13,15 @@ public interface PluginClassLoaderFactory {
             final ClassLoader parentClassLoader,
             final URL oneNestedJarUrl,
             final Collection<String> embeddedJarPathsInNestedJar);
+
+    default PluginClassLoader createForNestedJarWithDependencies(
+            final ClassLoader parentClassLoader,
+            final URL oneNestedJarUrl,
+            final Collection<String> embeddedJarPathsInNestedJar,
+            final Collection<URL> dependencyJarUrls) {
+        return this.createForNestedJar(
+                parentClassLoader,
+                oneNestedJarUrl,
+                embeddedJarPathsInNestedJar);
+    }
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderModule.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderModule.java
@@ -84,6 +84,21 @@ public class PluginClassLoaderModule implements Module {
                         parentFirstPackages,
                         parentFirstResources);
             }
+
+            @Override
+            public PluginClassLoader createForNestedJarWithDependencies(
+                    final ClassLoader parentClassLoader,
+                    final URL oneNestedJarUrl,
+                    final Collection<String> embeddedJarPathsInNestedJar,
+                    final Collection<URL> dependencyJarUrls) {
+                return PluginClassLoader.createForNestedJar(
+                        parentClassLoader,
+                        oneNestedJarUrl,
+                        embeddedJarPathsInNestedJar,
+                        dependencyJarUrls,
+                        parentFirstPackages,
+                        parentFirstResources);
+            }
         }
     }
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
@@ -77,20 +77,21 @@ public class MavenPluginSource implements PluginSource {
         }
 
         final MavenPluginPaths pluginPaths;
-        final Path jarPath;
         try {
             pluginPaths = mavenArtifactFinder.findMavenPluginJarsWithDirectDependencies(
                     mavenPluginType.getGroup(),
                     "embulk-" + category + "-" + mavenPluginType.getName(),
                     mavenPluginType.getClassifier(),
                     mavenPluginType.getVersion());
-            jarPath = pluginPaths.getPluginJarPath();
         } catch (MavenArtifactNotFoundException ex) {
             throw new PluginSourceNotMatchException(ex);
         }
 
         final Class<?> pluginMainClass;
-        try (JarPluginLoader loader = JarPluginLoader.load(jarPath, pluginClassLoaderFactory)) {
+        try (JarPluginLoader loader = JarPluginLoader.load(
+                 pluginPaths.getPluginJarPath(),
+                 pluginPaths.getPluginDependencyJarPaths(),
+                 pluginClassLoaderFactory)) {
             pluginMainClass = loader.getPluginMainClass();
         } catch (InvalidJarPluginException ex) {
             throw new PluginSourceNotMatchException(ex);

--- a/embulk-core/src/test/java/org/embulk/plugin/jar/ExampleDependencyJar.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/jar/ExampleDependencyJar.java
@@ -1,0 +1,7 @@
+package org.embulk.plugin.jar;
+
+public class ExampleDependencyJar {
+    public String getTestDependencyString() {
+        return "hoge";
+    }
+}

--- a/embulk-core/src/test/java/org/embulk/plugin/jar/ExampleJarSpiV0.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/jar/ExampleJarSpiV0.java
@@ -4,4 +4,8 @@ public class ExampleJarSpiV0 {
     public String getTestString() {
         return "foobar";
     }
+
+    public ExampleDependencyJar getDependencyObject() {
+        return new ExampleDependencyJar();
+    }
 }


### PR DESCRIPTION
After finding "direct" dependencies in #1012, this PR actually loads the out-of-plugin-JAR dependencies. Can you have a look when you have time? @sakama (Cc: @muga) It's not in a hurry.

We may want better tests to load JARs, but that'd be out of `embulk-core`. We'd need much work for such tests.

I've at least confirmed that it successfully loads and runs specially-built `embulk-decoder-commons_compress` with external `org.apache.commons:commons-compress:1.13`.