### PR TITLE
Cleanup EmbulkEmbed and EmbulkService

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkService.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkService.java
@@ -1,73 +1,67 @@
 package org.embulk;
 
-import static com.google.common.base.Preconditions.checkState;
-
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.embulk.config.ConfigSource;
-import org.embulk.exec.ExecModule;
-import org.embulk.exec.ExtensionServiceLoaderModule;
-import org.embulk.exec.SystemConfigModule;
-import org.embulk.jruby.JRubyScriptingModule;
-import org.embulk.plugin.BuiltinPluginSourceModule;
-import org.embulk.plugin.PluginClassLoaderModule;
-import org.embulk.plugin.maven.MavenPluginSourceModule;
 
 // Use EmbulkEmbed instead. To be removed by v0.10 or earlier.
 @Deprecated  // https://github.com/embulk/embulk/issues/932
 public class EmbulkService {
-    private final ConfigSource systemConfig;
-
-    protected Injector injector;
-    private boolean initialized;
-
-    public EmbulkService(ConfigSource systemConfig) {
+    public EmbulkService(final ConfigSource systemConfig) {
         this.systemConfig = systemConfig;
     }
 
-    protected Iterable<? extends Module> getAdditionalModules(ConfigSource systemConfig) {
-        return ImmutableList.of();
-    }
-
-    protected Iterable<? extends Module> overrideModules(Iterable<? extends Module> modules, ConfigSource systemConfig) {
-        return modules;
-    }
-
-    static List<Module> standardModuleList(ConfigSource systemConfig) {
-        return ImmutableList.of(
-                new SystemConfigModule(systemConfig),
-                new ExecModule(),
-                new ExtensionServiceLoaderModule(systemConfig),
-                new PluginClassLoaderModule(systemConfig),
-                new BuiltinPluginSourceModule(),
-                new MavenPluginSourceModule(systemConfig),
-                new JRubyScriptingModule(systemConfig));
-    }
-
     public Injector initialize() {
-        checkState(!initialized, "Already initialized");
+        if (this.initialized) {
+            throw new IllegalStateException("Already initialized");
+        }
 
-        ImmutableList.Builder<Module> builder = ImmutableList.builder();
-        builder.addAll(standardModuleList(systemConfig));
-        builder.addAll(getAdditionalModules(systemConfig));
+        final ArrayList<Module> built = new ArrayList<>();
+        for (final Module module : this.standardModuleList(systemConfig)) {
+            built.add(module);
+        }
+        for (final Module module : this.getAdditionalModules(systemConfig)) {
+            built.add(module);
+        }
 
-        Iterable<? extends Module> modules = builder.build();
-        modules = overrideModules(modules, systemConfig);
+        final Iterable<? extends Module> initialModules = Collections.unmodifiableList(built);
+        final Iterable<? extends Module> overriddenModules = this.overrideModules(initialModules, systemConfig);
 
-        injector = Guice.createInjector(modules);
-        initialized = true;
+        this.injector = Guice.createInjector(overriddenModules);
+        this.initialized = true;
 
-        return injector;
+        return this.injector;
     }
 
     @Deprecated
     public synchronized Injector getInjector() {
-        if (initialized) {
-            return injector;
+        if (this.initialized) {
+            return this.injector;
         }
-        return initialize();
+        return this.initialize();
     }
+
+    protected Iterable<? extends Module> getAdditionalModules(final ConfigSource systemConfig) {
+        return Collections.unmodifiableList(new ArrayList<Module>());
+    }
+
+    protected Iterable<? extends Module> overrideModules(
+            final Iterable<? extends Module> modules, final ConfigSource systemConfig) {
+        return modules;
+    }
+
+    @Deprecated
+    static List<Module> standardModuleList(final ConfigSource systemConfig) {
+        return EmbulkEmbed.standardModuleList(systemConfig);
+    }
+
+    protected Injector injector;
+
+    private final ConfigSource systemConfig;
+
+    private boolean initialized;
 }

--- a/embulk-core/src/main/java/org/embulk/EmbulkSetup.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkSetup.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Map;
-import org.embulk.config.ConfigSource;
 
 /**
  * EmbulkSetup initiates an EmbulkRunner instance. It was originally implemented with Ruby in lib/embulk.rb.
@@ -27,8 +26,7 @@ public class EmbulkSetup {
         }
 
         final EmbulkEmbed.Bootstrap bootstrap = new org.embulk.EmbulkEmbed.Bootstrap();
-        final ConfigSource systemConfig = bootstrap.getSystemConfigLoader().fromJsonString(systemConfigJson);
-        bootstrap.setSystemConfig(systemConfig);
+        bootstrap.setSystemConfigFromJson(systemConfigJson);
         final EmbulkEmbed embed = bootstrap.initialize();  // see embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.
 
         return new EmbulkRunner(embed);


### PR DESCRIPTION
Retry of #1038 in a bit different manner. We don't need to upgrade Guice after #1078. We can do this kind of refactoring more safely.

* Reorder methods and fields.
* Set system config through JSON-formatted `String` in `Bootstrap`. No use of "System config loader" outside.
* Move `EmbulkService.standardModuleList` to `EmbulkEmbed`
* Reduce usage of Guava
* Use Java 8 `java.util.function.Function` instead of Guava `Function`
* Use statically-initialized `Logger`

@sakama Can you have a look?