### PR TITLE
Make stop_on_invalid_record effective for invalid dates such as 2018-02-31

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
@@ -1,6 +1,7 @@
 package org.embulk.spi.time;
 
 import com.google.common.base.Optional;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import org.embulk.config.Config;
@@ -224,7 +225,11 @@ public class TimestampParser {
     }
 
     public final Timestamp parse(final String text) throws TimestampParseException {
-        return Timestamp.ofInstant(this.parseInternal(text));
+        try {
+            return Timestamp.ofInstant(this.parseInternal(text));
+        } catch (final DateTimeException ex) {
+            throw new TimestampParseException(ex);
+        }
     }
 
     private final TimestampParserLegacy delegate;

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -3,7 +3,6 @@ package org.embulk.spi.time;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -652,7 +651,6 @@ public class TestTimestampParser {
     }
 
     @Test
-    @Ignore
     public void testInvalidDate() {
         failToParse("2018-02-31T12:34:56", "%Y-%m-%dT%H:%M:%S");
     }
@@ -663,7 +661,6 @@ public class TestTimestampParser {
     }
 
     @Test
-    @Ignore
     public void testJavaInvalidDate() {
         failJavaToParse("2018-02-31T12:34:56", "yyyy-MM-dd'T'HH:mm:ss");
     }

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -3,6 +3,7 @@ package org.embulk.spi.time;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -648,6 +649,23 @@ public class TestTimestampParser {
         testRubyToParse("-1.5", "%s.%N", -2L, 500000000);
         testRubyToParse("1.000000001", "%s.%N", 1L, 1);
         testRubyToParse("-1.000000001", "%s.%N", -2L, 999999999);
+    }
+
+    @Test
+    @Ignore
+    public void testInvalidDate() {
+        failToParse("2018-02-31T12:34:56", "%Y-%m-%dT%H:%M:%S");
+    }
+
+    @Test
+    public void testRubyInvalidDate() {
+        failRubyToParse("2018-02-31T12:34:56", "%Y-%m-%dT%H:%M:%S");
+    }
+
+    @Test
+    @Ignore
+    public void testJavaInvalidDate() {
+        failJavaToParse("2018-02-31T12:34:56", "yyyy-MM-dd'T'HH:mm:ss");
     }
 
     private void testJavaToParse(final String string, final String format, final long second, final int nanoOfSecond) {


### PR DESCRIPTION
We observed that CSV parser's `stop_on_invalid_record: false` was not working as intended when a parsed timestamp was invalid (non-existing) date/time, such as 2018-02-31.

It was because `DateTimeException` in creating a `*DateTime` instance was not caught and wrapped with `TimestampParseException` although `DateTimeParseException` was caught.

@sakama @kamatama41 Can you have a look?