### PR TITLE
Cleanup Buffer, BufferAllocator, and PooledBufferAllocator, and deprecate ByteSize

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -340,7 +340,7 @@ public class EmbulkEmbed {
     static List<Module> standardModuleList(final ConfigSource systemConfig) {
         final ArrayList<Module> built = new ArrayList<>();
         built.add(new SystemConfigModule(systemConfig));
-        built.add(new ExecModule());
+        built.add(new ExecModule(systemConfig));
         built.add(new ExtensionServiceLoaderModule(systemConfig));
         built.add(new PluginClassLoaderModule(systemConfig));
         built.add(new BuiltinPluginSourceModule());

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -6,10 +6,14 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.module.guice.ObjectMapperModule;
-import com.google.common.base.Preconditions;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import java.math.BigDecimal;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.embulk.config.ConfigSource;
 import org.embulk.config.ModelManager;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.ExecutorPlugin;
@@ -21,15 +25,21 @@ import org.embulk.spi.util.CharsetSerDe;
 import org.slf4j.ILoggerFactory;
 
 public class ExecModule implements Module {
+    public ExecModule(final ConfigSource systemConfig) {
+        this.systemConfig = systemConfig;
+    }
+
     @Override
-    public void configure(Binder binder) {
-        Preconditions.checkNotNull(binder, "binder is null.");
+    public void configure(final Binder binder) {
+        if (binder == null) {
+            throw new NullPointerException("binder is null.");
+        }
 
         binder.bind(BulkLoader.class);
 
         binder.bind(ILoggerFactory.class).toProvider(LoggerProvider.class).in(Scopes.SINGLETON);
         binder.bind(ModelManager.class).in(Scopes.SINGLETON);
-        binder.bind(BufferAllocator.class).to(PooledBufferAllocator.class).in(Scopes.SINGLETON);
+        binder.bind(BufferAllocator.class).toInstance(this.createBufferAllocatorFromSystemConfig());
         binder.bind(TempFileAllocator.class).in(Scopes.SINGLETON);
 
         // GuessExecutor, PreviewExecutor
@@ -39,8 +49,8 @@ public class ExecModule implements Module {
         // LocalExecutorPlugin
         registerPluginTo(binder, ExecutorPlugin.class, "local", LocalExecutorPlugin.class);
 
-        // serde
-        ObjectMapperModule mapper = new ObjectMapperModule();
+        // SerDe
+        final ObjectMapperModule mapper = new ObjectMapperModule();
         DateTimeZoneSerDe.configure(mapper);
         TimestampSerDe.configure(mapper);
         CharsetSerDe.configure(mapper);
@@ -50,4 +60,64 @@ public class ExecModule implements Module {
         mapper.registerModule(new JodaModule());  // jackson-datatype-joda
         mapper.configure(binder);
     }
+
+    private BufferAllocator createBufferAllocatorFromSystemConfig() {
+        final String byteSizeRepresentation = this.systemConfig.get(String.class, "page_size", null);
+        if (byteSizeRepresentation == null) {
+            return new PooledBufferAllocator();
+        } else {
+            final int byteSize = parseByteSizeRepresentation(byteSizeRepresentation);
+            return new PooledBufferAllocator(byteSize);
+        }
+    }
+
+    private static int parseByteSizeRepresentation(final String byteSizeRepresentation) {
+        if (byteSizeRepresentation == null) {  // Should not happen.
+            throw new NullPointerException("size is null");
+        }
+        if (byteSizeRepresentation.isEmpty()) {
+            throw new IllegalArgumentException("size is empty");
+        }
+
+        final Matcher matcher = BYTE_SIZE_PATTERN.matcher(byteSizeRepresentation);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid byte size string '" + byteSizeRepresentation + "'");
+        }
+
+        final String numberPart = matcher.group(1);
+        final String unitPart = matcher.group(2);
+
+        final BigDecimal number = new BigDecimal(numberPart);  // NumberFormatException extends IllegalArgumentException.
+
+        if (unitPart.isEmpty()) {
+            return number.intValue();
+        }
+
+        switch (unitPart.toUpperCase(Locale.ENGLISH)) {
+            case "B":
+                return number.intValue();
+            case "KB":
+                return number.multiply(KILO).intValue();
+            case "MB":
+                return number.multiply(MEGA).intValue();
+            case "GB":
+                return number.multiply(GIGA).intValue();
+            case "TB":
+                return number.multiply(TERA).intValue();
+            case "PB":
+                return number.multiply(PETA).intValue();
+            default:
+                throw new IllegalArgumentException("Unknown unit '" + unitPart + "'");
+        }
+    }
+
+    private static final Pattern BYTE_SIZE_PATTERN = Pattern.compile("\\A(\\d+(?:\\.\\d+)?)\\s?([a-zA-Z]*)\\z");
+
+    private static final BigDecimal KILO = new BigDecimal(1L << 10);  // 1_024
+    private static final BigDecimal MEGA = new BigDecimal(1L << 20);  // 1_048_576
+    private static final BigDecimal GIGA = new BigDecimal(1L << 30);  // 1_073_741_824
+    private static final BigDecimal TERA = new BigDecimal(1L << 40);  // 1_099_511_627_776
+    private static final BigDecimal PETA = new BigDecimal(1L << 50);  // 1_125_899_906_842_624
+
+    private final ConfigSource systemConfig;
 }

--- a/embulk-core/src/main/java/org/embulk/spi/unit/ByteSize.java
+++ b/embulk-core/src/main/java/org/embulk/spi/unit/ByteSize.java
@@ -7,14 +7,18 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Parses and formats byte size representations, such as "4MB", "83GB".
+ *
+ * <p>This class is deprecated, to be removed in plan. Any plugin should not use it.
+ */
+@Deprecated
 public class ByteSize implements Comparable<ByteSize> {
-    private static final Pattern PATTERN = Pattern.compile("\\A(\\d+(?:\\.\\d+)?)\\s?([a-zA-Z]*)\\z");
-
-    private final long bytes;
-    private final Unit displayUnit;
-
     public ByteSize(double size, Unit unit) {
+        logger.warn("org.embulk.spi.unit.ByteSize is deprecated. Used at:", new Throwable());
         Preconditions.checkArgument(!Double.isInfinite(size), "size is infinite");
         Preconditions.checkArgument(!Double.isNaN(size), "size is not a number");
         Preconditions.checkArgument(size >= 0, "size is negative");
@@ -26,6 +30,7 @@ public class ByteSize implements Comparable<ByteSize> {
 
     @JsonCreator
     public ByteSize(long bytes) {
+        logger.warn("org.embulk.spi.unit.ByteSize is deprecated. Used at:", new Throwable());
         Preconditions.checkArgument(bytes >= 0, "size is negative");
         this.bytes = bytes;
         this.displayUnit = Unit.BYTES;
@@ -136,4 +141,11 @@ public class ByteSize implements Comparable<ByteSize> {
             return unitString;
         }
     }
+
+    private static final Logger logger = LoggerFactory.getLogger(ByteSize.class);
+
+    private static final Pattern PATTERN = Pattern.compile("\\A(\\d+(?:\\.\\d+)?)\\s?([a-zA-Z]*)\\z");
+
+    private final long bytes;
+    private final Unit displayUnit;
 }

--- a/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
+++ b/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
@@ -32,7 +32,7 @@ public class EmbulkTestRuntime extends GuiceBinder {
         public void configure(Binder binder) {
             ConfigSource systemConfig = getSystemConfig();
             new SystemConfigModule(systemConfig).configure(binder);
-            new ExecModule().configure(binder);
+            new ExecModule(systemConfig).configure(binder);
             new ExtensionServiceLoaderModule(systemConfig).configure(binder);
             new BuiltinPluginSourceModule().configure(binder);
             new JRubyScriptingModule(systemConfig).configure(binder);

--- a/embulk-core/src/test/java/org/embulk/spi/unit/TestByteSize.java
+++ b/embulk-core/src/test/java/org/embulk/spi/unit/TestByteSize.java
@@ -53,14 +53,17 @@ public class TestByteSize {
         assertByteSizeString("42.33KB", "42.33KB");
     }
 
+    @SuppressWarnings("deprecation")
     private static void assertByteSize(long bytes, String string) {
         assertEquals(bytes, ByteSize.parseByteSize(string).getBytes());
     }
 
+    @SuppressWarnings("deprecation")
     private static void assertByteSizeString(String expected, String string) {
         assertEquals(expected, ByteSize.parseByteSize(string).toString());
     }
 
+    @SuppressWarnings("deprecation")
     private static void assertInvalidByteSize(String string) {
         try {
             ByteSize.parseByteSize(string);


### PR DESCRIPTION
Cleaning up `Buffer`, `BufferAllocator`, and `PooledBufferAllocator`. Along with it,

* Reorder methods and fields.
* `PooledBufferAllocator` to be instantiated without Guice and system config.
* Deprecate `ByteSize`, which has been used only in `PooledBufferAllocator`. No plugins using this class are found.
* Use `BigDecimal` to parse byte size strings, instead of `double`.
* Reduce usage of Guava.

@sakama Can you have a look when you have time? (Not in a hurry)