### PR TITLE
Check Java versions from selfrun scripts: Fix #1020

### DIFF
--- a/embulk-core/src/main/bat/selfrun.bat
+++ b/embulk-core/src/main/bat/selfrun.bat
@@ -33,6 +33,50 @@ if "%overwrite_optimize%" == "true" (
     )
 )
 
+for /f "usebackq delims=" %%w in (`java -fullversion 2^>^&1`) do set java_fullversion=%%w
+echo %java_fullversion% | find "java full version ""1.7" > NUL
+if not ERRORLEVEL 1 (set java_version=7)
+echo %java_fullversion% | find "java full version ""1.8" > NUL
+if not ERRORLEVEL 1 (set java_version=8)
+echo %java_fullversion% | find "java full version ""9" > NUL
+if not ERRORLEVEL 1 (set java_version=9)
+echo %java_fullversion% | find "java full version ""10" > NUL
+if not ERRORLEVEL 1 (set java_version=10)
+echo %java_fullversion% | find "java full version ""11" > NUL
+if not ERRORLEVEL 1 (set java_version=11)
+if not defined java_version (set java_version=0)
+
+if %java_version% EQU 7 (
+    echo "[ERROR] Embulk no longer supports Java 1.7." 1>&2
+    exit 1
+
+) else if %java_version% EQU 8 (
+    rem Do nothing for Java 8
+
+) else if %java_version% EQU 9 (
+    echo "[WARN] Embulk does not guarantee running with Java 9." 1>&2
+    echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
+    echo "" 1>&2
+    set java_args=--add-modules java.xml.bind --add-modules=java.se.ee %java_args%
+
+) else if %java_version% EQU 10 (
+    echo "[WARN] Embulk does not guarantee running with Java 10." 1>&2
+    echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
+    echo "" 1>&2
+    set java_args=--add-modules java.xml.bind --add-modules=java.se.ee %java_args%
+
+) else if %java_version% EQU 11 (
+    echo "[WARN] Embulk does not guarantee running with Java 11." 1>&2
+    echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
+    echo "" 1>&2
+    set java_args=--add-modules java.xml.bind --add-modules=java.se.ee %java_args%
+
+) else (
+    echo "[WARN] Unrecognized Java version: %java_fullversion%" 1>&2
+    echo "" 1>&2
+
+)
+
 if "%optimize%" == "true" (
     set java_args=-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC %java_args%
 ) else (

--- a/embulk-core/src/main/bat/selfrun.bat
+++ b/embulk-core/src/main/bat/selfrun.bat
@@ -50,33 +50,33 @@ if not ERRORLEVEL 1 (set java_version=11)
 if not defined java_version (set java_version=0)
 
 if %java_version% EQU 7 (
-    echo "[ERROR] Embulk no longer supports Java 1.7." 1>&2
+    echo [ERROR] Embulk no longer supports Java 1.7. 1>&2
     exit 1
 
 ) else if %java_version% EQU 8 (
     rem Do nothing for Java 8
 
 ) else if %java_version% EQU 9 (
-    echo "[WARN] Embulk does not guarantee running with Java 9." 1>&2
-    echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
-    echo "" 1>&2
+    echo [WARN] Embulk does not guarantee running with Java 9. 1>&2
+    echo [WARN] Executing Java with: "--add-modules java.xml.bind --add-modules=java.se.ee" 1>&2
+    echo. 1>&2
     set java_args=--add-modules java.xml.bind --add-modules=java.se.ee %java_args%
 
 ) else if %java_version% EQU 10 (
-    echo "[WARN] Embulk does not guarantee running with Java 10." 1>&2
-    echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
-    echo "" 1>&2
+    echo [WARN] Embulk does not guarantee running with Java 10. 1>&2
+    echo [WARN] Executing Java with: "--add-modules java.xml.bind --add-modules=java.se.ee" 1>&2
+    echo. 1>&2
     set java_args=--add-modules java.xml.bind --add-modules=java.se.ee %java_args%
 
 ) else if %java_version% EQU 11 (
-    echo "[WARN] Embulk does not guarantee running with Java 11." 1>&2
-    echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
-    echo "" 1>&2
+    echo [WARN] Embulk does not guarantee running with Java 11. 1>&2
+    echo [WARN] Executing Java with: "--add-modules java.xml.bind --add-modules=java.se.ee" 1>&2
+    echo. 1>&2
     set java_args=--add-modules java.xml.bind --add-modules=java.se.ee %java_args%
 
 ) else (
-    echo "[WARN] Unrecognized Java version: %java_fullversion%" 1>&2
-    echo "" 1>&2
+    echo [WARN] Unrecognized Java version: %java_fullversion% 1>&2
+    echo. 1>&2
 
 )
 

--- a/embulk-core/src/main/bat/selfrun.bat
+++ b/embulk-core/src/main/bat/selfrun.bat
@@ -1,5 +1,8 @@
 @echo off
 
+rem NOTE: Do not use backquotes in this bat file because backquotes are unintentionally recognized by sh.
+rem NOTE: Just quotes are available for [ for /f "delims=" %%w ('...') ].
+
 setlocal
 
 rem Do not use %0 to identify the JAR (bat) file.
@@ -33,7 +36,7 @@ if "%overwrite_optimize%" == "true" (
     )
 )
 
