### PR TITLE
Warn for EmbulkEmbed#destroy

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -316,6 +316,11 @@ public class EmbulkEmbed {
     }
 
     public void destroy() {
+        // TODO: Throw this exception in reality. It may be UnsupportedOperationException finally.
+        new RuntimeException(
+                "EmbulkEmbed#destroy() is planned to be unsupported as JSR-250 lifecycle annotations are unsupported. "
+                + "See https://github.com/embulk/embulk/issues/1047 for the details.")
+                .printStackTrace();
         try {
             injector.destroy();
         } catch (Exception ex) {

--- a/embulk-test/src/main/java/org/embulk/test/TestingEmbulk.java
+++ b/embulk-test/src/main/java/org/embulk/test/TestingEmbulk.java
@@ -91,7 +91,8 @@ public class TestingEmbulk implements TestRule {
 
     public void destroy() {
         if (embed != null) {
-            embed.destroy();
+            // EmbulkEmbed#destroy had been called here.
+            // It was removed as JSR-250 lifecycle support is to be unsupported.
             embed = null;
         }
         if (tempFiles != null) {
@@ -111,10 +112,8 @@ public class TestingEmbulk implements TestRule {
             reset();
         }
 
-        @Override
-        protected void finished(Description description) {
-            destroy();
-        }
+        // EmbulkEmbed#destroy had been called in TestWatcher#finished.
+        // It was removed as JSR-250 lifecycle support is to be unsupported.
     }
 
     public Path createTempFile(String suffix) {


### PR DESCRIPTION
After #1075, warning for `EmbulkEmbed#destroy` as well. The method is effective only for  `@PreDestroy` methods, but as mentioned in #1075, we don't observe actual usages of `@PreDestroy` around Embulk.

Can you have a look? @sakama @kamatama41 