### PR TITLE
Match local files in a consistent case-sensitivity manner even on Mac OSX: LocalFileInputPlugin

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/LocalFileInputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/LocalFileInputPlugin.java
@@ -319,7 +319,7 @@ public class LocalFileInputPlugin implements FileInputPlugin {
     private static Path getRealCasePathOfDirectoryNoFollowLinks(final Path dirNormalized) {
         Path built;
         if (dirNormalized.isAbsolute()) {
-            built = Paths.get("/");
+            built = dirNormalized.getRoot();
         } else {
             built = Paths.get("");
         }

--- a/embulk-standards/src/test/java/org/embulk/standards/TestLocalFileInputPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestLocalFileInputPlugin.java
@@ -132,9 +132,7 @@ public class TestLocalFileInputPlugin {
             assertTrue(files.contains(buildPath("Directory1\\foo2")));
             assertTrue(files.contains(buildPath("Directory1\\Foo3")));
         } else if (System.getProperty("os.name").contains("Mac OS")) {
-            assertEquals(2, files.size());
-            assertTrue(files.contains(buildPath("Directory1/foo1")));
-            assertTrue(files.contains(buildPath("Directory1/foo2")));
+            assertEquals(0, files.size());
         } else {
             assertEquals(0, files.size());
         }

--- a/embulk-standards/src/test/java/org/embulk/standards/TestLocalFileInputPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestLocalFileInputPlugin.java
@@ -128,9 +128,9 @@ public class TestLocalFileInputPlugin {
         // It intentionally tests in the platform-aware way, not in the platform-oblivious way.
         if (System.getProperty("os.name").contains("Windows")) {
             assertEquals(3, files.size());
-            assertTrue(files.contains(buildPath("Directory1\\foo1")));
-            assertTrue(files.contains(buildPath("Directory1\\foo2")));
-            assertTrue(files.contains(buildPath("Directory1\\Foo3")));
+            assertTrue(files.contains(buildPath("directory1\\foo1")));
+            assertTrue(files.contains(buildPath("directory1\\foo2")));
+            assertTrue(files.contains(buildPath("directory1\\Foo3")));
         } else if (System.getProperty("os.name").contains("Mac OS")) {
             assertEquals(0, files.size());
         } else {

--- a/embulk-standards/src/test/java/org/embulk/standards/TestLocalFileInputPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestLocalFileInputPlugin.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.base.Optional;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
@@ -61,6 +63,101 @@ public class TestLocalFileInputPlugin {
             assertTrue(files.contains(buildPath("foofoo1")));
             assertTrue(files.contains(buildPath("foofoo4/foo")));
             assertTrue(files.contains(buildPath("foofoo4/bar")));
+        }
+    }
+
+    @Test
+    public void testListFilesDots() throws IOException {
+        // TODO: Mock the current directory.
+        final LocalFileInputPlugin plugin = new LocalFileInputPlugin();
+        try {
+            Files.createFile(Paths.get("file1"));
+            Files.createFile(Paths.get("file2"));
+            Files.createDirectory(Paths.get("dirA"));
+            Files.createFile(Paths.get("dirA", "file3"));
+            Files.createFile(Paths.get("dirA", "file4"));
+            Files.createDirectory(Paths.get("dirB"));
+            Files.createFile(Paths.get("dirB", "file5"));
+            Files.createFile(Paths.get("dirB", "file6"));
+
+            final LocalFileInputPlugin.PluginTask file1Task = buildRawTask("file1");
+            final List<String> file1Files = plugin.listFiles(file1Task);
+            assertEquals(1, file1Files.size());
+            assertTrue(file1Files.contains("file1"));
+
+            final LocalFileInputPlugin.PluginTask dotSlashFile1Task = buildRawTask("." + File.separator + "file1");
+            final List<String> dotSlashFile1Files = plugin.listFiles(dotSlashFile1Task);
+            assertEquals(1, dotSlashFile1Files.size());
+            assertTrue(dotSlashFile1Files.contains("." + File.separator + "file1"));
+
+            final LocalFileInputPlugin.PluginTask fileTask = buildRawTask("file");
+            final List<String> fileFiles = plugin.listFiles(fileTask);
+            assertEquals(2, fileFiles.size());
+            assertTrue(fileFiles.contains("file1"));
+            assertTrue(fileFiles.contains("file2"));
+
+            final LocalFileInputPlugin.PluginTask dotSlashFileTask = buildRawTask("." + File.separator + "file");
+            final List<String> dotSlashFileFiles = plugin.listFiles(dotSlashFileTask);
+            assertEquals(2, dotSlashFileFiles.size());
+            assertTrue(dotSlashFileFiles.contains("." + File.separator + "file1"));
+            assertTrue(dotSlashFileFiles.contains("." + File.separator + "file2"));
+
+            final LocalFileInputPlugin.PluginTask dirATask = buildRawTask("dirA");
+            final List<String> dirAFiles = plugin.listFiles(dirATask);
+            assertEquals(2, dirAFiles.size());
+            assertTrue(dirAFiles.contains("dirA" + File.separator + "file3"));
+            assertTrue(dirAFiles.contains("dirA" + File.separator + "file4"));
+
+            final LocalFileInputPlugin.PluginTask dotSlashDirATask = buildRawTask("." + File.separator + "dirA");
+            final List<String> dotSlashDirAFiles = plugin.listFiles(dotSlashDirATask);
+            assertEquals(2, dotSlashDirAFiles.size());
+            assertTrue(dotSlashDirAFiles.contains("." + File.separator + "dirA" + File.separator + "file3"));
+            assertTrue(dotSlashDirAFiles.contains("." + File.separator + "dirA" + File.separator + "file4"));
+
+            final LocalFileInputPlugin.PluginTask dirTask = buildRawTask("dir");
+            final List<String> dirFiles = plugin.listFiles(dirTask);
+            assertEquals(4, dirFiles.size());
+            assertTrue(dirFiles.contains("dirA" + File.separator + "file3"));
+            assertTrue(dirFiles.contains("dirA" + File.separator + "file4"));
+            assertTrue(dirFiles.contains("dirB" + File.separator + "file5"));
+            assertTrue(dirFiles.contains("dirB" + File.separator + "file6"));
+
+            final LocalFileInputPlugin.PluginTask dotSlashDirTask = buildRawTask("." + File.separator + "dir");
+            final List<String> dotSlashDirFiles = plugin.listFiles(dotSlashDirTask);
+            assertEquals(4, dotSlashDirFiles.size());
+            assertTrue(dotSlashDirFiles.contains("." + File.separator + "dirA" + File.separator + "file3"));
+            assertTrue(dotSlashDirFiles.contains("." + File.separator + "dirA" + File.separator + "file4"));
+            assertTrue(dotSlashDirFiles.contains("." + File.separator + "dirB" + File.separator + "file5"));
+            assertTrue(dotSlashDirFiles.contains("." + File.separator + "dirB" + File.separator + "file6"));
+
+            final LocalFileInputPlugin.PluginTask dotSlashTask = buildRawTask("." + File.separator + "");
+            final List<String> dotSlashFiles = plugin.listFiles(dotSlashTask);
+            assertTrue(6 <= dotSlashFiles.size());  // Other files and directories exist.
+            assertTrue(dotSlashFiles.contains("." + File.separator + "file1"));
+            assertTrue(dotSlashFiles.contains("." + File.separator + "file2"));
+            assertTrue(dotSlashFiles.contains("." + File.separator + "dirA" + File.separator + "file3"));
+            assertTrue(dotSlashFiles.contains("." + File.separator + "dirA" + File.separator + "file4"));
+            assertTrue(dotSlashFiles.contains("." + File.separator + "dirB" + File.separator + "file5"));
+            assertTrue(dotSlashFiles.contains("." + File.separator + "dirB" + File.separator + "file6"));
+
+            final LocalFileInputPlugin.PluginTask dotTask = buildRawTask(".");
+            final List<String> dotFiles = plugin.listFiles(dotTask);
+            assertTrue(6 <= dotFiles.size());  // Other files and directories exist.
+            assertTrue(dotFiles.contains("." + File.separator + "file1"));
+            assertTrue(dotFiles.contains("." + File.separator + "file2"));
+            assertTrue(dotFiles.contains("." + File.separator + "dirA" + File.separator + "file3"));
+            assertTrue(dotFiles.contains("." + File.separator + "dirA" + File.separator + "file4"));
+            assertTrue(dotFiles.contains("." + File.separator + "dirB" + File.separator + "file5"));
+            assertTrue(dotFiles.contains("." + File.separator + "dirB" + File.separator + "file6"));
+        } finally {
+            Files.deleteIfExists(Paths.get("dirB", "file6"));
+            Files.deleteIfExists(Paths.get("dirB", "file5"));
+            Files.deleteIfExists(Paths.get("dirB"));
+            Files.deleteIfExists(Paths.get("dirA", "file4"));
+            Files.deleteIfExists(Paths.get("dirA", "file3"));
+            Files.deleteIfExists(Paths.get("dirA"));
+            Files.deleteIfExists(Paths.get("file2"));
+            Files.deleteIfExists(Paths.get("file1"));
         }
     }
 
@@ -136,6 +233,26 @@ public class TestLocalFileInputPlugin {
         } else {
             assertEquals(0, files.size());
         }
+    }
+
+    private LocalFileInputPlugin.PluginTask buildRawTask(
+            final String pathPrefix) {
+        return this.buildRawTask(pathPrefix, null, null);
+    }
+
+    private LocalFileInputPlugin.PluginTask buildRawTask(
+            final String pathPrefix,
+            final String lastPath,
+            final Boolean followSymlinks) {
+        final ConfigSource config = Exec.newConfigSource();
+        config.set("path_prefix", pathPrefix);
+        if (lastPath != null) {
+            config.set("last_path", Optional.of(lastPath));
+        }
+        if (followSymlinks != null) {
+            config.set("follow_symlinks", followSymlinks);
+        }
+        return config.loadConfig(LocalFileInputPlugin.PluginTask.class);
     }
 
     private LocalFileInputPlugin.PluginTask buildTask(


### PR DESCRIPTION
Follow-up to #1022.

As discussed in https://github.com/embulk/embulk/pull/1022#discussion_r198352790, the fix in #1022 was not perfect on Mac OS X, but we had no right ways to do that at that time.

After some investigation and experiments, I found that it is possible to be consistent with `PathMatcher`.

I wonder if we could apply this before releasing the next version 0.9.8. Can you have a look when you have time? @kamatama41 @sakama?

* This file has some more points that should be refactored, but they're left intentionally to focus on this change. I'll have another refactoring change later.
* This should be successful on TravisCI (Linux) and Appveyor (Windows), but the existing tests would fail on Mac OS X. I will have another commit in this PR to fix the tests.