### PR TITLE
Parse exceeding dates like 2018-02-31 only in the legacy timestamp parser, not in the "ruby:" timestamp parser

### DIFF
--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampParser.java
@@ -665,9 +665,9 @@ public class TestTimestampParser {
 
     @Test
     public void testRubyExcessDate() {
-        testRubyToParse("2018-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1520035200L);  // 2018-03-03
-        testRubyToParse("2016-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1456876800L);  // 2016-03-02
-        testRubyToParse("2018-11-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1543622400L);  // 2018-12-01
+        failRubyToParse("2018-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failRubyToParse("2016-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failRubyToParse("2018-11-31T00:00:00", "%Y-%m-%dT%H:%M:%S");
 
         failRubyToParse("2018-10-32T00:00:00", "%Y-%m-%dT%H:%M:%S");
         failRubyToParse("2018-13-01T00:00:00", "%Y-%m-%dT%H:%M:%S");


### PR DESCRIPTION
@sakama @kamatama41 As discussed directly,
* We once implement Ruby-compatible behavior with 2018-02-31 (to be 2018-03-03) in v0.9.10.
* Then, we will reject 2018-02-31 in later versions.

Toward this goal, I finally thought that we need this Ruby-compatible behavior only in the "legacy" timestamp parser. I'm reverting a change in #1067 on the "ruby:" timestamp parser.

Can you have a look?

----

JFYI: Embulk has three types of timestamp parsers since v0.9.0.

* Legacy: specified by `format: %Y-%m-...`. It aims to be compatible with Embulk v0.8.
    * We have compatible behavior about 2018-02-31 in v0.9.10.
    * We'll give up compatibility in later versions.
* Ruby: specified like `format: "ruby:%Y-%m-..."`. It aims to be more compliant with original Ruby's `Time.strptime`.
    * We'll have different behavior about 2018-02-31, though.
* Java: specified like `format: "java:uuuu-MM-..."`. It is based on `java.time.format.DateTimeFormatter`.