### PR TITLE
Update the repository for www.embulk.org site

### DIFF
--- a/embulk-docs/push-gh-pages.sh
+++ b/embulk-docs/push-gh-pages.sh
@@ -16,7 +16,7 @@ function r() {
 [ "$TRAVIS_BRANCH" != "master" -a "$TRAVIS_BRANCH" != "$(git describe --tags --always HEAD)" ] && exit 0
 
 revision="$(git rev-parse HEAD)"
-remote="https://github.com/embulk/embulk.github.io.git"
+remote="https://github.com/embulk/www.embulk.org.git"
 re ./gradlew site
 
 r git fetch --unshallow || echo "using complete repository."


### PR DESCRIPTION
We'll update the repository to provide the https://www.embulk.org website.

@sakama @kamatama41 Can you have a look?