### PR TITLE
Silence LoggerProvider, and configure Logback only when Embulk is executed from CLI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,8 +185,9 @@ dependencies {
     compile project(':embulk-core')
     compile project(':embulk-standards')
 
-    // Logback is included only in the executable package.
+    // Logback and jansi are included only in the executable package. (jansi for logback colors to work on Windows.)
     compile 'ch.qos.logback:logback-classic:1.1.3'
+    compile 'org.fusesource.jansi:jansi:1.11'
 }
 
 shadowJar {  // Builds a fat-JAR with recurred dependencies from the above ':embulk-core' and ':embulk-standards'.

--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,9 @@ repositories {
 dependencies {
     compile project(':embulk-core')
     compile project(':embulk-standards')
+
+    // Logback is included only in the executable package.
+    compile 'ch.qos.logback:logback-classic:1.1.3'
 }
 
 shadowJar {  // Builds a fat-JAR with recurred dependencies from the above ':embulk-core' and ':embulk-standards'.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -6,5 +6,6 @@ This directory contains Embulk project's internal design documentation in Markdo
 ## Document Index
 
 * [External Variables](external_variables.md) - Listing of external variables affecting Embulk's execution
+* [SLF4J Logging](slf4j.md) - How SLF4J works in Embulk
 * [Timestamp Parsing](timestamp_parsing.md) - Basic design policy to parse timestamps in the Embulk core framework
 * [Undocumented Features](undocumented.md) - Features undocumented as they are experimental, fragile, unstable, unsupported and/or only for developers

--- a/docs/design/slf4j.md
+++ b/docs/design/slf4j.md
@@ -1,0 +1,49 @@
+SLF4J Logging
+==============
+
+Embulk has adopted [SLF4J](https://www.slf4j.org/) for logging both in the core and plugins. This document describes the history and the current status how SLF4J is adopted in Embulk.
+
+
+Initially
+----------
+
+* SLF4J 1.7.9 and Log4j 1.2.17 were chosen in Embulk v0.1.0.
+* All slf4j-api, slf4j-log4j12, and log4j had been included in embulk-core's dependencies.
+* All slf4j-api, slf4j-log4j12, and log4j had been extracted and included flatly in Embulk's binary executable distributions.
+* Plugins depended on slf4j-api in embulk-core's dependencies (as provided) or in executable distributions.
+* Logger instances were retrieved from `org.embulk.exec.LoggerProvider` (`com.google.inject.Provider<org.slf4j.ILoggerFactory>`) through Guice.
+  * Log4j, the default logger implementation, was initialized/configured in `org.embulk.exec.LoggerProvider`.
+  * Plugins had to call `Exec.getLogger`, instead of calling `LoggerFactory.getLogger` directly, so that the plugin could retrieve an overridden Logger.
+* Software using Embulk as a library had to override Guice bindings through `EmbulkService` or `EmbulkEmbed` to use another logger implementation.
+  * Different logger implementations were able to be assigned to different `ExecSession` instances even in the same Java VM process.
+  * Even if `LoggerProvider` was overridden by another logger implementation, slf4j-log4j21 and log4j were still in the classpath.
+
+
+Since Embulk v0.6.12
+--------------------
+
+* Logback 1.1.3 was chosen as a logger implementation in place of Log4j.
+* The logger architecture did not change only except for the logger implementation.
+
+
+Since Embulk v0.9.?? (upcoming)
+--------------------------------
+
+* Only slf4j-api will be included in embulk-core's dependencies. Logback is not in the dependencies.
+* Both slf4j-api and logback will be extracted and included flatly in Embulk's binary executable distributions.
+* Logback will be initialized/configured globally only when the binary executable distribution is executed from CLI.
+* Logger instances will be retrieved from `org.slf4j.LoggerFactory` directly, not through Guice.
+  * Plugins will be allowed to call `LoggerFactory.getLogger` directly.
+  * `Exec.getLogger` and `ExecSession.getLogger` will be deprecated to call `org.slf4j.LoggerFactory#getLogger` directly.
+  * The `LoggerProvider` module will be deprecated/removed as well.
+* Software using Embulk as a library will need to configure the classpath or classloading to choose the logger implementation.
+  * The logger implementation will be chosen globally by SLF4J's default selection method.
+  * Only one logger implmentation will be available in the same Java VM process. No more different logger implementations for different `ExecSession` instances.
+
+
+In the future
+--------------
+
+* SLF4J may be updated to the 1.8 series.
+* Plugins may have slf4j-api by themselves. Or, different slf4j-api may be assigned to each `PluginClassLoader` by the core.
+* The logger implementation may be switched to Embulk's own one to forward to the Reporter Plugin.

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -55,7 +55,6 @@ dependencies {
     compile 'io.airlift:slice:0.9'
     compile 'joda-time:joda-time:2.9.2'
     compile 'io.netty:netty-buffer:4.0.44.Final'
-    compile 'org.fusesource.jansi:jansi:1.11'
     compile 'org.msgpack:msgpack-core:0.8.11'
 
     // For embulk/guess/charset.rb. See also embulk.gemspec

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -46,7 +46,6 @@ dependencies {
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7'
     compile 'com.fasterxml.jackson.module:jackson-module-guice:2.6.7'
-    compile 'ch.qos.logback:logback-classic:1.1.3'
     compile 'org.slf4j:slf4j-api:1.7.12'
     compile 'org.jruby:jruby-complete:' + rootProject.jrubyVersion
     compile 'com.google.code.findbugs:annotations:3.0.0'

--- a/embulk-core/src/main/java/org/embulk/cli/CliLogbackConfigurator.java
+++ b/embulk-core/src/main/java/org/embulk/cli/CliLogbackConfigurator.java
@@ -1,0 +1,211 @@
+package org.embulk.cli;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Optional;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configures Logback's root logger.
+ *
+ * <p>It calls Logback's configurators through reflection so that embulk-core does not need to depend on Logback's classes.
+ */
+@SuppressWarnings({"checkstyle:AbbreviationAsWordInName", "checkstyle:MemberName", "checkstyle:ParameterName"})
+final class CliLogbackConfigurator {
+    static void configure(final Optional<String> logPath, final Optional<String> logLevel) {
+        final URL configurationResource = chooseConfigurationResource(logPath);
+        final ClassLoader classLoader = CliLogbackConfigurator.class.getClassLoader();
+        try {
+            new CliLogbackConfigurator(classLoader).configureLogger(logLevel, configurationResource);
+        } catch (final LogbackException ex) {
+            final Throwable cause = ex.getCause();
+            if (cause instanceof ReflectiveOperationException) {
+                System.err.println("Failed in loading Logback classes.");
+            } else {
+                System.err.println("Failed in configuring Logback.");
+            }
+            cause.printStackTrace();
+        }
+    }
+
+    private CliLogbackConfigurator(final ClassLoader classLoader) throws LogbackException {
+        try {
+            this.Level_class = classLoader.loadClass("ch.qos.logback.classic.Level");
+            this.Logger_class = classLoader.loadClass("ch.qos.logback.classic.Logger");
+            this.LoggerContext_class = classLoader.loadClass("ch.qos.logback.classic.LoggerContext");
+            this.JoranConfigurator_class = classLoader.loadClass("ch.qos.logback.classic.joran.JoranConfigurator");
+            this.Context_class = classLoader.loadClass("ch.qos.logback.core.Context");
+            this.JoranException_class = classLoader.loadClass("ch.qos.logback.core.joran.spi.JoranException");
+
+            this.OFF = getStaticField(this.Level_class, "OFF");
+            this.ERROR = getStaticField(this.Level_class, "ERROR");
+            this.WARN = getStaticField(this.Level_class, "WARN");
+            this.INFO = getStaticField(this.Level_class, "INFO");
+            this.DEBUG = getStaticField(this.Level_class, "DEBUG");
+            this.TRACE = getStaticField(this.Level_class, "TRACE");
+
+            this.constructJoranConfigurator = this.JoranConfigurator_class.getConstructor();
+
+            this.setLevel = this.Logger_class.getMethod("setLevel", this.Level_class);
+            this.reset = this.LoggerContext_class.getMethod("reset");
+            this.setContext = this.JoranConfigurator_class.getMethod("setContext", this.Context_class);
+            this.doConfigure = this.JoranConfigurator_class.getMethod("doConfigure", URL.class);
+        } catch (final ReflectiveOperationException ex) {
+            throw new LogbackException(ex);
+        }
+    }
+
+    private void configureLogger(final Optional<String> logLevel, final URL configurationResource) throws LogbackException {
+        /*
+         * LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+         */
+        final ILoggerFactory context = LoggerFactory.getILoggerFactory();
+        if (!context.getClass().isAssignableFrom(this.LoggerContext_class)) {
+            throw new ClassCastException(
+                    "LoggerFactory.getILoggerFactory() did not return logback's ch.qos.logback.classic.LoggerContext.");
+        }
+
+        /*
+         * JoranConfigurator configurator = new JoranConfigurator();
+         * configurator.setContext(context);
+         * context.reset();
+         */
+        final Object configuratorObject;
+        try {
+            configuratorObject = this.constructJoranConfigurator.newInstance();
+            this.setContext.invoke(configuratorObject, context);
+            this.reset.invoke(context);
+        } catch (final ReflectiveOperationException ex) {
+            throw new LogbackException(ex);
+        }
+
+        /*
+         * try {
+         *     configurator.doConfigure(getClass().getResource(name));
+         * } catch (JoranException ex) {
+         *     throw new RuntimeException(ex);
+         * }
+         */
+        try {
+            this.doConfigure.invoke(configuratorObject, configurationResource);
+        } catch (final ReflectiveOperationException ex) {
+            if (ex instanceof InvocationTargetException) {
+                final Throwable targetException = ((InvocationTargetException) ex).getTargetException();
+                if (this.JoranException_class.isAssignableFrom(targetException.getClass())) {
+                    throw new RuntimeException(targetException);
+                }
+            }
+            throw new LogbackException(ex);
+        }
+
+        final Logger logger = getRootLogger();
+
+        /*
+         * if (logger instanceof Logger) {
+         *     ((Logger) logger).setLevel(Level.toLevel(level.toUpperCase(), Level.DEBUG));
+         * }
+         */
+        if (this.Logger_class.isAssignableFrom(logger.getClass())) {
+            try {
+                this.setLevel.invoke(logger, this.chooseLevel(logLevel));
+            } catch (final ReflectiveOperationException ex) {
+                throw new LogbackException(ex);
+            }
+        }
+
+    }
+
+    private static URL chooseConfigurationResource(final Optional<String> logPath) {
+        if (logPath.orElse("-").equals("-")) {
+            if (System.console() != null) {
+                return CliLogbackConfigurator.class.getResource("/embulk/logback-color.xml");
+            } else {
+                return CliLogbackConfigurator.class.getResource("/embulk/logback-console.xml");
+            }
+        }
+
+        // logback uses system property to embed variables in XML file
+        System.setProperty("embulk.logPath", logPath.get());
+        return CliLogbackConfigurator.class.getResource("/embulk/logback-file.xml");
+    }
+
+    private Object chooseLevel(final Optional<String> levelString) {
+        switch (levelString.orElse("info")) {
+            case "error":
+                return this.ERROR;
+            case "warn":
+                return this.WARN;
+            case "info":
+                return this.INFO;
+            case "debug":
+                return this.DEBUG;
+            case "trace":
+                return this.TRACE;
+            default:
+                throw new IllegalArgumentException(String.format(
+                        "Log level %s is invalid. Available levels are error, warn, info, debug and trace.",
+                        levelString.orElse("(null)")));
+        }
+    }
+
+    private static Logger getRootLogger() throws LogbackException {
+        // org.slf4j.Logger.ROOT_LOGGER_NAME is fine. ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME inherits slf4j's.
+        final Logger logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        if (logger == null) {
+            throw new NullPointerException("The root logger is unexpectedly null.");
+        }
+        if (!logger.getClass().getName().equals("ch.qos.logback.classic.Logger")) {
+            throw new ClassCastException("The root logger is unexpectedly not ch.qos.logback.classic.Logger.");
+        }
+        return logger;
+    }
+
+    private static Object getStaticField(final Class<?> clazz, final String fieldName) throws LogbackException {
+        try {
+            final Field field = clazz.getField(fieldName);
+            return field.get(null);
+        } catch (final ReflectiveOperationException ex) {
+            throw new LogbackException(ex);
+        }
+    }
+
+    private static final class LogbackException extends ReflectiveOperationException {
+        public LogbackException(final ReflectiveOperationException cause) {
+            super(pickupException(cause));
+        }
+
+        private static Throwable pickupException(final ReflectiveOperationException cause) {
+            if (cause instanceof InvocationTargetException) {
+                return ((InvocationTargetException) cause).getTargetException();
+            } else {
+                return cause;
+            }
+        }
+    }
+
+    private final Class<?> Level_class;
+    private final Class<?> Logger_class;
+    private final Class<?> LoggerContext_class;
+    private final Class<?> JoranException_class;
+    private final Class<?> Context_class;
+    private final Class<?> JoranConfigurator_class;
+
+    private final Object OFF;
+    private final Object ERROR;
+    private final Object WARN;
+    private final Object INFO;
+    private final Object DEBUG;
+    private final Object TRACE;
+
+    private final Constructor<?> constructJoranConfigurator;
+
+    private final Method setLevel;
+    private final Method reset;
+    private final Method setContext;
+    private final Method doConfigure;
+}

--- a/embulk-core/src/main/java/org/embulk/cli/EmbulkCommandLine.java
+++ b/embulk-core/src/main/java/org/embulk/cli/EmbulkCommandLine.java
@@ -12,8 +12,6 @@ public class EmbulkCommandLine {
     private EmbulkCommandLine(
             final List<String> arguments,
             final Map<String, Object> systemConfig,
-            final String logPath,
-            final String logLevel,
             final String bundlePath,
             final String configDiff,
             final boolean force,
@@ -22,8 +20,6 @@ public class EmbulkCommandLine {
             final String resumeState) {
         this.arguments = Collections.unmodifiableList(arguments);
         this.systemConfig = Collections.unmodifiableMap(systemConfig);
-        this.logPath = logPath;
-        this.logLevel = logLevel;
         this.bundlePath = bundlePath;
         this.configDiff = configDiff;
         this.force = force;
@@ -36,8 +32,6 @@ public class EmbulkCommandLine {
         public Builder() {
             this.arguments = new ArrayList<String>();
             this.systemConfig = new HashMap<String, Object>();
-            this.logPath = null;
-            this.logLevel = null;
             this.bundlePath = null;
             this.configDiff = null;
             this.force = false;
@@ -69,8 +63,6 @@ public class EmbulkCommandLine {
             return new EmbulkCommandLine(
                     this.arguments,
                     systemConfigJRubyLoadPath,
-                    this.logPath,
-                    this.logLevel,
                     this.bundlePath,
                     this.configDiff,
                     this.force,
@@ -91,18 +83,6 @@ public class EmbulkCommandLine {
 
         public Builder addSystemConfig(final String key, final String value) {
             addInHashMap(this.systemConfig, key, value);
-            return this;
-        }
-
-        public Builder setLogPath(final String logPath) {
-            this.logPath = logPath;
-            addInHashMap(this.systemConfig, "log_path", logPath);
-            return this;
-        }
-
-        public Builder setLogLevel(final String logLevel) {
-            this.logLevel = logLevel;
-            addInHashMap(this.systemConfig, "log_level", logLevel);
             return this;
         }
 
@@ -162,8 +142,6 @@ public class EmbulkCommandLine {
 
         private ArrayList<String> arguments;
         private HashMap<String, Object> systemConfig;
-        private String logPath;
-        private String logLevel;
         private String bundlePath;
         private String configDiff;
         private boolean force;
@@ -184,14 +162,6 @@ public class EmbulkCommandLine {
 
     public final Map<String, Object> getSystemConfig() {
         return this.systemConfig;
-    }
-
-    public final String getLogPath() {
-        return this.logPath;
-    }
-
-    public final String getLogLevel() {
-        return this.logLevel;
     }
 
     public final String getBundlePath() {
@@ -220,8 +190,6 @@ public class EmbulkCommandLine {
 
     private final List<String> arguments;
     private final Map<String, Object> systemConfig;
-    private final String logPath;
-    private final String logLevel;
     private final String bundlePath;
     private final String configDiff;
     private final boolean force;

--- a/embulk-core/src/main/java/org/embulk/cli/EmbulkCommandLine.java
+++ b/embulk-core/src/main/java/org/embulk/cli/EmbulkCommandLine.java
@@ -12,6 +12,8 @@ public class EmbulkCommandLine {
     private EmbulkCommandLine(
             final List<String> arguments,
             final Map<String, Object> systemConfig,
+            final String logPath,
+            final String logLevel,
             final String bundlePath,
             final String configDiff,
             final boolean force,
@@ -20,6 +22,8 @@ public class EmbulkCommandLine {
             final String resumeState) {
         this.arguments = Collections.unmodifiableList(arguments);
         this.systemConfig = Collections.unmodifiableMap(systemConfig);
+        this.logPath = logPath;
+        this.logLevel = logLevel;
         this.bundlePath = bundlePath;
         this.configDiff = configDiff;
         this.force = force;
@@ -32,6 +36,8 @@ public class EmbulkCommandLine {
         public Builder() {
             this.arguments = new ArrayList<String>();
             this.systemConfig = new HashMap<String, Object>();
+            this.logPath = null;
+            this.logLevel = null;
             this.bundlePath = null;
             this.configDiff = null;
             this.force = false;
@@ -63,6 +69,8 @@ public class EmbulkCommandLine {
             return new EmbulkCommandLine(
                     this.arguments,
                     systemConfigJRubyLoadPath,
+                    this.logPath,
+                    this.logLevel,
                     this.bundlePath,
                     this.configDiff,
                     this.force,
@@ -83,6 +91,18 @@ public class EmbulkCommandLine {
 
         public Builder addSystemConfig(final String key, final String value) {
             addInHashMap(this.systemConfig, key, value);
+            return this;
+        }
+
+        public Builder setLogPath(final String logPath) {
+            this.logPath = logPath;
+            addInHashMap(this.systemConfig, "log_path", logPath);
+            return this;
+        }
+
+        public Builder setLogLevel(final String logLevel) {
+            this.logLevel = logLevel;
+            addInHashMap(this.systemConfig, "log_level", logLevel);
             return this;
         }
 
@@ -142,6 +162,8 @@ public class EmbulkCommandLine {
 
         private ArrayList<String> arguments;
         private HashMap<String, Object> systemConfig;
+        private String logPath;
+        private String logLevel;
         private String bundlePath;
         private String configDiff;
         private boolean force;
@@ -162,6 +184,14 @@ public class EmbulkCommandLine {
 
     public final Map<String, Object> getSystemConfig() {
         return this.systemConfig;
+    }
+
+    public final String getLogPath() {
+        return this.logPath;
+    }
+
+    public final String getLogLevel() {
+        return this.logLevel;
     }
 
     public final String getBundlePath() {
@@ -190,6 +220,8 @@ public class EmbulkCommandLine {
 
     private final List<String> arguments;
     private final Map<String, Object> systemConfig;
+    private final String logPath;
+    private final String logLevel;
     private final String bundlePath;
     private final String configDiff;
     private final boolean force;

--- a/embulk-core/src/main/java/org/embulk/cli/EmbulkRun.java
+++ b/embulk-core/src/main/java/org/embulk/cli/EmbulkRun.java
@@ -15,6 +15,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.embulk.EmbulkRunner;
 import org.embulk.EmbulkSetup;
 import org.embulk.cli.parse.EmbulkCommandLineHelpRequired;
@@ -88,6 +89,9 @@ public class EmbulkRun {
                     parser.printHelp(System.err);
                     return 1;
                 }
+                CliLogbackConfigurator.configure(
+                        Optional.ofNullable(commandLine.getLogPath()),
+                        Optional.ofNullable(commandLine.getLogLevel()));
                 return runSubcommand(subcommand, subcommandArguments, commandLine, jrubyOptions);
         }
     }
@@ -610,7 +614,7 @@ public class EmbulkRun {
                 "log", "PATH", "Output log messages to a file (default: -)",
                 new OptionBehavior() {
                     public void behave(final EmbulkCommandLine.Builder commandLineBuilder, final String argument) {
-                        commandLineBuilder.setSystemConfig("log_path", argument);
+                        commandLineBuilder.setLogPath(argument);
                     }
                 }));
         // op.on('-l', '--log-level LEVEL', 'Log level (error, warn, info, debug or trace)') do
@@ -621,7 +625,7 @@ public class EmbulkRun {
                 "l", "log-level", "LEVEL", "Log level (error, warn, info, debug or trace)",
                 new OptionBehavior() {
                     public void behave(final EmbulkCommandLine.Builder commandLineBuilder, final String argument) {
-                        commandLineBuilder.setSystemConfig("log_level", argument);
+                        commandLineBuilder.setLogLevel(argument);
                     }
                 }));
         // op.on('-X KEY=VALUE', 'Add a performance system config') do |kv|

--- a/embulk-core/src/main/java/org/embulk/cli/EmbulkRun.java
+++ b/embulk-core/src/main/java/org/embulk/cli/EmbulkRun.java
@@ -15,7 +15,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import org.embulk.EmbulkRunner;
 import org.embulk.EmbulkSetup;
 import org.embulk.cli.parse.EmbulkCommandLineHelpRequired;
@@ -89,9 +88,6 @@ public class EmbulkRun {
                     parser.printHelp(System.err);
                     return 1;
                 }
-                CliLogbackConfigurator.configure(
-                        Optional.ofNullable(commandLine.getLogPath()),
-                        Optional.ofNullable(commandLine.getLogLevel()));
                 return runSubcommand(subcommand, subcommandArguments, commandLine, jrubyOptions);
         }
     }
@@ -614,7 +610,7 @@ public class EmbulkRun {
                 "log", "PATH", "Output log messages to a file (default: -)",
                 new OptionBehavior() {
                     public void behave(final EmbulkCommandLine.Builder commandLineBuilder, final String argument) {
-                        commandLineBuilder.setLogPath(argument);
+                        commandLineBuilder.setSystemConfig("log_path", argument);
                     }
                 }));
         // op.on('-l', '--log-level LEVEL', 'Log level (error, warn, info, debug or trace)') do
@@ -625,7 +621,7 @@ public class EmbulkRun {
                 "l", "log-level", "LEVEL", "Log level (error, warn, info, debug or trace)",
                 new OptionBehavior() {
                     public void behave(final EmbulkCommandLine.Builder commandLineBuilder, final String argument) {
-                        commandLineBuilder.setLogLevel(argument);
+                        commandLineBuilder.setSystemConfig("log_level", argument);
                     }
                 }));
         // op.on('-X KEY=VALUE', 'Add a performance system config') do |kv|

--- a/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
+++ b/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
@@ -30,6 +30,7 @@ import org.embulk.spi.Schema;
 import org.embulk.spi.TaskState;
 import org.embulk.spi.util.Filters;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BulkLoader {
     private final Injector injector;
@@ -500,7 +501,7 @@ public class BulkLoader {
         final ExecutorPlugin exec = newExecutorPlugin(task);
         final ProcessPluginSet plugins = new ProcessPluginSet(task);
 
-        final LoaderState state = newLoaderState(Exec.getLogger(BulkLoader.class), plugins);
+        final LoaderState state = newLoaderState(logger, plugins);
         state.setTransactionStage(TransactionStage.INPUT_BEGIN);
         try {
             ConfigDiff inputConfigDiff = plugins.getInputPlugin().transaction(task.getInputConfig(), new InputPlugin.Control() {
@@ -572,7 +573,7 @@ public class BulkLoader {
         final ExecutorPlugin exec = newExecutorPlugin(task);
         final ProcessPluginSet plugins = new ProcessPluginSet(task);
 
-        final LoaderState state = newLoaderState(Exec.getLogger(BulkLoader.class), plugins);
+        final LoaderState state = newLoaderState(logger, plugins);
         state.setTransactionStage(TransactionStage.INPUT_BEGIN);
         try {
             @SuppressWarnings("checkstyle:LineLength")
@@ -699,4 +700,6 @@ public class BulkLoader {
     private static Schema last(List<Schema> schemas) {
         return schemas.get(schemas.size() - 1);
     }
+
+    private static final Logger logger = LoggerFactory.getLogger(BulkLoader.class);
 }

--- a/embulk-core/src/main/java/org/embulk/exec/LoggerProvider.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LoggerProvider.java
@@ -1,71 +1,12 @@
 package org.embulk.exec;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
-import ch.qos.logback.core.joran.spi.JoranException;
-import com.google.inject.Inject;
 import com.google.inject.Provider;
-import org.embulk.config.ConfigSource;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
 public class LoggerProvider implements Provider<ILoggerFactory> {
-    @Inject
-    public LoggerProvider(@ForSystemConfig ConfigSource systemConfig) {
-        final String level;
-        String logLevel = systemConfig.get(String.class, "log_level", "info");  // here can't use loadConfig because ModelManager uses LoggerProvider
-        switch (logLevel) {
-            case "error":
-                level = "ERROR";
-                break;
-            case "warn":
-                level = "WARN";
-                break;
-            case "info":
-                level = "INFO";
-                break;
-            case "debug":
-                level = "DEBUG";
-                break;
-            case "trace":
-                level = "TRACE";
-                break;
-            default:
-                throw new IllegalArgumentException(String.format(
-                        "System property embulk.logLevel=%s is invalid. Available levels are error, warn, info, debug and trace.", logLevel));
-        }
-
-        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-        JoranConfigurator configurator = new JoranConfigurator();
-        configurator.setContext(context);
-        context.reset();
-
-        String logPath = systemConfig.get(String.class, "log_path", "-");
-
-        String name;
-        if (logPath.equals("-")) {
-            if (System.console() != null) {
-                name = "/embulk/logback-color.xml";
-            } else {
-                name = "/embulk/logback-console.xml";
-            }
-        } else {
-            // logback uses system property to embed variables in XML file
-            System.setProperty("embulk.logPath", logPath);
-            name = "/embulk/logback-file.xml";
-        }
-        try {
-            configurator.doConfigure(getClass().getResource(name));
-        } catch (JoranException ex) {
-            throw new RuntimeException(ex);
-        }
-
-        org.slf4j.Logger logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-        if (logger instanceof Logger) {
-            ((Logger) logger).setLevel(Level.toLevel(level.toUpperCase(), Level.DEBUG));
-        }
+    public LoggerProvider() {
+        // Logback is initialized by org.embulk.cli.CliLogbackConfigurator only when executed from CLI.
     }
 
     public ILoggerFactory get() {

--- a/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
@@ -25,6 +25,7 @@ import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.embulk.spi.util.Filters;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PreviewExecutor {
     private final Injector injector;
@@ -150,7 +151,6 @@ public class PreviewExecutor {
     }
 
     private static class SamplingPageOutput implements PageOutput {
-        private final Logger log = Exec.getLogger(this.getClass());
         private final int sampleRows;
         private final Schema schema;
         private List<Page> pages;
@@ -180,7 +180,7 @@ public class PreviewExecutor {
         @Override
         public void finish() {
             if (res != null) {
-                log.error("PreviewResult recreation will cause a bug. The plugin must call PageOutput#finish() only once.");
+                logger.error("PreviewResult recreation will cause a bug. The plugin must call PageOutput#finish() only once.");
             }
 
             if (recordCount == 0) {
@@ -201,4 +201,6 @@ public class PreviewExecutor {
             }
         }
     }
+
+    private static final Logger logger = LoggerFactory.getLogger(PreviewExecutor.class);
 }

--- a/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
@@ -23,6 +23,7 @@ import org.embulk.spi.PageOutput;
 import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.Schema;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
  * Used by FileInputRunner.guess
@@ -121,8 +122,9 @@ public class SamplingParserPlugin implements ParserPlugin {
         }
     }
 
+    private static final Logger logger = LoggerFactory.getLogger(SamplingParserPlugin.class);
+
     private final NumberFormat numberFormat = NumberFormat.getNumberInstance(ENGLISH);
-    private final Logger log = Exec.getLogger(this.getClass());
     private final int minSampleBufferBytes;
 
     public interface PluginTask extends Task, SampleBufferTask {}
@@ -143,7 +145,7 @@ public class SamplingParserPlugin implements ParserPlugin {
         PluginTask task = config.loadConfig(PluginTask.class);
         Preconditions.checkArgument(minSampleBufferBytes < task.getSampleBufferBytes(), "minSampleBufferBytes must be smaller than sample_buffer_bytes");
 
-        log.info("Try to read {} bytes from input source", numberFormat.format(task.getSampleBufferBytes()));
+        logger.info("Try to read {} bytes from input source", numberFormat.format(task.getSampleBufferBytes()));
         control.run(task.dump(), null);
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/Exec.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Exec.java
@@ -43,10 +43,14 @@ public class Exec {
         return session().getTransactionTime();
     }
 
+    @Deprecated  // @see docs/design/slf4j.md
+    @SuppressWarnings("deprecation")
     public static Logger getLogger(String name) {
         return session().getLogger(name);
     }
 
+    @Deprecated  // @see docs/design/slf4j.md
+    @SuppressWarnings("deprecation")
     public static Logger getLogger(Class<?> name) {
         return session().getLogger(name);
     }

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -21,7 +21,10 @@ import org.slf4j.Logger;
 
 public class ExecSession {
     private final Injector injector;
+
+    // TODO: Remove it.
     private final ILoggerFactory loggerFactory;
+
     private final ModelManager modelManager;
     private final PluginManager pluginManager;
     private final BufferAllocator bufferAllocator;
@@ -53,7 +56,9 @@ public class ExecSession {
             return this;
         }
 
+        @Deprecated  // @see docs/design/slf4j.md
         public Builder setLoggerFactory(ILoggerFactory loggerFactory) {
+            // TODO: Make it ineffective.
             this.loggerFactory = loggerFactory;
             return this;
         }
@@ -128,11 +133,15 @@ public class ExecSession {
         return transactionTime;
     }
 
+    @Deprecated  // @see docs/design/slf4j.md
     public Logger getLogger(String name) {
+        // TODO: Make it always return org.slf4j.LoggerFactory.getLogger(...).
         return loggerFactory.getLogger(name);
     }
 
+    @Deprecated  // @see docs/design/slf4j.md
     public Logger getLogger(Class<?> name) {
+        // TODO: Make it always return org.slf4j.LoggerFactory.getLogger(...).
         return loggerFactory.getLogger(name.getName());
     }
 

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -28,6 +28,7 @@ import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.util.LineDecoder;
 import org.embulk.spi.util.Timestamps;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CsvParserPlugin implements ParserPlugin {
     private static final ImmutableSet<String> TRUE_STRINGS =
@@ -132,7 +133,7 @@ public class CsvParserPlugin implements ParserPlugin {
             if (str.length() >= 2) {
                 throw new ConfigException("\"quote\" option accepts only 1 character.");
             } else if (str.isEmpty()) {
-                Exec.getLogger(CsvParserPlugin.class).warn("Setting '' (empty string) to \"quote\" option is obsoleted. Currently it becomes '\"' automatically but this behavior will be removed. Please set '\"' explicitly.");
+                logger.warn("Setting '' (empty string) to \"quote\" option is obsoleted. Currently it becomes '\"' automatically but this behavior will be removed. Please set '\"' explicitly.");
                 return new QuoteCharacter('"');
             } else {
                 return new QuoteCharacter(str.charAt(0));
@@ -176,7 +177,7 @@ public class CsvParserPlugin implements ParserPlugin {
             if (str.length() >= 2) {
                 throw new ConfigException("\"escape\" option accepts only 1 character.");
             } else if (str.isEmpty()) {
-                Exec.getLogger(CsvParserPlugin.class).warn("Setting '' (empty string) to \"escape\" option is obsoleted. Currently it becomes null automatically but this behavior will be removed. Please set \"escape: null\" explicitly.");
+                logger.warn("Setting '' (empty string) to \"escape\" option is obsoleted. Currently it becomes null automatically but this behavior will be removed. Please set \"escape: null\" explicitly.");
                 return noEscape();
             } else {
                 return new EscapeCharacter(str.charAt(0));
@@ -203,10 +204,7 @@ public class CsvParserPlugin implements ParserPlugin {
         }
     }
 
-    private final Logger log;
-
     public CsvParserPlugin() {
-        log = Exec.getLogger(CsvParserPlugin.class);
     }
 
     @Override
@@ -364,7 +362,7 @@ public class CsvParserPlugin implements ParserPlugin {
                         if (stopOnInvalidRecord) {
                             throw new DataException(String.format("Invalid record at %s:%d: %s", fileName, lineNumber, skippedLine), e);
                         }
-                        log.warn(String.format("Skipped line %s:%d (%s): %s", fileName, lineNumber, e.getMessage(), skippedLine));
+                        logger.warn(String.format("Skipped line %s:%d (%s): %s", fileName, lineNumber, e.getMessage(), skippedLine));
                         //exec.notice().skippedLine(skippedLine);
 
                         hasNextRecord = tokenizer.nextRecord();
@@ -385,4 +383,6 @@ public class CsvParserPlugin implements ParserPlugin {
             super(cause);
         }
     }
+
+    private static final Logger logger = LoggerFactory.getLogger(CsvParserPlugin.class);
 }

--- a/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
@@ -32,6 +32,7 @@ import org.embulk.spi.util.FileInputInputStream;
 import org.msgpack.core.Preconditions;
 import org.msgpack.value.Value;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JsonParserPlugin implements ParserPlugin {
 
@@ -59,12 +60,6 @@ public class JsonParserPlugin implements ParserPlugin {
         @Config("invalid_string_escapes")
         @ConfigDefault("\"PASSTHROUGH\"")
         InvalidEscapeStringPolicy getInvalidEscapeStringPolicy();
-    }
-
-    private final Logger log;
-
-    public JsonParserPlugin() {
-        this.log = Exec.getLogger(JsonParserPlugin.class);
     }
 
     @Override
@@ -107,7 +102,7 @@ public class JsonParserPlugin implements ParserPlugin {
                             if (stopOnInvalidRecord) {
                                 throw new DataException(String.format("Invalid record in %s: %s", fileName, value.toJson()), e);
                             }
-                            log.warn(String.format("Skipped record in %s (%s): %s", fileName, e.getMessage(), value.toJson()));
+                            logger.warn(String.format("Skipped record in %s (%s): %s", fileName, e.getMessage(), value.toJson()));
                         }
                     }
                 } catch (IOException | JsonParseException e) {
@@ -213,4 +208,6 @@ public class JsonParserPlugin implements ParserPlugin {
             super(message);
         }
     }
+
+    private static final Logger logger = LoggerFactory.getLogger(JsonParserPlugin.class);
 }

--- a/embulk-standards/src/main/java/org/embulk/standards/LocalFileInputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/LocalFileInputPlugin.java
@@ -35,6 +35,7 @@ import org.embulk.spi.FileInputPlugin;
 import org.embulk.spi.TransactionalFileInput;
 import org.embulk.spi.util.InputStreamTransactionalFileInput;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LocalFileInputPlugin implements FileInputPlugin {
     public interface PluginTask extends Task {
@@ -62,8 +63,8 @@ public class LocalFileInputPlugin implements FileInputPlugin {
         final PluginTask task = config.loadConfig(PluginTask.class);
 
         // list files recursively
-        final List<String> files = listFiles(task, this.instanceLogger);
-        this.instanceLogger.info("Loading files {}", files);
+        final List<String> files = listFiles(task);
+        logger.info("Loading files {}", files);
         task.setFiles(files);
 
         // number of processors is same with number of files
@@ -127,11 +128,11 @@ public class LocalFileInputPlugin implements FileInputPlugin {
         };
     }
 
-    static List<String> listFilesForTesting(final PluginTask task, final Logger logger) {
-        return listFiles(task, logger);
+    static List<String> listFilesForTesting(final PluginTask task) {
+        return listFiles(task);
     }
 
-    private static List<String> listFiles(final PluginTask task, final Logger logger) {
+    private static List<String> listFiles(final PluginTask task) {
         // This |pathPrefixResolved| can still be a relative path from the working directory.
         // The path should not be normalized by Path#normalize to eliminate redundant name elements like "." and "..".
         final Path pathPrefixResolved = WORKING_DIRECTORY.resolve(Paths.get(task.getPathPrefix()));
@@ -402,5 +403,5 @@ public class LocalFileInputPlugin implements FileInputPlugin {
     private static final Path DOT = Paths.get(".");
     private static final Path DOT_DOT = Paths.get("..");
 
-    private final Logger instanceLogger = Exec.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(LocalFileInputPlugin.class);
 }

--- a/embulk-standards/src/main/java/org/embulk/standards/LocalFileOutputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/LocalFileOutputPlugin.java
@@ -21,6 +21,7 @@ import org.embulk.spi.Exec;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.TransactionalFileOutput;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LocalFileOutputPlugin implements FileOutputPlugin {
     public interface PluginTask extends Task {
@@ -34,8 +35,6 @@ public class LocalFileOutputPlugin implements FileOutputPlugin {
         @ConfigDefault("\"%03d.%02d.\"")
         String getSequenceFormat();
     }
-
-    private final Logger log = Exec.getLogger(getClass());
 
     @Override
     public ConfigDiff transaction(ConfigSource config, int taskCount,
@@ -81,7 +80,7 @@ public class LocalFileOutputPlugin implements FileOutputPlugin {
             public void nextFile() {
                 closeFile();
                 String path = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + pathSuffix;
-                log.info("Writing local file '{}'", path);
+                logger.info("Writing local file '{}'", path);
                 fileNames.add(path);
                 try {
                     output = new FileOutputStream(new File(path));
@@ -130,4 +129,6 @@ public class LocalFileOutputPlugin implements FileOutputPlugin {
             }
         };
     }
+
+    private static final Logger logger = LoggerFactory.getLogger(LocalFileOutputPlugin.class);
 }

--- a/embulk-standards/src/main/java/org/embulk/standards/RemoveColumnsFilterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/RemoveColumnsFilterPlugin.java
@@ -17,7 +17,6 @@ import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
-import org.embulk.spi.Exec;
 import org.embulk.spi.FilterPlugin;
 import org.embulk.spi.Page;
 import org.embulk.spi.PageBuilder;
@@ -25,7 +24,6 @@ import org.embulk.spi.PageOutput;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.embulk.spi.SchemaConfigException;
-import org.slf4j.Logger;
 
 public class RemoveColumnsFilterPlugin implements FilterPlugin {
     public interface PluginTask extends Task {
@@ -50,12 +48,9 @@ public class RemoveColumnsFilterPlugin implements FilterPlugin {
         public int[] getIndexMapping();
     }
 
-    private final Logger logger;
-
+    // TODO: Remove this?
     @Inject
-    public RemoveColumnsFilterPlugin() {
-        logger = Exec.getLogger(getClass());
-    }
+    public RemoveColumnsFilterPlugin() {}
 
     @Override
     public void transaction(ConfigSource config, Schema inputSchema, FilterPlugin.Control control) {

--- a/embulk-standards/src/main/java/org/embulk/standards/RenameFilterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/RenameFilterPlugin.java
@@ -18,11 +18,11 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Column;
-import org.embulk.spi.Exec;
 import org.embulk.spi.FilterPlugin;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * |RenameFilterPlugin| renames column names.
@@ -452,5 +452,5 @@ public class RenameFilterPlugin implements FilterPlugin {
     // It should be practically acceptable to assume any output accepts column names with 8 characters at least...
     private static final int minimumMaxLengthInUniqueNumberSuffix = 8;
 
-    private final Logger logger = Exec.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(RenameFilterPlugin.class);
 }

--- a/embulk-standards/src/test/java/org/embulk/standards/TestLocalFileInputPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestLocalFileInputPlugin.java
@@ -15,8 +15,6 @@ import org.embulk.spi.Exec;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests LocalFileInputPlugin.
@@ -234,7 +232,7 @@ public class TestLocalFileInputPlugin {
     }
 
     private static List<String> listFiles(final LocalFileInputPlugin.PluginTask task) {
-        return LocalFileInputPlugin.listFilesForTesting(task, logger);
+        return LocalFileInputPlugin.listFilesForTesting(task);
     }
 
     private LocalFileInputPlugin.PluginTask buildRawTask(
@@ -287,6 +285,4 @@ public class TestLocalFileInputPlugin {
         pathPrefixBuilder.append(subPath);
         return pathPrefixBuilder.toString();
     }
-
-    private static final Logger logger = LoggerFactory.getLogger(TestLocalFileInputPlugin.class);
 }


### PR DESCRIPTION
The details are described in `docs/design/slf4j.md`.

It won't be merged very soon for v0.9.12. It targets later versions such as v0.9.14 or v0.9.15 so that we can confirm the impact of this change before merging.

Can you have a look? @sakama @kamatama41 