### PR TITLE
Fix "new" and "migrate" command not work in Windows.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/cli/EmbulkMigrate.java
+++ b/embulk-core/src/main/java/org/embulk/cli/EmbulkMigrate.java
@@ -382,13 +382,18 @@ public class EmbulkMigrate {
         }
 
         private void setExecutable(String targetFileName) throws IOException {
-            final Path targetPath = this.basePath.resolve(targetFileName);
-            final Set<PosixFilePermission> permissions =
-                    new HashSet<PosixFilePermission>(Files.getPosixFilePermissions(targetPath));
-            permissions.add(PosixFilePermission.OWNER_EXECUTE);
-            permissions.add(PosixFilePermission.GROUP_EXECUTE);
-            permissions.add(PosixFilePermission.OTHERS_EXECUTE);
-            Files.setPosixFilePermissions(targetPath, permissions);
+            try {
+                final Path targetPath = this.basePath.resolve(targetFileName);
+                final Set<PosixFilePermission> permissions =
+                        new HashSet<PosixFilePermission>(Files.getPosixFilePermissions(targetPath));
+                permissions.add(PosixFilePermission.OWNER_EXECUTE);
+                permissions.add(PosixFilePermission.GROUP_EXECUTE);
+                permissions.add(PosixFilePermission.OTHERS_EXECUTE);
+                Files.setPosixFilePermissions(targetPath, permissions);
+            } catch (UnsupportedOperationException ex) {
+                System.err.println("Warning: Skip setting executable permission to `gradlew`, "
+                        + "because POSIX permission is not supported by this filesystem.");
+            }
         }
 
         private final Path basePath;

--- a/embulk-core/src/main/java/org/embulk/cli/EmbulkNew.java
+++ b/embulk-core/src/main/java/org/embulk/cli/EmbulkNew.java
@@ -385,13 +385,18 @@ public class EmbulkNew {
     }
 
     private void setExecutable(String targetFileName) throws IOException {
-        final Path targetPath = this.pluginBasePath.resolve(targetFileName);
-        final Set<PosixFilePermission> permissions =
-                new HashSet<PosixFilePermission>(Files.getPosixFilePermissions(targetPath));
-        permissions.add(PosixFilePermission.OWNER_EXECUTE);
-        permissions.add(PosixFilePermission.GROUP_EXECUTE);
-        permissions.add(PosixFilePermission.OTHERS_EXECUTE);
-        Files.setPosixFilePermissions(targetPath, permissions);
+        try {
+            final Path targetPath = this.pluginBasePath.resolve(targetFileName);
+            final Set<PosixFilePermission> permissions =
+                    new HashSet<PosixFilePermission>(Files.getPosixFilePermissions(targetPath));
+            permissions.add(PosixFilePermission.OWNER_EXECUTE);
+            permissions.add(PosixFilePermission.GROUP_EXECUTE);
+            permissions.add(PosixFilePermission.OTHERS_EXECUTE);
+            Files.setPosixFilePermissions(targetPath, permissions);
+        } catch (UnsupportedOperationException ex) {
+            System.err.println("Warning: Skip setting executable permission to `gradlew`, "
+                    + "because POSIX permission is not supported by this filesystem.");
+        }
     }
 
     private final Path basePath;


### PR DESCRIPTION
See #1031.

NTFS filesystem not support POSIX permission.
I added process in `EmbulkNew#setExecutable` and `EmbulkMigrate#setExecutable`.

1. try/catch of `UnsupportedOperationException`
2. output warning and skip "set executable" process, if `UnsupportedOperationException` was throwd