### PR TITLE
Check Java versions also for non-Oracle Java: Fix #1056

### DIFF
--- a/embulk-core/src/main/bat/selfrun.bat
+++ b/embulk-core/src/main/bat/selfrun.bat
@@ -37,15 +37,15 @@ if "%overwrite_optimize%" == "true" (
 )
 
 for /f "delims=" %%w in ('java -fullversion 2^>^&1') do set java_fullversion=%%w
-echo %java_fullversion% | find "java full version ""1.7" > NUL
+echo %java_fullversion% | find " full version ""1.7" > NUL
 if not ERRORLEVEL 1 (set java_version=7)
-echo %java_fullversion% | find "java full version ""1.8" > NUL
+echo %java_fullversion% | find " full version ""1.8" > NUL
 if not ERRORLEVEL 1 (set java_version=8)
-echo %java_fullversion% | find "java full version ""9" > NUL
+echo %java_fullversion% | find " full version ""9" > NUL
 if not ERRORLEVEL 1 (set java_version=9)
-echo %java_fullversion% | find "java full version ""10" > NUL
+echo %java_fullversion% | find " full version ""10" > NUL
 if not ERRORLEVEL 1 (set java_version=10)
-echo %java_fullversion% | find "java full version ""11" > NUL
+echo %java_fullversion% | find " full version ""11" > NUL
 if not ERRORLEVEL 1 (set java_version=11)
 if not defined java_version (set java_version=0)
 

--- a/embulk-core/src/main/bat/selfrun.bat
+++ b/embulk-core/src/main/bat/selfrun.bat
@@ -69,10 +69,8 @@ if %java_version% EQU 7 (
     set java_args=--add-modules java.xml.bind --add-modules=java.se.ee %java_args%
 
 ) else if %java_version% EQU 11 (
-    echo [WARN] Embulk does not guarantee running with Java 11. 1>&2
-    echo [WARN] Executing Java with: "--add-modules java.xml.bind --add-modules=java.se.ee" 1>&2
-    echo. 1>&2
-    set java_args=--add-modules java.xml.bind --add-modules=java.se.ee %java_args%
+    echo [ERROR] Embulk does not support support Java 11 yet. 1>&2
+    exit 1
 
 ) else (
     echo [WARN] Unrecognized Java version: %java_fullversion% 1>&2

--- a/embulk-core/src/main/bat/selfrun.bat
+++ b/embulk-core/src/main/bat/selfrun.bat
@@ -69,7 +69,7 @@ if %java_version% EQU 7 (
     set java_args=--add-modules java.xml.bind --add-modules=java.se.ee %java_args%
 
 ) else if %java_version% EQU 11 (
-    echo [ERROR] Embulk does not support support Java 11 yet. 1>&2
+    echo [ERROR] Embulk does not support Java 11 yet. 1>&2
     exit 1
 
 ) else (

--- a/embulk-core/src/main/sh/selfrun.sh
+++ b/embulk-core/src/main/sh/selfrun.sh
@@ -53,25 +53,25 @@ done
 java_fullversion=`java -fullversion 2>&1`
 
 case "$java_fullversion" in
-    java\ full\ version\ \"1.7*\")
+    [a-z]*\ full\ version\ \"1.7*\")
         echo "[ERROR] Embulk no longer supports Java 1.7." 1>&2
         exit 1
         ;;
-    java\ full\ version\ \"1.8*\")
+    [a-z]*\ full\ version\ \"1.8*\")
         ;;
-    java\ full\ version\ \"9*\")
+    [a-z]*\ full\ version\ \"9*\")
         echo "[WARN] Embulk does not guarantee running with Java 9." 1>&2
         echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
         echo "" 1>&2
         java_args="--add-modules java.xml.bind --add-modules=java.se.ee $java_args"
         ;;
-    java\ full\ version\ \"10*\")
+    [a-z]*\ full\ version\ \"10*\")
         echo "[WARN] Embulk does not guarantee running with Java 10." 1>&2
         echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
         echo "" 1>&2
         java_args="--add-modules java.xml.bind --add-modules=java.se.ee $java_args"
         ;;
-    java\ full\ version\ \"11*\")
+    [a-z]*\ full\ version\ \"11*\")
         echo "[WARN] Embulk does not guarantee running with Java 11." 1>&2
         echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
         echo "" 1>&2

--- a/embulk-core/src/main/sh/selfrun.sh
+++ b/embulk-core/src/main/sh/selfrun.sh
@@ -72,10 +72,8 @@ case "$java_fullversion" in
         java_args="--add-modules java.xml.bind --add-modules=java.se.ee $java_args"
         ;;
     [a-z]*\ full\ version\ \"11*\")
-        echo "[WARN] Embulk does not guarantee running with Java 11." 1>&2
-        echo "[WARN] Executing Java with: \"--add-modules java.xml.bind --add-modules=java.se.ee\"" 1>&2
-        echo "" 1>&2
-        java_args="--add-modules java.xml.bind --add-modules=java.se.ee $java_args"
+        echo "[ERROR] Embulk does not support support Java 11 yet." 1>&2
+        exit 1
         ;;
     *)
         echo "[WARN] Unrecognized Java version: $java_fullversion" 1>&2

--- a/embulk-core/src/main/sh/selfrun.sh
+++ b/embulk-core/src/main/sh/selfrun.sh
@@ -72,7 +72,7 @@ case "$java_fullversion" in
         java_args="--add-modules java.xml.bind --add-modules=java.se.ee $java_args"
         ;;
     [a-z]*\ full\ version\ \"11*\")
-        echo "[ERROR] Embulk does not support support Java 11 yet." 1>&2
+        echo "[ERROR] Embulk does not support Java 11 yet." 1>&2
         exit 1
         ;;
     *)


### PR DESCRIPTION
This PR tries to fix #1056. Can you have a look, @sakama @kamatama41 @hiroyuki-sato ?

I assume that the names (`java` or `openjdk`) are lower-case alphabets. When we see other cases, we'll have another fix.