### PR TITLE
Use Guice directly without guice-bootstrap's lifecycle annotation support

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -34,7 +34,6 @@ repositories {
 
 // determine which dependencies have updates: $ gradle dependencyUpdates
 dependencies {
-    compile 'org.embulk:guice-bootstrap:0.3.0'
     compile 'com.google.guava:guava:18.0'
     compile 'com.google.inject:guice:4.0'
     compile 'com.google.inject.extensions:guice-multibindings:4.0'


### PR DESCRIPTION
It actually removes guice-bootstrap's lifecycle annotation support as warned in #1075 and #1077. This is to be merged sometime after v0.9.12 is released with #1075 and #1077. If we have reports from users about #1075 or #1077, it will be reconsidered.

It is porting guice-bootstrap's [`Bootstrap`](https://github.com/embulk/guice-bootstrap/blob/v0.3.0/src/main/java/org/embulk/guice/Bootstrap.java) into `EmbulkEmbed.Bootstrap` with removing lifecycle annotation support.

@sakama @kamatama41 Can you have a look?