### PR TITLE
Do not warn Maven libraries uninitialized when using self-contained JARs

### DIFF
--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
@@ -62,7 +62,7 @@ public final class EmbulkDependencyClassLoaders {
         public static final DependencyClassLoader MAVEN_DEPENDENCY_CLASS_LOADER;
 
         static {
-            if (MAVEN_DEPENDENCIES.isEmpty()) {
+            if (MAVEN_DEPENDENCIES.isEmpty() && !USE_SELF_CONTAINED_JAR_FILES.get()) {
                 logger.warn(messageUninitialized("Maven"));
             }
             MAVEN_DEPENDENCY_CLASS_LOADER = new DependencyClassLoader(


### PR DESCRIPTION
One follow-up to #1085. #1085 unintentionally showed a warning `Dependencies for Maven are uninitialized. Expected to use classes loaded by the parent ClassLoader.` when using the self-contained JARs == in case of the all-in-one CLI package.

This PR fixes that.

@kamatama41 @sakama Can you have a look?