### PR TITLE
Revert Guice and Guava versions

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 // determine which dependencies have updates: $ gradle dependencyUpdates
 dependencies {
-    compile 'org.embulk:guice-bootstrap:0.3.2'
+    compile 'org.embulk:guice-bootstrap:0.3.0'
     compile 'com.google.guava:guava:18.0'
     compile 'com.google.inject:guice:4.0'
     compile 'com.google.inject.extensions:guice-multibindings:4.0'

--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -1,47 +1,46 @@
 package org.embulk;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigLoader;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.ModelManager;
 import org.embulk.exec.BulkLoader;
-import org.embulk.exec.ExecModule;
 import org.embulk.exec.ExecutionResult;
-import org.embulk.exec.ExtensionServiceLoaderModule;
 import org.embulk.exec.GuessExecutor;
 import org.embulk.exec.PartialExecutionException;
 import org.embulk.exec.PreviewExecutor;
 import org.embulk.exec.PreviewResult;
 import org.embulk.exec.ResumeState;
-import org.embulk.exec.SystemConfigModule;
 import org.embulk.exec.TransactionStage;
+import org.embulk.guice.Bootstrap;
 import org.embulk.guice.LifeCycleInjector;
-import org.embulk.jruby.JRubyScriptingModule;
-import org.embulk.plugin.BuiltinPluginSourceModule;
-import org.embulk.plugin.PluginClassLoaderModule;
-import org.embulk.plugin.maven.MavenPluginSourceModule;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.ExecSession;
 
 public class EmbulkEmbed {
-    private EmbulkEmbed(final ConfigSource systemConfig, final LifeCycleInjector injector) {
-        this.injector = injector;
-        this.logger = injector.getInstance(org.slf4j.ILoggerFactory.class).getLogger(EmbulkEmbed.class.getName());
-        this.bulkLoader = injector.getInstance(BulkLoader.class);
-        this.guessExecutor = injector.getInstance(GuessExecutor.class);
-        this.previewExecutor = injector.getInstance(PreviewExecutor.class);
+    public static ConfigLoader newSystemConfigLoader() {
+        return new ConfigLoader(new ModelManager(null, new ObjectMapper()));
     }
 
     public static class Bootstrap {
+        private final ConfigLoader systemConfigLoader;
+
+        private ConfigSource systemConfig;
+
+        private final List<Function<? super List<Module>, ? extends Iterable<? extends Module>>> moduleOverrides;
+
         public Bootstrap() {
             this.systemConfigLoader = newSystemConfigLoader();
             this.systemConfig = systemConfigLoader.newConfigSource();
@@ -49,187 +48,118 @@ public class EmbulkEmbed {
         }
 
         public ConfigLoader getSystemConfigLoader() {
-            return this.systemConfigLoader;
+            return systemConfigLoader;
         }
 
-        public Bootstrap setSystemConfig(final ConfigSource systemConfig) {
+        public Bootstrap setSystemConfig(ConfigSource systemConfig) {
             this.systemConfig = systemConfig.deepCopy();
             return this;
         }
 
-        public Bootstrap addModules(final Module... additionalModules) {
-            return this.addModules(Arrays.asList(additionalModules));
+        public Bootstrap addModules(Module... additionalModules) {
+            return addModules(Arrays.asList(additionalModules));
         }
 
-        public Bootstrap addModules(final Iterable<? extends Module> additionalModules) {
-            final ArrayList<Module> copyMutable = new ArrayList<>();
-            for (final Module module : additionalModules) {
-                copyMutable.add(module);
-            }
-            final List<Module> copy = Collections.unmodifiableList(copyMutable);
-            return this.overrideModules(modules -> Iterables.concat(modules, copy));
+        public Bootstrap addModules(Iterable<? extends Module> additionalModules) {
+            final List<Module> copy = ImmutableList.copyOf(additionalModules);
+            return overrideModules(new Function<List<Module>, Iterable<Module>>() {
+                    public Iterable<Module> apply(List<Module> modules) {
+                        return Iterables.concat(modules, copy);
+                    }
+                });
         }
 
-        @Deprecated
-        public Bootstrap overrideModules(
-                final com.google.common.base.Function<? super List<Module>, ? extends Iterable<? extends Module>> function) {
-            this.moduleOverrides.add(function::apply);
+        public Bootstrap overrideModules(Function<? super List<Module>, ? extends Iterable<? extends Module>> function) {
+            moduleOverrides.add(function);
             return this;
         }
 
         public EmbulkEmbed initialize() {
-            return this.build(true);
+            return build(true);
         }
 
         public EmbulkEmbed initializeCloseable() {
-            return this.build(false);
+            return build(false);
         }
 
-        private EmbulkEmbed build(final boolean destroyOnShutdownHook) {
+        private EmbulkEmbed build(boolean destroyOnShutdownHook) {
+            // TODO: Replace use of EmbulkService.
+            @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/932
             org.embulk.guice.Bootstrap bootstrap = new org.embulk.guice.Bootstrap()
                     .requireExplicitBindings(false)
-                    .addModules(standardModuleList(systemConfig));
+                    .addModules(EmbulkService.standardModuleList(systemConfig));
 
-            for (final Function<? super List<Module>, ? extends Iterable<? extends Module>> override : moduleOverrides) {
+            for (Function<? super List<Module>, ? extends Iterable<? extends Module>> override : moduleOverrides) {
                 bootstrap = bootstrap.overrideModules(override);
             }
 
-            final LifeCycleInjector injector;
+            LifeCycleInjector injector;
             if (destroyOnShutdownHook) {
                 injector = bootstrap.initialize();
             } else {
                 injector = bootstrap.initializeCloseable();
             }
 
-            return new EmbulkEmbed(this.systemConfig, injector);
+            return new EmbulkEmbed(systemConfig, injector);
         }
-
-        private final ConfigLoader systemConfigLoader;
-        private final List<Function<? super List<Module>, ? extends Iterable<? extends Module>>> moduleOverrides;
-
-        private ConfigSource systemConfig;
     }
 
-    public static class ResumableResult {
-        public ResumableResult(final PartialExecutionException partialExecutionException) {
-            this.successfulResult = null;
-            if (partialExecutionException == null) {
-                throw new NullPointerException();
-            }
-            this.partialExecutionException = partialExecutionException;
-        }
+    private final LifeCycleInjector injector;
+    private final org.slf4j.Logger logger;
+    private final BulkLoader bulkLoader;
+    private final GuessExecutor guessExecutor;
+    private final PreviewExecutor previewExecutor;
 
-        public ResumableResult(final ExecutionResult successfulResult) {
-            if (successfulResult == null) {
-                throw new NullPointerException();
-            }
-            this.successfulResult = successfulResult;
-            this.partialExecutionException = null;
-        }
-
-        public boolean isSuccessful() {
-            return successfulResult != null;
-        }
-
-        public ExecutionResult getSuccessfulResult() {
-            if (this.successfulResult == null) {
-                throw new IllegalStateException();
-            }
-            return this.successfulResult;
-        }
-
-        public Throwable getCause() {
-            if (this.partialExecutionException == null) {
-                throw new IllegalStateException();
-            }
-            return this.partialExecutionException.getCause();
-        }
-
-        public ResumeState getResumeState() {
-            if (this.partialExecutionException == null) {
-                throw new IllegalStateException();
-            }
-            return this.partialExecutionException.getResumeState();
-        }
-
-        public TransactionStage getTransactionStage() {
-            return this.partialExecutionException.getTransactionStage();
-        }
-
-        private final ExecutionResult successfulResult;
-        private final PartialExecutionException partialExecutionException;
-    }
-
-    public class ResumeStateAction {
-        public ResumeStateAction(final ConfigSource config, final ResumeState resumeState) {
-            this.config = config;
-            this.resumeState = resumeState;
-        }
-
-        public ResumableResult resume() {
-            final ExecutionResult result;
-            try {
-                result = bulkLoader.resume(config, resumeState);
-            } catch (final PartialExecutionException partial) {
-                return new ResumableResult(partial);
-            }
-            return new ResumableResult(result);
-        }
-
-        public void cleanup() {
-            bulkLoader.cleanup(config, resumeState);
-        }
-
-        private final ConfigSource config;
-        private final ResumeState resumeState;
-    }
-
-    public static ConfigLoader newSystemConfigLoader() {
-        return new ConfigLoader(new ModelManager(null, new ObjectMapper()));
+    EmbulkEmbed(ConfigSource systemConfig, LifeCycleInjector injector) {
+        this.injector = injector;
+        this.logger = injector.getInstance(org.slf4j.ILoggerFactory.class).getLogger(EmbulkEmbed.class.getName());
+        this.bulkLoader = injector.getInstance(BulkLoader.class);
+        this.guessExecutor = injector.getInstance(GuessExecutor.class);
+        this.previewExecutor = injector.getInstance(PreviewExecutor.class);
     }
 
     public Injector getInjector() {
-        return this.injector;
+        return injector;
     }
 
     public ModelManager getModelManager() {
-        return this.injector.getInstance(ModelManager.class);
+        return injector.getInstance(ModelManager.class);
     }
 
     public BufferAllocator getBufferAllocator() {
-        return this.injector.getInstance(BufferAllocator.class);
+        return injector.getInstance(BufferAllocator.class);
     }
 
     public ConfigLoader newConfigLoader() {
-        return this.injector.getInstance(ConfigLoader.class);
+        return injector.getInstance(ConfigLoader.class);
     }
 
-    public ConfigDiff guess(final ConfigSource config) {
+    public ConfigDiff guess(ConfigSource config) {
         this.logger.info("Started Embulk v" + EmbulkVersion.VERSION);
-        final ExecSession exec = newExecSession(config);
+        ExecSession exec = newExecSession(config);
         try {
-            return this.guessExecutor.guess(exec, config);
+            return guessExecutor.guess(exec, config);
         } finally {
             exec.cleanup();
         }
     }
 
-    public PreviewResult preview(final ConfigSource config) {
+    public PreviewResult preview(ConfigSource config) {
         this.logger.info("Started Embulk v" + EmbulkVersion.VERSION);
-        final ExecSession exec = newExecSession(config);
+        ExecSession exec = newExecSession(config);
         try {
-            return this.previewExecutor.preview(exec, config);
+            return previewExecutor.preview(exec, config);
         } finally {
             exec.cleanup();
         }
     }
 
-    public ExecutionResult run(final ConfigSource config) {
+    public ExecutionResult run(ConfigSource config) {
         this.logger.info("Started Embulk v" + EmbulkVersion.VERSION);
-        final ExecSession exec = newExecSession(config);
+        ExecSession exec = newExecSession(config);
         try {
             return bulkLoader.run(exec, config);
-        } catch (final PartialExecutionException partial) {
+        } catch (PartialExecutionException partial) {
             try {
                 bulkLoader.cleanup(config, partial.getResumeState());
             } catch (Throwable ex) {
@@ -239,7 +169,7 @@ public class EmbulkEmbed {
         } finally {
             try {
                 exec.cleanup();
-            } catch (final Exception ex) {
+            } catch (Exception ex) {
                 // TODO add this exception to ExecutionResult.getIgnoredExceptions
                 // or partial.addSuppressed
                 ex.printStackTrace(System.err);
@@ -247,21 +177,21 @@ public class EmbulkEmbed {
         }
     }
 
-    public ResumableResult runResumable(final ConfigSource config) {
+    public ResumableResult runResumable(ConfigSource config) {
         this.logger.info("Started Embulk v" + EmbulkVersion.VERSION);
-        final ExecSession exec = newExecSession(config);
+        ExecSession exec = newExecSession(config);
         try {
-            final ExecutionResult result;
+            ExecutionResult result;
             try {
                 result = bulkLoader.run(exec, config);
-            } catch (final PartialExecutionException partial) {
+            } catch (PartialExecutionException partial) {
                 return new ResumableResult(partial);
             }
             return new ResumableResult(result);
         } finally {
             try {
                 exec.cleanup();
-            } catch (final Exception ex) {
+            } catch (Exception ex) {
                 // TODO add this exception to ExecutionResult.getIgnoredExceptions
                 // or partial.addSuppressed
                 ex.printStackTrace(System.err);
@@ -269,43 +199,87 @@ public class EmbulkEmbed {
         }
     }
 
-    public ResumeStateAction resumeState(final ConfigSource config, final ConfigSource resumeStateConfig) {
+    private ExecSession newExecSession(ConfigSource config) {
+        ConfigSource execConfig = config.deepCopy().getNestedOrGetEmpty("exec");
+        return ExecSession.builder(injector).fromExecConfig(execConfig).build();
+    }
+
+    public ResumeStateAction resumeState(ConfigSource config, ConfigSource resumeStateConfig) {
         this.logger.info("Started Embulk v" + EmbulkVersion.VERSION);
-        final ResumeState resumeState = resumeStateConfig.loadConfig(ResumeState.class);
+        ResumeState resumeState = resumeStateConfig.loadConfig(ResumeState.class);
         return new ResumeStateAction(config, resumeState);
+    }
+
+    public static class ResumableResult {
+        private final ExecutionResult successfulResult;
+        private final PartialExecutionException partialExecutionException;
+
+        public ResumableResult(PartialExecutionException partialExecutionException) {
+            this.successfulResult = null;
+            this.partialExecutionException = checkNotNull(partialExecutionException);
+        }
+
+        public ResumableResult(ExecutionResult successfulResult) {
+            this.successfulResult = checkNotNull(successfulResult);
+            this.partialExecutionException = null;
+        }
+
+        public boolean isSuccessful() {
+            return successfulResult != null;
+        }
+
+        public ExecutionResult getSuccessfulResult() {
+            checkState(successfulResult != null);
+            return successfulResult;
+        }
+
+        public Throwable getCause() {
+            checkState(partialExecutionException != null);
+            return partialExecutionException.getCause();
+        }
+
+        public ResumeState getResumeState() {
+            checkState(partialExecutionException != null);
+            return partialExecutionException.getResumeState();
+        }
+
+        public TransactionStage getTransactionStage() {
+            return partialExecutionException.getTransactionStage();
+        }
+    }
+
+    public class ResumeStateAction {
+        private final ConfigSource config;
+        private final ResumeState resumeState;
+
+        public ResumeStateAction(ConfigSource config, ResumeState resumeState) {
+            this.config = config;
+            this.resumeState = resumeState;
+        }
+
+        public ResumableResult resume() {
+            ExecutionResult result;
+            try {
+                result = bulkLoader.resume(config, resumeState);
+            } catch (PartialExecutionException partial) {
+                return new ResumableResult(partial);
+            }
+            return new ResumableResult(result);
+        }
+
+        public void cleanup() {
+            bulkLoader.cleanup(config, resumeState);
+        }
     }
 
     public void destroy() {
         try {
-            this.injector.destroy();
-        } catch (final Exception ex) {
+            injector.destroy();
+        } catch (Exception ex) {
             if (ex instanceof RuntimeException) {
                 throw (RuntimeException) ex;
             }
             throw new RuntimeException(ex);
         }
     }
-
-    static List<Module> standardModuleList(final ConfigSource systemConfig) {
-        final ArrayList<Module> moduleListBuilt = new ArrayList<>();
-        moduleListBuilt.add(new SystemConfigModule(systemConfig));
-        moduleListBuilt.add(new ExecModule());
-        moduleListBuilt.add(new ExtensionServiceLoaderModule(systemConfig));
-        moduleListBuilt.add(new PluginClassLoaderModule(systemConfig));
-        moduleListBuilt.add(new BuiltinPluginSourceModule());
-        moduleListBuilt.add(new MavenPluginSourceModule(systemConfig));
-        moduleListBuilt.add(new JRubyScriptingModule(systemConfig));
-        return Collections.unmodifiableList(moduleListBuilt);
-    }
-
-    private ExecSession newExecSession(final ConfigSource config) {
-        final ConfigSource execConfig = config.deepCopy().getNestedOrGetEmpty("exec");
-        return ExecSession.builder(this.injector).fromExecConfig(execConfig).build();
-    }
-
-    private final LifeCycleInjector injector;
-    private final org.slf4j.Logger logger;
-    private final BulkLoader bulkLoader;
-    private final GuessExecutor guessExecutor;
-    private final PreviewExecutor previewExecutor;
 }

--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -2,13 +2,10 @@ package org.embulk;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterables;
-import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
-import com.google.inject.util.Modules;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -36,57 +33,12 @@ import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.ExecSession;
 
 public class EmbulkEmbed {
-    private EmbulkEmbed(final ConfigSource systemConfig, final Injector injector) {
+    private EmbulkEmbed(final ConfigSource systemConfig, final LifeCycleInjector injector) {
         this.injector = injector;
         this.logger = injector.getInstance(org.slf4j.ILoggerFactory.class).getLogger(EmbulkEmbed.class.getName());
         this.bulkLoader = injector.getInstance(BulkLoader.class);
         this.guessExecutor = injector.getInstance(GuessExecutor.class);
         this.previewExecutor = injector.getInstance(PreviewExecutor.class);
-    }
-
-    /**
-     * Bootstrap without Life Cycle Management (guice-bootstrap).
-     *
-     * <p>For external EmbulkEmbed users: DO NOT USE (depend on) THIS YET! Its interface still may change.
-     */
-    public static class SimpleBootstrap {
-        public SimpleBootstrap(final ConfigSource systemConfig) {
-            this.systemConfig = systemConfig;
-            this.additionalModules = new ArrayList<>();
-            this.overridingModules = new ArrayList<>();
-        }
-
-        public SimpleBootstrap addModules(final Module... additionalModules) {
-            return this.addModules(Arrays.asList(additionalModules));
-        }
-
-        public SimpleBootstrap addModules(final Collection<? extends Module> additionalModules) {
-            this.additionalModules.addAll(additionalModules);
-            return this;
-        }
-
-        public SimpleBootstrap overrideModules(final Module... overridingModules) {
-            return this.overrideModules(Arrays.asList(overridingModules));
-        }
-
-        public SimpleBootstrap overrideModules(final Collection<? extends Module> overridingModules) {
-            this.overridingModules.addAll(overridingModules);
-            return this;
-        }
-
-        public EmbulkEmbed build() {
-            final ArrayList<Module> initialModules = new ArrayList<>();
-            initialModules.addAll(standardModuleList(this.systemConfig));
-            initialModules.addAll(this.additionalModules);
-
-            final Module overriddenModule = Modules.override(initialModules).with(this.overridingModules);
-
-            return new EmbulkEmbed(this.systemConfig, Guice.createInjector(overriddenModule));
-        }
-
-        private final List<Module> additionalModules;
-        private final List<Module> overridingModules;
-        private final ConfigSource systemConfig;
     }
 
     public static class Bootstrap {
@@ -324,16 +276,13 @@ public class EmbulkEmbed {
     }
 
     public void destroy() {
-        if (this.injector instanceof LifeCycleInjector) {
-            final LifeCycleInjector lifeCycleInjector = (LifeCycleInjector) this.injector;
-            try {
-                lifeCycleInjector.destroy();
-            } catch (final Exception ex) {
-                if (ex instanceof RuntimeException) {
-                    throw (RuntimeException) ex;
-                }
-                throw new RuntimeException(ex);
+        try {
+            this.injector.destroy();
+        } catch (final Exception ex) {
+            if (ex instanceof RuntimeException) {
+                throw (RuntimeException) ex;
             }
+            throw new RuntimeException(ex);
         }
     }
 
@@ -354,7 +303,7 @@ public class EmbulkEmbed {
         return ExecSession.builder(this.injector).fromExecConfig(execConfig).build();
     }
 
-    private final Injector injector;
+    private final LifeCycleInjector injector;
     private final org.slf4j.Logger logger;
     private final BulkLoader bulkLoader;
     private final GuessExecutor guessExecutor;


### PR DESCRIPTION
Let me revert #1038 and #1048 once to have a v0.9 version that is surely more compatible with v0.8 series... #1038 upgraded Guice, and it upgraded Guava as well. Upgrading Guava may cause unexpected incompatibility.

Once next v0.9.11 is confirmed and considered to be more "compatible" with v0.8, Guice/Guava are upgraded again in later versions. The same approach with #1068 about dates like 2018-02-31.

@sakama @kamatama41 Can I have your opinions on this?