### PR TITLE
Upgrade Apache Maven and maven-resolver-provider to 3.6.1 in embulk-deps-maven

### DIFF
--- a/embulk-deps/maven/build.gradle
+++ b/embulk-deps/maven/build.gradle
@@ -8,16 +8,21 @@ repositories {
 }
 
 dependencies {
-    compileOnly project(':embulk-core')
+    compileOnly project(":embulk-core")
 
-    // For MavenPluginSource / MavenArtifactFinder.
-    compile 'org.apache.maven:maven-artifact:3.3.9'
-    compile 'org.eclipse.aether:aether-api:1.1.0'
-    compile 'org.eclipse.aether:aether-spi:1.1.0'
-    compile 'org.eclipse.aether:aether-util:1.1.0'
-    compile 'org.eclipse.aether:aether-impl:1.1.0'
-    compile 'org.apache.maven:maven-aether-provider:3.3.9'
+    compile "org.apache.maven:maven-artifact:3.6.1"
+    compile "org.apache.maven.resolver:maven-resolver-api:1.3.3"
+    compile "org.apache.maven.resolver:maven-resolver-spi:1.3.3"
+    compile "org.apache.maven.resolver:maven-resolver-util:1.3.3"
+    compile("org.apache.maven.resolver:maven-resolver-impl:1.3.3") {
+        exclude group: "org.slf4j", module: "slf4j-api"  // Included in embulk-core.
+    }
+    compile("org.apache.maven:maven-resolver-provider:3.6.1") {
+        exclude group: "javax.inject", module: "javax.inject"  // Included in embulk-core.
+        exclude group: "com.google.inject", module: "guice"  // Included in embulk-core.
+        exclude group: "org.slf4j", module: "slf4j-api"  // Included in embulk-core.
+    }
 
-    testCompile project(':embulk-core')
-    testCompile 'junit:junit:4.12'
+    testCompile project(":embulk-core")
+    testCompile "junit:junit:4.12"
 }


### PR DESCRIPTION
Upgrading Apache Maven (as Java library) to the latest 3.6.1.

Note that Eclipse Aether is now migrated to Apache and named as Apache Maven Resolver.
http://maven.40175.n5.nabble.com/Formerly-Aether-now-Maven-Artifact-Resolver-documentation-td5900927.html