### PR TITLE
Use "element_at" instead of "pointer" in the built-in JSON parser plugin

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -384,17 +384,17 @@ if you set invalid\_string\_escapes and appear invalid JSON string (such as ``\a
 
 The ``columns`` option declares the list of columns, and the way how to extract JSON values into Embulk columns.
 
-+----------+-------------------------------------------------------------------------------------------------------+
-| name     | description                                                                                           |
-+==========+=======================================================================================================+
-| name     | Name of the column. The JSON value with this name is extracted if `pointer` is not specified.         |
-+----------+-------------------------------------------------------------------------------------------------------+
-| type     | Type of the column (same as CSV parser's one)                                                         |
-+----------+-------------------------------------------------------------------------------------------------------+
-| pointer  | Pointer to the descendant node to be extracted as the column, expressed as a JSON Pointer (optional). |
-+----------+-------------------------------------------------------------------------------------------------------+
-| format   | Format of the timestamp if type is timestamp                                                          |
-+----------+-------------------------------------------------------------------------------------------------------+
++-------------+----------------------------------------------------------------------------------------------------+
+| name        | description                                                                                        |
++=============+====================================================================================================+
+| name        | Name of the column. The JSON value with this name is extracted if `element_at` is not specified.   |
++-------------+----------------------------------------------------------------------------------------------------+
+| type        | Type of the column (same as CSV parser's one)                                                      |
++-------------+----------------------------------------------------------------------------------------------------+
+| element\_at | Descendant element to be extracted as the column, expressed as a relative JSON Pointer (optional). |
++-------------+----------------------------------------------------------------------------------------------------+
+| format      | Format of the timestamp if type is timestamp                                                       |
++-------------+----------------------------------------------------------------------------------------------------+
 
 Example
 ~~~~~~~~

--- a/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/JsonParserPlugin.java
@@ -90,9 +90,9 @@ public class JsonParserPlugin implements ParserPlugin {
     }
 
     public interface OptionalColumnConfig extends Task, TimestampParser.TimestampColumnOption {
-        @Config("pointer")
+        @Config("element_at")
         @ConfigDefault("null")
-        Optional<String> getPointer();
+        Optional<String> getElementAt();
     }
 
     @Override
@@ -395,8 +395,8 @@ public class JsonParserPlugin implements ParserPlugin {
             final Column column = columns.get(i);
             final ColumnConfig columnConfig = config.getColumn(i);
             final OptionalColumnConfig options = columnConfig.getOption().loadConfig(OptionalColumnConfig.class);
-            if (options.getPointer().isPresent()) {
-                result.put(column, options.getPointer().get());
+            if (options.getElementAt().isPresent()) {
+                result.put(column, options.getElementAt().get());
             }
         }
         return result;

--- a/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
@@ -367,13 +367,13 @@ public class TestJsonParserPlugin {
     public void useSchemaConfigWithPointer() throws Exception {
         // Check parsing all types and inexistent column
         final List<Object> schemaConfig = new ArrayList<>();
-        schemaConfig.add(config().set("name", "_c0").set("type", "long").set("pointer", "/a/0"));
-        schemaConfig.add(config().set("name", "_c1").set("type", "double").set("pointer", "/a/1"));
-        schemaConfig.add(config().set("name", "_c2").set("type", "string").set("pointer", "/a/2"));
-        schemaConfig.add(config().set("name", "_c3").set("type", "boolean").set("pointer", "/a/3/b/0"));
-        schemaConfig.add(config().set("name", "_c4").set("type", "timestamp").set("format", "%Y-%m-%d %H:%M:%S").set("pointer", "/a/3/b/1"));
-        schemaConfig.add(config().set("name", "_c5").set("type", "json").set("pointer", "/c"));
-        schemaConfig.add(config().set("name", "_c99").set("type", "json").set("pointer", "/d"));
+        schemaConfig.add(config().set("name", "_c0").set("type", "long").set("element_at", "/a/0"));
+        schemaConfig.add(config().set("name", "_c1").set("type", "double").set("element_at", "/a/1"));
+        schemaConfig.add(config().set("name", "_c2").set("type", "string").set("element_at", "/a/2"));
+        schemaConfig.add(config().set("name", "_c3").set("type", "boolean").set("element_at", "/a/3/b/0"));
+        schemaConfig.add(config().set("name", "_c4").set("type", "timestamp").set("format", "%Y-%m-%d %H:%M:%S").set("element_at", "/a/3/b/1"));
+        schemaConfig.add(config().set("name", "_c5").set("type", "json").set("element_at", "/c"));
+        schemaConfig.add(config().set("name", "_c99").set("type", "json").set("element_at", "/d"));
 
         ConfigSource config = this.config.set("columns", schemaConfig);
         transaction(config, fileInput(


### PR DESCRIPTION
The configuration name `pointer` was the last remaining consideration when we discussed the names. What do you think: `element_at` instead?

```
    columns:
      - {name: id, type: long}
      - {name: name, type: string}
      - {name: first_tag, type: string, element_at: "/tags/0"}
```

The noun "element" came from https://json.org/. It is enough explicit that it extracts a JSON element from that position. We can naturally extend it later like `element_at: "jsonpath:tags[0]"`.

What do you think, @kamatama41 @sakama ?