### PR TITLE
fix typo on sample script of ruby-formatter

### DIFF
--- a/embulk-core/src/main/resources/org/embulk/plugin/template/ruby/formatter.rb.vm
+++ b/embulk-core/src/main/resources/org/embulk/plugin/template/ruby/formatter.rb.vm
@@ -22,7 +22,7 @@ module Embulk
         @option3 = task["option3"]
 
         # your data
-        @current_file == nil
+        @current_file = nil
         @current_file_size = 0
       end
 


### PR DESCRIPTION
Fix typo on sample script of ruby-formatter