### PR TITLE
Fix EmbulkEmbed.Bootstrap.setSystemConfig, which was not working

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -58,12 +58,11 @@ public class EmbulkEmbed {
         }
 
         public Bootstrap setSystemConfigFromJson(final String systemConfigJson) {
-            this.systemConfig = this.systemConfigLoader.fromJsonString(systemConfigJson);
-            return this;
+            return this.setSystemConfig(this.systemConfigLoader.fromJsonString(systemConfigJson));
         }
 
-        public Bootstrap setSystemConfig(final ConfigSource systemConfig) {
-            this.systemConfig = this.systemConfig.deepCopy();
+        public Bootstrap setSystemConfig(final ConfigSource systemConfigGiven) {
+            this.systemConfig = systemConfigGiven.deepCopy();
             return this;
         }
 


### PR DESCRIPTION
Was a bug. `EmbulkEmbed.Bootstrap.setSystemConfig(ConfigSource)` was totally not working. (But it was not used in `embulk-core`. `embulk-core` uses `setSystemConfigFromJson` instead.)

Fixing the bug, and letting `setSystemConfigFromJson` to call `setSystemConfig` internally.

@sakama Can you have a look?