### PR TITLE
Tidy up Java plugin templates.

### DIFF
--- a/embulk-core/src/main/resources/org/embulk/plugin/template/java/decoder.java.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/java/decoder.java.vm
@@ -1,10 +1,5 @@
 package ${javaPackageName};
 
-import java.io.InputStream;
-import java.io.IOException;
-
-import com.google.common.base.Optional;
-
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigInject;
@@ -14,8 +9,8 @@ import org.embulk.config.TaskSource;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.DecoderPlugin;
 import org.embulk.spi.FileInput;
-import org.embulk.spi.util.FileInputInputStream;
-import org.embulk.spi.util.InputStreamFileInput;
+
+import java.util.Optional;
 
 public class ${javaClassName}
         implements DecoderPlugin
@@ -25,20 +20,20 @@ public class ${javaClassName}
     {
         // configuration option 1 (required integer)
         @Config("option1")
-        public int getOption1();
+        int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
         @Config("option2")
         @ConfigDefault("\"myvalue\"")
-        public String getOption2();
+        String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
         @Config("option3")
         @ConfigDefault("null")
-        public Optional<String> getOption3();
+        Optional<String> getOption3();
 
         @ConfigInject
-        public BufferAllocator getBufferAllocator();
+        BufferAllocator getBufferAllocator();
     }
 
     @Override

--- a/embulk-core/src/main/resources/org/embulk/plugin/template/java/encoder.java.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/java/encoder.java.vm
@@ -1,10 +1,5 @@
 package ${javaPackageName};
 
-import java.io.IOException;
-import java.io.OutputStream;
-
-import com.google.common.base.Optional;
-
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigInject;
@@ -14,8 +9,8 @@ import org.embulk.config.TaskSource;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.EncoderPlugin;
 import org.embulk.spi.FileOutput;
-import org.embulk.spi.util.FileOutputOutputStream;
-import org.embulk.spi.util.OutputStreamFileOutput;
+
+import java.util.Optional;
 
 public class ${javaClassName}
         implements EncoderPlugin
@@ -25,20 +20,20 @@ public class ${javaClassName}
     {
         // configuration option 1 (required integer)
         @Config("option1")
-        public int getOption1();
+        int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
         @Config("option2")
         @ConfigDefault("\"myvalue\"")
-        public String getOption2();
+        String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
         @Config("option3")
         @ConfigDefault("null")
-        public Optional<String> getOption3();
+        Optional<String> getOption3();
 
         @ConfigInject
-        public BufferAllocator getBufferAllocator();
+        BufferAllocator getBufferAllocator();
     }
 
     @Override

--- a/embulk-core/src/main/resources/org/embulk/plugin/template/java/file_input.java.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/java/file_input.java.vm
@@ -1,11 +1,5 @@
 package ${javaPackageName};
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -18,7 +12,9 @@ import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FileInputPlugin;
 import org.embulk.spi.TransactionalFileInput;
-import org.embulk.spi.util.InputStreamTransactionalFileInput;
+
+import java.util.List;
+import java.util.Optional;
 
 public class ${javaClassName}
         implements FileInputPlugin
@@ -28,31 +24,31 @@ public class ${javaClassName}
     {
         // configuration option 1 (required integer)
         @Config("option1")
-        public int getOption1();
+        int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
         @Config("option2")
         @ConfigDefault("\"myvalue\"")
-        public String getOption2();
+        String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
         @Config("option3")
         @ConfigDefault("null")
-        public Optional<String> getOption3();
+        Optional<String> getOption3();
 
         //@Config("path_prefix")
-        //public String getPathPrefix();
+        //String getPathPrefix();
 
         //@Config("last_path")
         //@ConfigDefault("null")
-        //public Optional<String> getLastPath();
+        //Optional<String> getLastPath();
 
         // usually, you store list of files in task to pass them from transaction() to run().
-        //public List<String> getFiles();
-        //public void setFiles(List<String> files);
+        //List<String> getFiles();
+        //void setFiles(List<String> files);
 
         @ConfigInject
-        public BufferAllocator getBufferAllocator();
+        BufferAllocator getBufferAllocator();
     }
 
     @Override

--- a/embulk-core/src/main/resources/org/embulk/plugin/template/java/file_output.java.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/java/file_output.java.vm
@@ -1,9 +1,5 @@
 package ${javaPackageName};
 
-import java.util.List;
-
-import com.google.common.base.Optional;
-
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -14,6 +10,9 @@ import org.embulk.config.TaskSource;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.TransactionalFileOutput;
+
+import java.util.List;
+import java.util.Optional;
 
 public class ${javaClassName}
         implements FileOutputPlugin
@@ -42,14 +41,14 @@ public class ${javaClassName}
         //
 
         //@Config("path_prefix")
