### PR TITLE
Clean up EmbulkEmbed and EmbulkService

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 // determine which dependencies have updates: $ gradle dependencyUpdates
 dependencies {
-    compile 'org.embulk:guice-bootstrap:0.3.0'
+    compile 'org.embulk:guice-bootstrap:0.3.2'
     compile 'com.google.guava:guava:18.0'
     compile 'com.google.inject:guice:4.0'
     compile 'com.google.inject.extensions:guice-multibindings:4.0'

--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -24,7 +24,6 @@ import org.embulk.exec.PreviewResult;
 import org.embulk.exec.ResumeState;
 import org.embulk.exec.SystemConfigModule;
 import org.embulk.exec.TransactionStage;
-import org.embulk.guice.Bootstrap;
 import org.embulk.guice.LifeCycleInjector;
 import org.embulk.jruby.JRubyScriptingModule;
 import org.embulk.plugin.BuiltinPluginSourceModule;
@@ -68,11 +67,7 @@ public class EmbulkEmbed {
                 copyMutable.add(module);
             }
             final List<Module> copy = Collections.unmodifiableList(copyMutable);
-            return overrideModules(new com.google.common.base.Function<List<Module>, Iterable<Module>>() {
-                    public Iterable<Module> apply(List<Module> modules) {
-                        return Iterables.concat(modules, copy);
-                    }
-                });
+            return this.overrideModules(modules -> Iterables.concat(modules, copy));
         }
 
         @Deprecated

--- a/embulk-core/src/main/java/org/embulk/EmbulkService.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkService.java
@@ -1,73 +1,67 @@
 package org.embulk;
 
-import static com.google.common.base.Preconditions.checkState;
-
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.embulk.config.ConfigSource;
-import org.embulk.exec.ExecModule;
-import org.embulk.exec.ExtensionServiceLoaderModule;
-import org.embulk.exec.SystemConfigModule;
-import org.embulk.jruby.JRubyScriptingModule;
-import org.embulk.plugin.BuiltinPluginSourceModule;
-import org.embulk.plugin.PluginClassLoaderModule;
-import org.embulk.plugin.maven.MavenPluginSourceModule;
 
 // Use EmbulkEmbed instead. To be removed by v0.10 or earlier.
 @Deprecated  // https://github.com/embulk/embulk/issues/932
 public class EmbulkService {
-    private final ConfigSource systemConfig;
-
-    protected Injector injector;
-    private boolean initialized;
-
-    public EmbulkService(ConfigSource systemConfig) {
+    @Deprecated
+    public EmbulkService(final ConfigSource systemConfig) {
         this.systemConfig = systemConfig;
     }
 
-    protected Iterable<? extends Module> getAdditionalModules(ConfigSource systemConfig) {
-        return ImmutableList.of();
+    @Deprecated
+    protected Iterable<? extends Module> getAdditionalModules(final ConfigSource systemConfigParam) {
+        return Collections.unmodifiableList(new ArrayList<Module>());
     }
 
-    protected Iterable<? extends Module> overrideModules(Iterable<? extends Module> modules, ConfigSource systemConfig) {
+    @Deprecated
+    protected Iterable<? extends Module> overrideModules(
+            final Iterable<? extends Module> modules, final ConfigSource systemConfigParam) {
         return modules;
     }
 
-    static List<Module> standardModuleList(ConfigSource systemConfig) {
-        return ImmutableList.of(
-                new SystemConfigModule(systemConfig),
-                new ExecModule(),
-                new ExtensionServiceLoaderModule(systemConfig),
-                new PluginClassLoaderModule(systemConfig),
-                new BuiltinPluginSourceModule(),
-                new MavenPluginSourceModule(systemConfig),
-                new JRubyScriptingModule(systemConfig));
+    @Deprecated
+    static List<Module> standardModuleList(final ConfigSource systemConfigParam) {
+        return EmbulkEmbed.standardModuleList(systemConfigParam);
     }
 
+    @Deprecated
     public Injector initialize() {
-        checkState(!initialized, "Already initialized");
+        if (this.initialized) {
+            throw new IllegalStateException("Already initialized");
+        }
 
-        ImmutableList.Builder<Module> builder = ImmutableList.builder();
-        builder.addAll(standardModuleList(systemConfig));
-        builder.addAll(getAdditionalModules(systemConfig));
+        final ArrayList<Module> modulesBuilt = new ArrayList<>();
+        modulesBuilt.addAll(standardModuleList(this.systemConfig));
+        for (final Module module : getAdditionalModules(this.systemConfig)) {
+            modulesBuilt.add(module);
+        }
 
-        Iterable<? extends Module> modules = builder.build();
-        modules = overrideModules(modules, systemConfig);
+        final Iterable<? extends Module> modulesBeforeOverride = Collections.unmodifiableList(modulesBuilt);
 
-        injector = Guice.createInjector(modules);
-        initialized = true;
+        this.injector = Guice.createInjector(overrideModules(modulesBeforeOverride, this.systemConfig));
+        this.initialized = true;
 
-        return injector;
+        return this.injector;
     }
 
     @Deprecated
     public synchronized Injector getInjector() {
-        if (initialized) {
-            return injector;
+        if (this.initialized) {
+            return this.injector;
         }
-        return initialize();
+        return this.initialize();
     }
+
+    private final ConfigSource systemConfig;
+
+    protected Injector injector;
+    private boolean initialized;
 }


### PR DESCRIPTION
This is just refactoring. Can you have a look, @sakama @kamatama41 ?

* Move `EmbulkService.standardModuleList` to `EmbulkEmbed`
* Reduce usage of Guava
* Use Java 8 `java.util.function.Function` instead of Guava `Function`

----

This will use https://github.com/embulk/guice-bootstrap/pull/12.