-for /f "usebackq delims=" %%w in (`java -fullversion 2^>^&1`) do set java_fullversion=%%w
+for /f "delims=" %%w in ('java -fullversion 2^>^&1') do set java_fullversion=%%w
 echo %java_fullversion% | find "java full version ""1.7" > NUL
 if not ERRORLEVEL 1 (set java_version=7)
 echo %java_fullversion% | find "java full version ""1.8" > NUL

--- a/embulk-core/src/main/sh/selfrun.sh
+++ b/embulk-core/src/main/sh/selfrun.sh
@@ -50,6 +50,38 @@ while true; do
     esac
 done
 
+java_fullversion=`java -fullversion 2>&1`
+
+case "$java_fullversion" in
+    java\ full\ version\ \"1.7*\")
+        echo "[ERROR] Embulk no longer supports Java 1.7." 1>&2
+        exit 1
+        ;;
+    java\ full\ version\ \"1.8*\")
+        ;;
+    java\ full\ version\ \"9*\")
+        echo "[WARN] Embulk does not guarantee running with Java 9." 1>&2
+        echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
+        echo "" 1>&2
+        java_args="--add-modules java.xml.bind --add-modules=java.se.ee $java_args"
+        ;;
+    java\ full\ version\ \"10*\")
+        echo "[WARN] Embulk does not guarantee running with Java 10." 1>&2
+        echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
+        echo "" 1>&2
+        java_args="--add-modules java.xml.bind --add-modules=java.se.ee $java_args"
+        ;;
+    java\ full\ version\ \"11*\")
+        echo "[WARN] Embulk does not guarantee running with Java 11." 1>&2
+        echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
+        echo "" 1>&2
+        java_args="--add-modules java.xml.bind --add-modules=java.se.ee $java_args"
+        ;;
+    *)
+        echo "[WARN] Unrecognized Java version: $java_fullversion" 1>&2
+        echo "" 1>&2
+esac
+
 if test "$overwrite_optimize" = "true" -o "$default_optimize" -a "$overwrite_optimize" != "false"; then
     java_args="-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC $java_args"
 else

--- a/embulk-core/src/test/java/org/embulk/cli/SelfrunTest.java
+++ b/embulk-core/src/test/java/org/embulk/cli/SelfrunTest.java
@@ -36,10 +36,10 @@ public class SelfrunTest {
         final String line =
                 new String(Files.readAllBytes(fileSystem.getPath(originalSelfrunFile.getAbsolutePath())),
                            Charset.defaultCharset())
-                .replaceAll("java ",
+                .replaceAll("java (.java_args)",
                             "java -classpath "
                                     + classpath.getAbsolutePath().replaceAll("\\\\", "\\\\\\\\")
-                                    + " org.embulk.cli.DummyMain ");
+                                    + " org.embulk.cli.DummyMain $1");
 
         // Modify selfrun so that arguments are written in 'args.txt' .
         Files.write(fileSystem.getPath(testSelfrunFile.getAbsolutePath()),


### PR DESCRIPTION
Trying to run Embulk CLI with Java 9/10/11. Although the Embulk core (Java code) is not guaranteed to run with Java 9+, the selfrun scripts may help users to just try.

@sakama @kamatama41 Can you have a look? (Cc: @hiroyuki-sato)