-        //public String getPathPrefix();
+        //String getPathPrefix();
 
         //@Config("file_ext")
-        //public String getFileNameExtension();
+        //String getFileNameExtension();
 
         //@Config("sequence_format")
         //@ConfigDefault("\"%03d.%02d.\"")
-        //public String getSequenceFormat();
+        //String getSequenceFormat();
     }
 
     @Override

--- a/embulk-core/src/main/resources/org/embulk/plugin/template/java/filter.java.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/java/filter.java.vm
@@ -1,17 +1,15 @@
 package ${javaPackageName};
 
-import com.google.common.base.Optional;
-
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
-import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
-import org.embulk.spi.Column;
 import org.embulk.spi.FilterPlugin;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
+
+import java.util.Optional;
 
 public class ${javaClassName}
         implements FilterPlugin
@@ -21,17 +19,17 @@ public class ${javaClassName}
     {
         // configuration option 1 (required integer)
         @Config("option1")
-        public int getOption1();
+        int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
         @Config("option2")
         @ConfigDefault("\"myvalue\"")
-        public String getOption2();
+        String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
         @Config("option3")
         @ConfigDefault("null")
-        public Optional<String> getOption3();
+        Optional<String> getOption3();
     }
 
     @Override

--- a/embulk-core/src/main/resources/org/embulk/plugin/template/java/input.java.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/java/input.java.vm
@@ -1,9 +1,5 @@
 package ${javaPackageName};
 
-import java.util.List;
-
-import com.google.common.base.Optional;
-
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -17,6 +13,9 @@ import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
 import org.embulk.spi.SchemaConfig;
 
+import java.util.List;
+import java.util.Optional;
+
 public class ${javaClassName}
         implements InputPlugin
 {
@@ -25,21 +24,21 @@ public class ${javaClassName}
     {
         // configuration option 1 (required integer)
         @Config("option1")
-        public int getOption1();
+        int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
         @Config("option2")
         @ConfigDefault("\"myvalue\"")
-        public String getOption2();
+        String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
         @Config("option3")
         @ConfigDefault("null")
-        public Optional<String> getOption3();
+        Optional<String> getOption3();
 
         // if you get schema from config
         @Config("columns")
-        public SchemaConfig getColumns();
+        SchemaConfig getColumns();
     }
 
     @Override

--- a/embulk-core/src/main/resources/org/embulk/plugin/template/java/output.java.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/java/output.java.vm
@@ -1,9 +1,5 @@
 package ${javaPackageName};
 
-import java.util.List;
-
-import com.google.common.base.Optional;
-
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -13,9 +9,11 @@ import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Exec;
 import org.embulk.spi.OutputPlugin;
-import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
+
+import java.util.List;
+import java.util.Optional;
 
 public class ${javaClassName}
         implements OutputPlugin
@@ -25,17 +23,17 @@ public class ${javaClassName}
     {
         // configuration option 1 (required integer)
         @Config("option1")
-        public int getOption1();
+        int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
         @Config("option2")
         @ConfigDefault("\"myvalue\"")
-        public String getOption2();
+        String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
         @Config("option3")
         @ConfigDefault("null")
-        public Optional<String> getOption3();
+        Optional<String> getOption3();
     }
 
     @Override

--- a/embulk-core/src/main/resources/org/embulk/plugin/template/java/parser.java.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/java/parser.java.vm
@@ -1,10 +1,7 @@
 package ${javaPackageName};
 
-import com.google.common.base.Optional;
-
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
-import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
@@ -14,6 +11,8 @@ import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.Schema;
 import org.embulk.spi.SchemaConfig;
 
+import java.util.Optional;
+
 public class ${javaClassName}
         implements ParserPlugin
 {
@@ -22,17 +21,17 @@ public class ${javaClassName}
     {
         // configuration option 1 (required integer)
         @Config("option1")
-        public int getOption1();
+        int getOption1();
 
         // configuration option 2 (optional string, null is not allowed)
         @Config("option2")
         @ConfigDefault("\"myvalue\"")
-        public String getOption2();
+        String getOption2();
 
         // configuration option 3 (optional string, null is allowed)
         @Config("option3")
         @ConfigDefault("null")
-        public Optional<String> getOption3();
+        Optional<String> getOption3();
 
         // if you get schema from config or data source
         @Config("columns")


### PR DESCRIPTION
- Replace Google's Optional with java.util.Optional
- Correct order to import classes (especially `java.util.*`)
- Remove unnecessary "public" scopes in PluginTask
- Remove unused imports

This is mainly for #1041.
I confirmed all generated classes are passed with `checkstyle` task.

@dmikurube @sakama Please review, thank you 🙏 