### PR TITLE
Parse excess dates like 2018-02-31 to overrun into the next month, in legacy and "ruby:" timestamp parsers

### DIFF
--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -651,18 +651,42 @@ public class TestTimestampParser {
     }
 
     @Test
-    public void testInvalidDate() {
-        failToParse("2018-02-31T12:34:56", "%Y-%m-%dT%H:%M:%S");
+    public void testExcessDate() {
+        testToParse("2018-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1520035200L);  // 2018-03-03
+        testToParse("2016-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1456876800L);  // 2016-03-02
+        testToParse("2018-11-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1543622400L);  // 2018-12-01
+
+        failToParse("2018-10-32T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failToParse("2018-13-01T00:00:00", "%Y-%m-%dT%H:%M:%S");
+
+        failToParse("2018-00-01T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failToParse("2018-01-00T00:00:00", "%Y-%m-%dT%H:%M:%S");
     }
 
     @Test
-    public void testRubyInvalidDate() {
-        failRubyToParse("2018-02-31T12:34:56", "%Y-%m-%dT%H:%M:%S");
+    public void testRubyExcessDate() {
+        testRubyToParse("2018-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1520035200L);  // 2018-03-03
+        testRubyToParse("2016-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1456876800L);  // 2016-03-02
+        testRubyToParse("2018-11-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1543622400L);  // 2018-12-01
+
+        failRubyToParse("2018-10-32T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failRubyToParse("2018-13-01T00:00:00", "%Y-%m-%dT%H:%M:%S");
+
+        failRubyToParse("2018-00-01T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failRubyToParse("2018-01-00T00:00:00", "%Y-%m-%dT%H:%M:%S");
     }
 
     @Test
-    public void testJavaInvalidDate() {
-        failJavaToParse("2018-02-31T12:34:56", "yyyy-MM-dd'T'HH:mm:ss");
+    public void testJavaExcessDate() {
+        failJavaToParse("2018-02-31T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+        failJavaToParse("2016-02-31T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+        failJavaToParse("2018-11-31T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+
+        failJavaToParse("2018-10-32T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+        failJavaToParse("2018-13-01T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+
+        failJavaToParse("2018-00-01T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+        failJavaToParse("2018-01-00T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
     }
 
     private void testJavaToParse(final String string, final String format, final long second, final int nanoOfSecond) {


### PR DESCRIPTION
Although we've merged #1052, it turned out that excess dates like `2018-02-31` were successfully parsed in Embulk v0.8 series and Ruby with overrunning into the next month. For example,

* `2018-02-31` is parsed into `2018-03-03`.
* `2016-02-31` is parsed into `2018-03-02`. (2016 is a leap year.)
* `2018-11-31` is parsed into `2018-12-01`.

For compatibility, we're going to follow this.
