### PR TITLE
Stop on invalid JSON which doesn't have given "JSON pointer to root"

### DIFF
--- a/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
@@ -293,8 +293,8 @@ public class TestJsonParserPlugin {
         ConfigSource config = this.config.deepCopy().set("__experimental__json_pointer_to_root", "/_c0");
         transaction(config, fileInput(
                 "{\"_c0\":{\"b\": 1}, \"_c1\": true}",
-                "{}",            // should be skipped because it doesn't have "_c0"
-                "{\"_c0\": 1}",  // should be skipped because the value doesn't map value
+                "{}",            // should be skipped because it doesn't have "_c0" and stop_on_invalid_record is false
+                "{\"_c0\": 1}",  // should be skipped because the "_c0"'s value isn't map value and stop_on_invalid_record is false
                 "{\"_c0\":{\"b\": 2}, \"_c1\": false}"
         ));
 

--- a/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
@@ -310,6 +310,19 @@ public class TestJsonParserPlugin {
         assertEquals(newInteger(2), map.get(newString("b")));
     }
 
+    @Test(expected = DataException.class)
+    public void useJsonPointerToRootWithStopOnInvalidRecord() throws Exception {
+        ConfigSource config = this.config.deepCopy()
+                .set("__experimental__json_pointer_to_root", "/_c0")
+                .set("stop_on_invalid_record", true);
+
+        transaction(config, fileInput(
+                "{\"_c0\":{\"b\": 1}, \"_c1\": true}",
+                "{}",            // Stop with the record
+                "{\"_c0\":{\"b\": 2}, \"_c1\": false}"
+        ));
+    }
+
     @Test
     public void useSchemaConfig() throws Exception {
         // Check parsing all types and inexistent column


### PR DESCRIPTION
For #1102 and changes #1099's behavior.

## Overview 
Currently the parser can not detect invalid records that don't have the root pointer. 
For example, `embulk run` will be successful with the following inputs even if `stop_on_invalid_record: true`.  

### JSON records
```yaml
{"a": {"id": 1, "name": "Alice"}}
{"b": {"id": 2, "name": "Bob"}}
```

### Config YAML
```yaml
in:
  type: ...
  parser:
    type: json
    __experimental__json_pointer_to_root: /a
    stop_on_invalid_record: true
```
### Expected and actual
An error is raised caused by the invalid record `{"b": {"id": 2, "name": "Bob"}}`, but the record is skipped.
```
+-------------------------+
|             record:json |
+-------------------------+
| {"id":1,"name":"Alice"} |
+-------------------------+
```

## How to fix
Not directly applying JSON pointer to whole input JSON objects, then applying the pointer to each JSON object.