### PR TITLE
Process a new system config "gem_path", to work the same way as GEM_PATH

### DIFF
--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyInitializer.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyInitializer.java
@@ -18,6 +18,7 @@ public final class JRubyInitializer {
             final Injector injector,
             final Logger logger,
             final String gemHome,
+            final String gemPath,
             final boolean useDefaultEmbulkGemHome,
             final List<String> jrubyLoadPath,
             final List<String> jrubyClasspath,
@@ -26,6 +27,7 @@ public final class JRubyInitializer {
         this.injector = injector;
         this.logger = logger;
         this.gemHome = gemHome;
+        this.gemPath = gemPath;
         this.useDefaultEmbulkGemHome = useDefaultEmbulkGemHome;
         this.jrubyLoadPath = jrubyLoadPath;
         this.jrubyClasspath = jrubyClasspath;
@@ -37,6 +39,7 @@ public final class JRubyInitializer {
             final Injector injector,
             final Logger logger,
             final String gemHome,
+            final String gemPath,
             final boolean useDefaultEmbulkGemHome,
             final List jrubyLoadPathNonGeneric,
             final List jrubyClasspathNonGeneric,
@@ -82,6 +85,7 @@ public final class JRubyInitializer {
                 injector,
                 logger,
                 gemHome,
+                gemPath,
                 useDefaultEmbulkGemHome,
                 Collections.unmodifiableList(jrubyLoadPathBuilt),
                 Collections.unmodifiableList(jrubyClasspathBuilt),
@@ -145,6 +149,10 @@ public final class JRubyInitializer {
         return this.gemHome;
     }
 
+    String probeGemPathForTesting() {
+        return this.gemPath;
+    }
+
     boolean probeUseDefaultEmbulkGemHomeForTesting() {
         return this.useDefaultEmbulkGemHome;
     }
@@ -197,8 +205,8 @@ public final class JRubyInitializer {
                 // JRubyScriptingModule instances. However, because Gem loads ENV['GEM_HOME'] when
                 // Gem.clear_paths is called, applications may use unexpected GEM_HOME if clear_path
                 // is used.
-                this.logger.info("Gem's home and path are set by system config \"gem_home\": \"" + this.gemHome + "\"");
-                jruby.setGemPaths(this.gemHome);
+                this.logger.info("Gem's home and path are set by system configs \"gem_home\": \"" + this.gemHome + "\", \"gem_path\": \"" + this.gemPath + "\"");
+                jruby.setGemPaths(this.gemHome, this.gemPath);
                 this.logger.debug("Gem.paths.home = \"" + jruby.getGemHome() + "\"");
                 this.logger.debug("Gem.paths.path = " + jruby.getGemPathInString() + "");
             } else if (this.useDefaultEmbulkGemHome) {
@@ -281,6 +289,7 @@ public final class JRubyInitializer {
     private final Injector injector;
     private final Logger logger;
     private final String gemHome;
+    private final String gemPath;
     private final boolean useDefaultEmbulkGemHome;
     private final List<String> jrubyLoadPath;
     private final List<String> jrubyClasspath;

--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
@@ -46,6 +46,7 @@ public class JRubyScriptingModule implements Module {
                     injector.getInstance(ILoggerFactory.class).getLogger("init"),
 
                     systemConfig.get(String.class, "gem_home", null),
+                    systemConfig.get(String.class, "gem_path", null),
                     systemConfig.get(String.class, "jruby_use_default_embulk_gem_home", "false").equals("true"),
 
                     // TODO get jruby-home from systemConfig to call jruby.container.setHomeDirectory

--- a/embulk-core/src/main/java/org/embulk/jruby/LazyScriptingContainerDelegate.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/LazyScriptingContainerDelegate.java
@@ -46,8 +46,13 @@ public final class LazyScriptingContainerDelegate extends ScriptingContainerDele
     }
 
     @Override
-    public void setGemPaths(final String gemPath) throws JRubyInvalidRuntimeException {
-        getInitialized().setGemPaths(gemPath);
+    public void setGemPaths(final String gemHome) throws JRubyInvalidRuntimeException {
+        getInitialized().setGemPaths(gemHome);
+    }
+
+    @Override
+    public void setGemPaths(final String gemHome, final String gemPath) throws JRubyInvalidRuntimeException {
+        getInitialized().setGemPaths(gemHome, gemPath);
     }
 
     @Override
@@ -80,6 +85,14 @@ public final class LazyScriptingContainerDelegate extends ScriptingContainerDele
     public void processJRubyOption(final String jrubyOption)
             throws JRubyInvalidRuntimeException, UnrecognizedJRubyOptionException, NotWorkingJRubyOptionException {
         getInitialized().processJRubyOption(jrubyOption);
+    }
+
+    @Override
+    public Object callMethodArray(
+            final Object receiver,
+            final String methodName,
+            final Object[] args) throws JRubyInvalidRuntimeException {
+        return getInitialized().callMethodArray(receiver, methodName, args);
     }
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/jruby/ScriptingContainerDelegate.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/ScriptingContainerDelegate.java
@@ -45,7 +45,9 @@ public abstract class ScriptingContainerDelegate {
 
     public abstract void clearGemPaths() throws JRubyNotLoadedException;
 
-    public abstract void setGemPaths(final String gemPath) throws JRubyNotLoadedException;
+    public abstract void setGemPaths(final String gemHome) throws JRubyNotLoadedException;
+
+    public abstract void setGemPaths(final String gemHome, final String gemPath) throws JRubyNotLoadedException;
 
     public abstract boolean isBundleGemfileDefined() throws JRubyNotLoadedException;
 
@@ -60,6 +62,10 @@ public abstract class ScriptingContainerDelegate {
 
     public abstract void processJRubyOption(final String jrubyOption)
             throws JRubyNotLoadedException, UnrecognizedJRubyOptionException, NotWorkingJRubyOptionException;
+
+    public abstract Object callMethodArray(final Object receiver,
+                                           final String methodName,
+                                           final Object[] args) throws JRubyInvalidRuntimeException;
 
     public abstract Object callMethod(
             final Object receiver,

--- a/embulk-core/src/test/java/org/embulk/jruby/TestJRubyInitializer.java
+++ b/embulk-core/src/test/java/org/embulk/jruby/TestJRubyInitializer.java
@@ -23,6 +23,7 @@ public class TestJRubyInitializer {
                 null,
                 LoggerFactory.getLogger(TestJRubyInitializer.class),
                 "/gem/home",
+                null,
                 true,
                 loadPath,
                 classpath,
@@ -33,6 +34,8 @@ public class TestJRubyInitializer {
 
         assertEquals("/gem/home", initializer.probeGemHomeForTesting());
         assertTrue(initializer.probeUseDefaultEmbulkGemHomeForTesting());
+
+        assertEquals(null, initializer.probeGemPathForTesting());
 
         assertEquals(1, initializer.probeJRubyLoadPathForTesting().size());
         assertEquals("/load/path", initializer.probeJRubyLoadPathForTesting().get(0));


### PR DESCRIPTION
Allowing Embulk to configure `GEM_PATH`, in addition to `GEM_HOME`, through system configs.
https://stackoverflow.com/questions/11277227/whats-the-difference-between-gem-home-and-gem-path

By configuring `GEM_PATH`, users can look for Embulk plugins from multiple Gem directories.

@sakama Can you have a look when you have time?