### PR TITLE
Test with Logback so that logs can be checked

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.4'
 
     testCompile 'junit:junit:4.12'
+    testCompile 'ch.qos.logback:logback-classic:1.1.3'
 
     gems 'rubygems:bundler:1.16.0'
     gems 'rubygems:msgpack:1.1.0'

--- a/embulk-standards/build.gradle
+++ b/embulk-standards/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile project(':embulk-core').sourceSets.test.output
     testCompile project(':embulk-test')
+    testCompile 'ch.qos.logback:logback-classic:1.1.3'
 
     jrubyExec 'rubygems:simplecov:0.10.+'
     jrubyExec 'rubygems:test-unit:3.0.+'


### PR DESCRIPTION
SLF4J logs have not been displayed during tests. It adds Logback to `testCompile` to make them displayed.

@sakama Can you have a look?