### PR TITLE
Bump up to v0.9.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'org.ajoberstar.grgit'
 
-version = '0.9.17-SNAPSHOT'
+version = '0.9.18-SNAPSHOT'
 
 description = 'Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control.'
 


### PR DESCRIPTION
`v0.9.17` is out. Next `v0.9.18`!