### PR TITLE
[JSON Parser plugin] Use default schema if "columns" option is specified as empty array.

### DIFF
--- a/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
@@ -202,7 +202,7 @@ public class JsonParserPlugin implements ParserPlugin {
     }
 
     private static boolean isUsingCustomSchema(PluginTask task) {
-        return task.getSchemaConfig().isPresent();
+        return task.getSchemaConfig().isPresent() && !task.getSchemaConfig().get().isEmpty();
     }
 
     private static void setValueWithSingleJsonColumn(PageBuilder pageBuilder, Schema schema, MapValue value) {

--- a/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
@@ -348,6 +348,22 @@ public class TestJsonParserPlugin {
     }
 
     @Test
+    public void useDefaultSchemaIfSchemaConfigIsEmptyArray() throws Exception {
+        ConfigSource config = this.config.set("columns", new ArrayList<>());
+        transaction(config, fileInput(
+                "{\"_c0\": 1, \"_c1\": 1.234, \"_c2\": \"a\", \"_c3\": true, \"_c4\": \"2019-01-02 03:04:56\", \"_c5\":{\"a\": 1}}"
+        ));
+
+        List<Object[]> records = Pages.toObjects(newSchema(), output.pages);
+        assertEquals(1, records.size());
+
+        Object[] record = records.get(0);
+        assertArrayEquals(
+                record,
+                new Object[]{toJson("{\"_c0\": 1, \"_c1\": 1.234, \"_c2\": \"a\", \"_c3\": true, \"_c4\": \"2019-01-02 03:04:56\", \"_c5\":{\"a\": 1}}")});
+    }
+
+    @Test
     public void useSchemaConfigWithPointer() throws Exception {
         // Check parsing all types and inexistent column
         final List<Object> schemaConfig = new ArrayList<>();


### PR DESCRIPTION
For #1102 
Currently the JSON parser plugin creates empty schema if the `columns` option is specified as empty array. This PR prevents it and use default schema with such a case.