### PR TITLE
Support only rake 12.x on Java plugin's gemspec

### DIFF
--- a/embulk-core/src/main/resources/org/embulk/plugin/template/java/build.gradle.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/java/build.gradle.vm
@@ -90,7 +90,7 @@ Gem::Specification.new do |spec|
 
   #spec.add_dependency 'YOUR_GEM_DEPENDENCY', ['~> YOUR_GEM_DEPENDENCY_VERSION']
   spec.add_development_dependency 'bundler', ['~> 1.0']
-  spec.add_development_dependency 'rake', ['>= 10.0']
+  spec.add_development_dependency 'rake', ['~> 12.0']
 end
 /$)
     }


### PR DESCRIPTION
For #1061 
Open-ended dependency by using `>=` is not recommended by recent `gem` command.
So I made it narrower, only support rake v12.x.

What do you think about this? @sakama  @dmikurube 