### PR TITLE
[Experimental] Add an option to point a specific value within a JSON document via Json Pointer expression.

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
@@ -35,6 +35,10 @@ import org.slf4j.LoggerFactory;
 
 public class JsonParserPlugin implements ParserPlugin {
 
+    public JsonParserPlugin() {
+        this.jsonParser = new JsonParser();
+    }
+
     public enum InvalidEscapeStringPolicy {
         PASSTHROUGH("PASSTHROUGH"),
         SKIP("SKIP"),
@@ -147,9 +151,9 @@ public class JsonParserPlugin implements ParserPlugin {
         }
 
         if (task.getJsonPointerToRoot().isPresent()) {
-            return JSON_PARSER.openWithOffsetInJsonPointer(inputStream, task.getJsonPointerToRoot().get());
+            return jsonParser.openWithOffsetInJsonPointer(inputStream, task.getJsonPointerToRoot().get());
         } else {
-            return JSON_PARSER.open(inputStream);
+            return jsonParser.open(inputStream);
         }
     }
 
@@ -222,5 +226,5 @@ public class JsonParserPlugin implements ParserPlugin {
 
     private static final Pattern DIGITS_PATTERN = Pattern.compile("\\p{XDigit}+");
 
-    private static final JsonParser JSON_PARSER = new JsonParser();
+    private final JsonParser jsonParser;
 }

--- a/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
@@ -64,7 +64,8 @@ public class JsonParserPlugin implements ParserPlugin {
         @ConfigDefault("\"PASSTHROUGH\"")
         InvalidEscapeStringPolicy getInvalidEscapeStringPolicy();
 
-        @Config("json_pointer_to_root")
+        // TODO: rename it's determined
+        @Config("__experimental__json_pointer_to_root")
         @ConfigDefault("null")
         Optional<String> getJsonPointerToRoot();
     }

--- a/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
@@ -284,7 +284,7 @@ public class TestJsonParserPlugin {
 
     @Test
     public void useJsonPointerToRoot() throws Exception {
-        ConfigSource config = this.config.deepCopy().set("json_pointer_to_root", "/_c0");
+        ConfigSource config = this.config.deepCopy().set("__experimental__json_pointer_to_root", "/_c0");
         transaction(config, fileInput(
                 "{\"_c0\":{\"b\": 1}, \"_c1\": true}",
                 "{}",            // should be skipped because it doesn't have "_c0"


### PR DESCRIPTION
As we can parse only a specific JSON object within a JSON document by JsonParser since #1096, this option uses it.

## Usage
Sample JSON
```json
{"a": {"b": 1}}
```
Config YAML
```yaml
in:
  type: ...
  parser:
    type: json
    __experimental__json_pointer_to_root: "/a"
```
Result
```
+-------------+
| record:json |
+-------------+
|     {"b":1} |
+-------------+
```
