### PR TITLE
[Experimental] Add an option to select a specific value in a record as an Embulk's column for JSON Parser plugin.

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
@@ -1,6 +1,7 @@
 package org.embulk.spi.util;
 
 import com.google.common.base.Optional;
+import java.util.HashMap;
 import java.util.Map;
 import org.embulk.config.Task;
 import org.embulk.spi.Column;
@@ -24,6 +25,20 @@ public class Timestamps {
             if (column.getType() instanceof TimestampType) {
                 TimestampColumnOption option = column.getOption().loadConfig(TimestampColumnOption.class);
                 parsers[i] = TimestampParser.of(parserTask, option);
+            }
+            i++;
+        }
+        return parsers;
+    }
+
+    public static Map<Column, TimestampParser> newTimestampColumnParsersAsMap(
+            TimestampParser.Task parserTask, SchemaConfig schema) {
+        Map<Column, TimestampParser> parsers = new HashMap<>();
+        int i = 0;
+        for (ColumnConfig column : schema.getColumns()) {
+            if (column.getType() instanceof TimestampType) {
+                TimestampColumnOption option = column.getOption().loadConfig(TimestampColumnOption.class);
+                parsers.put(column.toColumn(i), TimestampParser.of(parserTask, option));
             }
             i++;
         }

--- a/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
@@ -1,7 +1,6 @@
 package org.embulk.spi.util;
 
 import com.google.common.base.Optional;
-import java.util.HashMap;
 import java.util.Map;
 import org.embulk.config.Task;
 import org.embulk.spi.Column;
@@ -25,20 +24,6 @@ public class Timestamps {
             if (column.getType() instanceof TimestampType) {
                 TimestampColumnOption option = column.getOption().loadConfig(TimestampColumnOption.class);
                 parsers[i] = TimestampParser.of(parserTask, option);
-            }
-            i++;
-        }
-        return parsers;
-    }
-
-    public static Map<Column, TimestampParser> newTimestampColumnParsersAsMap(
-            TimestampParser.Task parserTask, SchemaConfig schema) {
-        Map<Column, TimestampParser> parsers = new HashMap<>();
-        int i = 0;
-        for (ColumnConfig column : schema.getColumns()) {
-            if (column.getType() instanceof TimestampType) {
-                TimestampColumnOption option = column.getOption().loadConfig(TimestampColumnOption.class);
-                parsers.put(column.toColumn(i), TimestampParser.of(parserTask, option));
             }
             i++;
         }

--- a/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
@@ -94,7 +94,7 @@ public class JsonParserPlugin implements ParserPlugin {
 
     @VisibleForTesting
     Schema newSchema(PluginTask task) {
-        if (isUseCustomSchema(task)) {
+        if (isUsingCustomSchema(task)) {
             return task.getSchemaConfig().get().toSchema();
         } else {
             return Schema.builder().add("record", Types.JSON).build(); // generate a schema
@@ -107,7 +107,7 @@ public class JsonParserPlugin implements ParserPlugin {
 
         final boolean stopOnInvalidRecord = task.getStopOnInvalidRecord();
         final Map<Column, TimestampParser> timestampParsers = new HashMap<>();
-        if (isUseCustomSchema(task)) {
+        if (isUsingCustomSchema(task)) {
             timestampParsers.putAll(newTimestampColumnParsersAsMap(task, task.getSchemaConfig().get()));
         }
 
@@ -126,7 +126,7 @@ public class JsonParserPlugin implements ParserPlugin {
                                         String.format("A Json record must not represent map value but it's %s", value.getValueType().name()));
                             }
 
-                            if (isUseCustomSchema(task)) {
+                            if (isUsingCustomSchema(task)) {
                                 setValueWithCustomSchema(pageBuilder, schema, timestampParsers, value.asMapValue());
                             } else {
                                 setValueWithSingleJsonColumn(pageBuilder, schema, value.asMapValue());
@@ -155,7 +155,7 @@ public class JsonParserPlugin implements ParserPlugin {
         }
     }
 
-    private static boolean isUseCustomSchema(PluginTask task) {
+    private static boolean isUsingCustomSchema(PluginTask task) {
         return task.getSchemaConfig().isPresent();
     }
 


### PR DESCRIPTION
For #1102 
## Usage
Sample JSON
```json
{"id": 1, "name": "Alice", "active": true, "created_at": "2019-01-12 01:23:45"}
```
Config YAML
```yaml
in:
  type: ...
  parser:
    type: json
    __experimental__columns:
      - {name: id, type: long}
      - {name: name, type: string}   
      - {name: active, type: boolean}   
      - {name: created_at, type: timestamp, format: "%Y-%m-%d %H:%M:%S"}   
```
Result 
```
+---------+-------------+----------------+-------------------------+
| id:long | name:string | active:boolean |    created_at:timestamp |
+---------+-------------+----------------+-------------------------+
|       1 |       Alice |           true | 2019-01-12 01:23:45 UTC |
+---------+-------------+----------------+-------------------------+
```