### PR TITLE
Abandon FindBugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,11 +52,11 @@ ext {
 
 configure(subprojects.findAll { ['embulk-core', 'embulk-deps-cli', 'embulk-deps-maven', 'embulk-standards', 'embulk-test'].contains(it.name) }) {
     apply plugin: 'checkstyle'
-    apply plugin: 'findbugs'
     apply plugin: 'jacoco'
     apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
+    // TODO: Enable SpotBugs instead of FindBugs which was used in Embulk until v0.9.17.
 
     // The version needs to be declared here, not in each build.gradle, so that "bintray" can get the value.
     version = "${rootProject.version}"
@@ -80,13 +80,6 @@ configure(subprojects.findAll { ['embulk-core', 'embulk-deps-cli', 'embulk-deps-
         }
     }
 
-    tasks.withType(FindBugs) {
-        reports {
-            xml.enabled = false
-            html.enabled = true
-        }
-    }
-
     checkstyle {
         toolVersion '8.7'
         configFile = file("${rootProject.projectDir}/config/checkstyle/checkstyle.xml")
@@ -95,10 +88,6 @@ configure(subprojects.findAll { ['embulk-core', 'embulk-deps-cli', 'embulk-deps-
         ]
         ignoreFailures = false
         maxWarnings = 0  // https://github.com/gradle/gradle/issues/881
-    }
-
-    findbugs {
-        ignoreFailures = true
     }
 
     javadoc {

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     compile 'com.fasterxml.jackson.module:jackson-module-guice:2.6.7'
     compile 'org.slf4j:slf4j-api:1.7.12'
     compile 'org.jruby:jruby-complete:' + rootProject.jrubyVersion
-    compile 'com.google.code.findbugs:annotations:3.0.0'
     compile 'org.yaml:snakeyaml:1.18'
     compile 'javax.validation:validation-api:1.1.0.Final'
     compile 'org.apache.bval:bval-jsr303:0.5'

--- a/embulk-core/src/main/java/org/embulk/spi/Buffer.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Buffer.java
@@ -1,6 +1,5 @@
 package org.embulk.spi;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Arrays;
 
 public class Buffer {
@@ -42,7 +41,7 @@ public class Buffer {
         return new Buffer(src, offset, size).limit(size);
     }
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP")
+    // http://findbugs.sourceforge.net/bugDescriptions.html#EI_EXPOSE_REP
     public byte[] array() {
         return array;
     }

--- a/embulk-core/src/main/java/org/embulk/spi/type/AbstractType.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/AbstractType.java
@@ -1,7 +1,5 @@
 package org.embulk.spi.type;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public abstract class AbstractType implements Type {
     private final String name;
     private final Class<?> javaType;
@@ -28,7 +26,7 @@ public abstract class AbstractType implements Type {
         return fixedStorageSize;
     }
 
-    @SuppressFBWarnings(value = "EQ_UNUSUAL")
+    // http://findbugs.sourceforge.net/bugDescriptions.html#EQ_UNUSUAL
     @Override
     public boolean equals(Object o) {
         if (o == null) {

--- a/embulk-core/src/main/resources/embulk/parent_first_packages.properties
+++ b/embulk-core/src/main/resources/embulk/parent_first_packages.properties
@@ -36,7 +36,6 @@ com.kenai.constantine
 com.kenai.jffi
 com.kenai.jnr.x86asm
 com.martiansoftware.nailgun
-edu.umd.cs.findbugs.annotations
 io.airlift.slice
 io.netty.buffer
 io.netty.util

--- a/embulk-core/src/main/resources/embulk/parent_first_resources.properties
+++ b/embulk-core/src/main/resources/embulk/parent_first_resources.properties
@@ -3,7 +3,6 @@ ch/qos/logback/classic/boolex
 ch/qos/logback/classic/db/script
 com/ibm/icu
 com/martiansoftware/nailgun/builtins
-edu/umd/cs/findbugs/annotations
 embulk
 javax/annotation
 jni/Darwin


### PR DESCRIPTION
FindBugs is no longer maintained.
https://mailman.cs.umd.edu/pipermail/findbugs-discuss/2016-November/004321.html

And we have had unnecessary dependency on `com.google.code.findbugs:annotations:3.0.0` for FindBugs.

We're not effectively using FindBugs. It's time to abandon FindBugs. We may enable SpotBugs instead in the future.