### PR TITLE
Use Java 8's stream and functional interfaces instead of Guava for JSON Parser plugin.

### DIFF
--- a/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
@@ -13,7 +13,6 @@ import static org.msgpack.value.ValueFactory.newMap;
 import static org.msgpack.value.ValueFactory.newString;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.CharSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -190,52 +189,52 @@ public class TestJsonParserPlugin {
     }
 
     @Test
-    public void checkInvalidEscapeStringFunction() throws Exception {
+    public void checkInvalidEscapeStringFunction() {
         //PASSTHROUGH
         {
             String json = "{\\\"_c0\\\":true,\\\"_c1\\\":10,\\\"_c2\\\":\\\"embulk\\\",\\\"_c3\\\":{\\\"k\\\":\\\"v\\\"}}";
-            CharSource actual = plugin.invalidEscapeStringFunction(PASSTHROUGH).apply(json);
-            assertEquals(json, actual.read());
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(PASSTHROUGH).apply(json);
+            assertEquals(json, actual);
         }
 
         {
             String json = "{\"abc\b\f\n\r\t\\\\u0001\":\"efg\"}\\";
-            CharSource actual = plugin.invalidEscapeStringFunction(PASSTHROUGH).apply(json);
-            assertEquals(json, actual.read());
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(PASSTHROUGH).apply(json);
+            assertEquals(json, actual);
         }
 
         {
             String json = "{\"\\a\":\"b\"}\\";
-            CharSource actual = plugin.invalidEscapeStringFunction(PASSTHROUGH).apply(json);
-            assertEquals(json, actual.read());
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(PASSTHROUGH).apply(json);
+            assertEquals(json, actual);
         }
 
         //SKIP
         {
             String json = "{\\\"_c0\\\":true,\\\"_c1\\\":10,\\\"_c2\\\":\\\"embulk\\\",\\\"_c3\\\":{\\\"k\\\":\\\"v\\\"}}";
-            CharSource actual = plugin.invalidEscapeStringFunction(SKIP).apply(json);
-            assertEquals(json, actual.read());
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(SKIP).apply(json);
+            assertEquals(json, actual);
         }
 
         {
             // valid charset u0001
             String json = "{\"abc\b\f\n\r\t\\\\u0001\":\"efg\"}\\";
-            CharSource actual = plugin.invalidEscapeStringFunction(SKIP).apply(json);
-            assertEquals("{\"abc\b\f\n\r\t\\\\u0001\":\"efg\"}", actual.read());
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(SKIP).apply(json);
+            assertEquals("{\"abc\b\f\n\r\t\\\\u0001\":\"efg\"}", actual);
         }
 
         {
             // invalid charset \\u12xY remove forwarding backslash and u
             String json = "{\"\\u12xY\":\"efg\"}\\";
-            CharSource actual = plugin.invalidEscapeStringFunction(SKIP).apply(json);
-            assertEquals("{\"12xY\":\"efg\"}", actual.read());
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(SKIP).apply(json);
+            assertEquals("{\"12xY\":\"efg\"}", actual);
         }
 
         {
             String json = "{\"\\a\":\"b\"}\\";
-            CharSource actual = plugin.invalidEscapeStringFunction(SKIP).apply(json);
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(SKIP).apply(json);
             // backslash and `a` will removed.
-            assertEquals("{\"\":\"b\"}", actual.read());
+            assertEquals("{\"\":\"b\"}", actual);
         }
 
         {
@@ -243,36 +242,36 @@ public class TestJsonParserPlugin {
             String json = "{\"\\a\":\"b\"}"
                     + "\n"
                     + "\\";
-            CharSource actual = plugin.invalidEscapeStringFunction(SKIP).apply(json);
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(SKIP).apply(json);
             // backslash and `a` will removed.
-            assertEquals("{\"\":\"b\"}\n", actual.read());
+            assertEquals("{\"\":\"b\"}\n", actual);
         }
 
         //UNESCAPE
         {
             String json = "{\\\"_c0\\\":true,\\\"_c1\\\":10,\\\"_c2\\\":\\\"embulk\\\",\\\"_c3\\\":{\\\"k\\\":\\\"v\\\"}}";
-            CharSource actual = plugin.invalidEscapeStringFunction(UNESCAPE).apply(json);
-            assertEquals(json, actual.read());
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(UNESCAPE).apply(json);
+            assertEquals(json, actual);
         }
 
         {
             String json = "{\"abc\b\f\n\r\t\\\\u0001\":\"efg\"}\\";
-            CharSource actual = plugin.invalidEscapeStringFunction(UNESCAPE).apply(json);
-            assertEquals("{\"abc\b\f\n\r\t\\\\u0001\":\"efg\"}", actual.read());
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(UNESCAPE).apply(json);
+            assertEquals("{\"abc\b\f\n\r\t\\\\u0001\":\"efg\"}", actual);
         }
 
         {
             // invalid charset u000x remove forwarding backslash
             String json = "{\"\\u000x\":\"efg\"}\\";
-            CharSource actual = plugin.invalidEscapeStringFunction(UNESCAPE).apply(json);
-            assertEquals("{\"u000x\":\"efg\"}", actual.read());
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(UNESCAPE).apply(json);
+            assertEquals("{\"u000x\":\"efg\"}", actual);
         }
 
         {
             String json = "{\"\\a\":\"b\"}\\";
-            CharSource actual = plugin.invalidEscapeStringFunction(UNESCAPE).apply(json);
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(UNESCAPE).apply(json);
             // backslash will removed.
-            assertEquals("{\"a\":\"b\"}", actual.read());
+            assertEquals("{\"a\":\"b\"}", actual);
         }
 
         {
@@ -280,9 +279,9 @@ public class TestJsonParserPlugin {
             String json = "{\"\\a\":\"b\"}"
                     + "\n"
                     + "\\";
-            CharSource actual = plugin.invalidEscapeStringFunction(SKIP).apply(json);
+            String actual = JsonParserPlugin.invalidEscapeStringFunction(SKIP).apply(json);
             // backslash and `a` will removed.
-            assertEquals("{\"\":\"b\"}\n", actual.read());
+            assertEquals("{\"\":\"b\"}\n", actual);
         }
     }
 


### PR DESCRIPTION
This is a refactoring to reduce Guava's dependencies, doesn't change any behavior.
In addition, This change might improve performance.
On my laptop (MBP 15 inch), parsing 10,000,000 records becomes 15 seconds faster than previous version.

### JSON file
```json
{"id": 1, "name": "user1", "sex": "male"}
{"id": 2, "name": "user2", "sex": "male"}
{"id": 3, "name": "user3", "sex": "male"}
{"id": 4, "name": "user4", "sex": "male"}
{"id": 5, "name": "user5", "sex": "male"}
...
{"id": 9999996, "name": "user9999996", "sex": "male"}
{"id": 9999997, "name": "user9999997", "sex": "male"}
{"id": 9999998, "name": "user9999998", "sex": "male"}
{"id": 9999999, "name": "user9999999", "sex": "male"}
{"id": 10000000, "name": "user10000000", "sex": "male"}
```

### Config Yaml
```yaml
in:
  type: file
  path_prefix: sample_jsonl10000000.json
  parser:
    type: json
    invalid_string_escapes: SKIP
out:
  type: "null"
```

### Run with Embulk 0.9.14 (took 35 seconds)
```
$ time embulk9 -J-Xmx8g run config.yml
2019-01-29 17:06:43.321 +0900: Embulk v0.9.14
2019-01-29 17:06:43.812 +0900 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2019-01-29 17:06:45.997 +0900 [INFO] (main): Gem's home and path are set by default: "/Users/ishimura/.embulk/lib/gems"
2019-01-29 17:06:46.702 +0900 [INFO] (main): Started Embulk v0.9.14
2019-01-29 17:06:46.742 +0900 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'sample_jsonl10000000.json'
2019-01-29 17:06:46.744 +0900 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2019-01-29 17:06:46.748 +0900 [INFO] (0001:transaction): Loading files [sample_jsonl10000000.json]
2019-01-29 17:06:46.762 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2019-01-29 17:06:46.765 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2019-01-29 17:07:18.358 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2019-01-29 17:07:18.362 +0900 [INFO] (main): Committed.
2019-01-29 17:07:18.362 +0900 [INFO] (main): Next config diff: {"in":{"last_path":"sample_jsonl10000000.json"},"out":{}}
embulk9 -J-Xmx8g run config.yml  78.87s user 7.58s system 240% cpu 35.903 total
```
### Run with new version (took 20 seconds)

```
$ time ./build/executable/embulk-0.9.15-SNAPSHOT.jar -J-Xmx8g run config.yml
2019-01-29 17:11:23.275 +0900: Embulk v0.9.15-SNAPSHOT
2019-01-29 17:11:23.749 +0900 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2019-01-29 17:11:25.820 +0900 [INFO] (main): Gem's home and path are set by default: "/Users/ishimura/.embulk/lib/gems"
2019-01-29 17:11:26.542 +0900 [INFO] (main): Started Embulk v0.9.15-SNAPSHOT
2019-01-29 17:11:26.586 +0900 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'sample_jsonl10000000.json'
2019-01-29 17:11:26.587 +0900 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2019-01-29 17:11:26.593 +0900 [INFO] (0001:transaction): Loading files [sample_jsonl10000000.json]
2019-01-29 17:11:26.610 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2019-01-29 17:11:26.613 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2019-01-29 17:11:42.467 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2019-01-29 17:11:42.472 +0900 [INFO] (main): Committed.
2019-01-29 17:11:42.472 +0900 [INFO] (main): Next config diff: {"in":{"last_path":"sample_jsonl10000000.json"},"out":{}}
./build/executable/embulk-0.9.15-SNAPSHOT.jar -J-Xmx8g run config.yml  31.90s user 4.06s system 178% cpu 20.170 total
```