### PR TITLE
upgrade jruby-gradle plugin for embulk-plugin build.gradle template

### DIFF
--- a/embulk-core/src/main/resources/org/embulk/plugin/template/java/build.gradle.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/java/build.gradle.vm
@@ -1,6 +1,6 @@
 plugins {
     id "com.jfrog.bintray" version "1.1"
-    id "com.github.jruby-gradle.base" version "0.1.5"
+    id "com.github.jruby-gradle.base" version "1.5.0"
     id "java"
     id "checkstyle"
 }
@@ -50,14 +50,16 @@ task checkstyle(type: Checkstyle) {
 }
 
 task gem(type: JRubyExec, dependsOn: ["gemspec", "classpath"]) {
-    jrubyArgs "-rrubygems/gem_runner", "-eGem::GemRunner.new.run(ARGV)", "build"
-    script "${project.name}.gemspec"
+    jrubyArgs "-S"
+    script "gem"
+    scriptArgs "build", "${project.name}.gemspec"
     doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "pkg") }
 }
 
 task gemPush(type: JRubyExec, dependsOn: ["gem"]) {
-    jrubyArgs "-rrubygems/gem_runner", "-eGem::GemRunner.new.run(ARGV)", "push"
-    script "pkg/${project.name}-${project.version}.gem"
+    jrubyArgs "-S"
+    script "gem"
+    scriptArgs "push", "pkg/${project.name}-${project.version}.gem"
 }
 
 task "package"(dependsOn: ["gemspec", "classpath"]) {


### PR DESCRIPTION
For the problem of could not push to RubyGems via embulk-plugins in below issues.
- upgrading com.github.jruby-gradle.base 0.1.5 to 1.5.0

```
bash-3.2$ ./gradlew gemPush
:compileJava UP-TO-DATE
:compileScala UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:jar UP-TO-DATE
:classpath UP-TO-DATE
:gemspec UP-TO-DATE
:gem
  Successfully built RubyGem
  Name: embulk-parser-firebase_avro
  Version: 0.1.3
  File: embulk-parser-firebase_avro-0.1.3.gem
:gemPush
ERROR:  While executing gem ... (RuntimeError)
    Can't find 'rubygems-update' in any repo. Check `gem source list`.

BUILD SUCCESSFUL
```