### PR TITLE
Use EmbulkSystemProperties in embulk-core and its Guice Modules

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -13,7 +13,7 @@ import java.math.BigDecimal;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.embulk.config.ConfigSource;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.ModelManager;
 import org.embulk.deps.buffer.PooledBufferAllocator;
 import org.embulk.spi.BufferAllocator;
@@ -27,8 +27,8 @@ import org.embulk.spi.util.CharsetSerDe;
 import org.slf4j.ILoggerFactory;
 
 public class ExecModule implements Module {
-    public ExecModule(final ConfigSource systemConfig) {
-        this.systemConfig = systemConfig;
+    public ExecModule(final EmbulkSystemProperties embulkSystemProperties) {
+        this.embulkSystemProperties = embulkSystemProperties;
     }
 
     @Override
@@ -64,7 +64,7 @@ public class ExecModule implements Module {
     }
 
     private BufferAllocator createBufferAllocatorFromSystemConfig() {
-        final String byteSizeRepresentation = this.systemConfig.get(String.class, "page_size", null);
+        final String byteSizeRepresentation = this.embulkSystemProperties.getProperty("page_size");
         if (byteSizeRepresentation == null) {
             return PooledBufferAllocator.create();
         } else {
@@ -121,5 +121,5 @@ public class ExecModule implements Module {
     private static final BigDecimal TERA = new BigDecimal(1L << 40);  // 1_099_511_627_776
     private static final BigDecimal PETA = new BigDecimal(1L << 50);  // 1_125_899_906_842_624
 
-    private final ConfigSource systemConfig;
+    private final EmbulkSystemProperties embulkSystemProperties;
 }

--- a/embulk-core/src/main/java/org/embulk/exec/ExtensionServiceLoaderModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExtensionServiceLoaderModule.java
@@ -3,7 +3,7 @@ package org.embulk.exec;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import java.util.ServiceLoader;
-import org.embulk.config.ConfigSource;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.spi.Extension;
 
 /**
@@ -15,22 +15,22 @@ import org.embulk.spi.Extension;
  */
 public class ExtensionServiceLoaderModule implements Module {
     private final ClassLoader classLoader;
-    private final ConfigSource systemConfig;
+    private final EmbulkSystemProperties embulkSystemProperties;
 
-    public ExtensionServiceLoaderModule(ConfigSource systemConfig) {
-        this(ExtensionServiceLoaderModule.class.getClassLoader(), systemConfig);
+    public ExtensionServiceLoaderModule(final EmbulkSystemProperties embulkSystemProperties) {
+        this(ExtensionServiceLoaderModule.class.getClassLoader(), embulkSystemProperties);
     }
 
-    public ExtensionServiceLoaderModule(ClassLoader classLoader, ConfigSource systemConfig) {
+    public ExtensionServiceLoaderModule(final ClassLoader classLoader, final EmbulkSystemProperties embulkSystemProperties) {
         this.classLoader = classLoader;
-        this.systemConfig = systemConfig;
+        this.embulkSystemProperties = embulkSystemProperties;
     }
 
     @Override
     public void configure(Binder binder) {
         ServiceLoader<Extension> serviceLoader = ServiceLoader.load(Extension.class, classLoader);
         for (Extension extension : serviceLoader) {
-            for (Module module : extension.getModules(systemConfig)) {
+            for (Module module : extension.getModules(this.embulkSystemProperties)) {
                 module.configure(binder);
             }
         }

--- a/embulk-core/src/main/java/org/embulk/exec/ForSystemConfig.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ForSystemConfig.java
@@ -9,6 +9,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
+@Deprecated  // Removal is expected to be later, but no longer recommended.
 @Retention(RUNTIME)
 @Target({FIELD, PARAMETER, METHOD})
 @Qualifier

--- a/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
@@ -37,10 +38,10 @@ public class LocalExecutorPlugin implements ExecutorPlugin {
     private int defaultMinThreads;
 
     @Inject
-    public LocalExecutorPlugin(@ForSystemConfig ConfigSource systemConfig) {
+    public LocalExecutorPlugin(final EmbulkSystemProperties embulkSystemProperties) {
         int cores = Runtime.getRuntime().availableProcessors();
-        this.defaultMaxThreads = systemConfig.get(Integer.class, "max_threads", cores * 2);
-        this.defaultMinThreads = systemConfig.get(Integer.class, "min_output_tasks", cores);
+        this.defaultMaxThreads = embulkSystemProperties.getPropertyAsInteger("max_threads", cores * 2);
+        this.defaultMinThreads = embulkSystemProperties.getPropertyAsInteger("min_output_tasks", cores);
     }
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/exec/SystemConfigModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SystemConfigModule.java
@@ -2,19 +2,27 @@ package org.embulk.exec;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.ConfigSource;
 
 public class SystemConfigModule implements Module {
+    @Deprecated  // To be removed. Kept only for providing system config with @ForSystemConfig.
     private final ConfigSource systemConfig;
 
-    public SystemConfigModule(ConfigSource systemConfig) {
+    private final EmbulkSystemProperties embulkSystemProperties;
+
+    public SystemConfigModule(final ConfigSource systemConfig, final EmbulkSystemProperties embulkSystemProperties) {
         this.systemConfig = systemConfig;
+        this.embulkSystemProperties = embulkSystemProperties;
     }
 
+    @SuppressWarnings("deprecation")  // Using ForSystemConfig
     @Override
     public void configure(Binder binder) {
         binder.bind(ConfigSource.class)
                 .annotatedWith(ForSystemConfig.class)
                 .toInstance(systemConfig);
+        binder.bind(EmbulkSystemProperties.class)
+                .toInstance(embulkSystemProperties);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
@@ -12,15 +12,12 @@ import com.google.inject.spi.ProviderWithDependencies;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import org.embulk.config.ConfigSource;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.ModelManager;
-import org.embulk.exec.ForSystemConfig;
 import org.embulk.spi.BufferAllocator;
 import org.slf4j.ILoggerFactory;
 
 public class JRubyScriptingModule implements Module {
-    public JRubyScriptingModule(ConfigSource systemConfig) {}
-
     @Override
     public void configure(Binder binder) {
         binder.bind(ScriptingContainerDelegate.class).toProvider(ScriptingContainerProvider.class).in(Scopes.SINGLETON);
@@ -34,27 +31,27 @@ public class JRubyScriptingModule implements Module {
     private static class ScriptingContainerProvider
             implements ProviderWithDependencies<ScriptingContainerDelegate> {
         @Inject
-        public ScriptingContainerProvider(Injector injector, @ForSystemConfig ConfigSource systemConfig) {
+        public ScriptingContainerProvider(final Injector injector, final EmbulkSystemProperties embulkSystemProperties) {
             // use_global_ruby_runtime is valid only when it's guaranteed that just one Injector is
             // instantiated in this JVM.
-            this.useGlobalRubyRuntime = systemConfig.get(boolean.class, "use_global_ruby_runtime", false);
+            this.useGlobalRubyRuntime = embulkSystemProperties.getPropertyAsBoolean("use_global_ruby_runtime", false);
 
             this.initializer = JRubyInitializer.of(
                     injector,
                     injector.getInstance(ILoggerFactory.class).getLogger("init"),
 
-                    systemConfig.get(String.class, "gem_home", null),
-                    systemConfig.get(String.class, "gem_path", null),
-                    systemConfig.get(String.class, "jruby_use_default_embulk_gem_home", "false").equals("true"),
+                    embulkSystemProperties.getProperty("gem_home", null),
+                    embulkSystemProperties.getProperty("gem_path", null),
+                    embulkSystemProperties.getPropertyAsBoolean("jruby_use_default_embulk_gem_home", false),
 
-                    // TODO get jruby-home from systemConfig to call jruby.container.setHomeDirectory
-                    systemConfig.get(String.class, "jruby_load_path", null),
-                    systemConfig.get(String.class, "jruby_classpath", null),
-                    systemConfig.get(String.class, "jruby_command_line_options", null),
+                    // TODO get jruby-home from embulkSystemProperties to call jruby.container.setHomeDirectory
+                    embulkSystemProperties.getProperty("jruby_load_path", null),
+                    embulkSystemProperties.getProperty("jruby_classpath", null),
+                    embulkSystemProperties.getProperty("jruby_command_line_options", null),
 
-                    systemConfig.get(String.class, "jruby_global_bundler_plugin_source_directory", null),
+                    embulkSystemProperties.getProperty("jruby_global_bundler_plugin_source_directory", null),
 
-                    systemConfig.get(String.class, "jruby.require.sigdump", "false").equals("true"));
+                    embulkSystemProperties.getPropertyAsBoolean("jruby.require.sigdump", false));
         }
 
         @Override  // from |com.google.inject.Provider|

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
@@ -5,10 +5,9 @@ import com.google.inject.Injector;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.embulk.config.ConfigSource;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.deps.maven.MavenArtifactFinder;
 import org.embulk.deps.maven.MavenPluginPaths;
-import org.embulk.exec.ForSystemConfig;
 import org.embulk.plugin.MavenPluginType;
 import org.embulk.plugin.PluginClassLoaderFactory;
 import org.embulk.plugin.PluginSource;
@@ -32,9 +31,9 @@ import org.embulk.spi.ParserPlugin;
 
 public class MavenPluginSource implements PluginSource {
     @Inject
-    public MavenPluginSource(Injector injector, @ForSystemConfig ConfigSource systemConfig) {
+    public MavenPluginSource(final Injector injector, final EmbulkSystemProperties embulkSystemProperties) {
         this.injector = injector;
-        this.systemConfig = systemConfig;
+        this.embulkSystemProperties = embulkSystemProperties;
     }
 
     @Override
@@ -154,7 +153,7 @@ public class MavenPluginSource implements PluginSource {
     }
 
     private Path getLocalMavenRepository() throws PluginSourceNotMatchException {
-        final String m2RepoInSystemConfig = systemConfig.get(String.class, "m2_repo", null);
+        final String m2RepoInSystemConfig = this.embulkSystemProperties.getProperty("m2_repo", null);
 
         if (m2RepoInSystemConfig != null) {
             return Paths.get(m2RepoInSystemConfig);
@@ -186,5 +185,5 @@ public class MavenPluginSource implements PluginSource {
     }
 
     private final Injector injector;
-    private final ConfigSource systemConfig;
+    private final EmbulkSystemProperties embulkSystemProperties;
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSourceModule.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSourceModule.java
@@ -3,11 +3,10 @@ package org.embulk.plugin.maven;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.multibindings.Multibinder;
-import org.embulk.config.ConfigSource;
 import org.embulk.plugin.PluginSource;
 
 public class MavenPluginSourceModule implements Module {
-    public MavenPluginSourceModule(ConfigSource systemConfig) {}
+    public MavenPluginSourceModule() {}
 
     @Override
     public void configure(Binder binder) {

--- a/embulk-core/src/main/java/org/embulk/spi/Extension.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Extension.java
@@ -2,7 +2,7 @@ package org.embulk.spi;
 
 import com.google.inject.Module;
 import java.util.List;
-import org.embulk.config.ConfigSource;
+import org.embulk.EmbulkSystemProperties;
 
 /**
  * Extension is a module to extend the execution framework using Guice.
@@ -39,5 +39,5 @@ import org.embulk.config.ConfigSource;
  * </code>
  */
 public interface Extension {
-    List<Module> getModules(ConfigSource systemConfig);
+    List<Module> getModules(final EmbulkSystemProperties embulkSystemProperties);
 }

--- a/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
+++ b/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
@@ -3,6 +3,7 @@ package org.embulk;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import java.util.Properties;
 import java.util.Random;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.DataSourceImpl;
@@ -31,11 +32,12 @@ public class EmbulkTestRuntime extends GuiceBinder {
         @Override
         public void configure(Binder binder) {
             ConfigSource systemConfig = getSystemConfig();
-            new SystemConfigModule(systemConfig).configure(binder);
-            new ExecModule(systemConfig).configure(binder);
-            new ExtensionServiceLoaderModule(systemConfig).configure(binder);
+            final EmbulkSystemProperties embulkSystemProperties = EmbulkSystemProperties.of(new Properties());
+            new SystemConfigModule(systemConfig, embulkSystemProperties).configure(binder);
+            new ExecModule(embulkSystemProperties).configure(binder);
+            new ExtensionServiceLoaderModule(embulkSystemProperties).configure(binder);
             new BuiltinPluginSourceModule().configure(binder);
-            new JRubyScriptingModule(systemConfig).configure(binder);
+            new JRubyScriptingModule().configure(binder);
             new PluginClassLoaderModule().configure(binder);
             new TestUtilityModule().configure(binder);
             new TestPluginSourceModule().configure(binder);

--- a/embulk-core/src/test/java/org/embulk/TestEmbulkSystemProperties.java
+++ b/embulk-core/src/test/java/org/embulk/TestEmbulkSystemProperties.java
@@ -1,0 +1,151 @@
+package org.embulk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Properties;
+import org.junit.Test;
+
+public class TestEmbulkSystemProperties {
+    @Test
+    public void testParseInteger() {
+        assertInteger("11", 11, 1234);
+        assertInteger("  13", 13, 1234);
+        assertInteger("  17  ", 17, 1234);
+        assertInteger("111111111", 111111111, 1234);
+        assertInteger("-11", -11, 1234);
+    }
+
+    @Test
+    public void testParseIntegerInvalidFormat() {
+        /*
+         * They failed originally like below with Jackson:
+         *
+         * "fuo"
+         *   com.fasterxml.jackson.databind.exc.InvalidFormatException:
+         *   Can not construct instance of java.lang.Integer from String value 'fuo': not a valid Integer value
+         * "true"
+         *   com.fasterxml.jackson.databind.exc.InvalidFormatException
+         *   Can not construct instance of java.lang.Integer from String value 'true': not a valid Integer value
+         * "11f"
+         *   com.fasterxml.jackson.databind.exc.InvalidFormatException
+         *   Can not construct instance of java.lang.Integer from String value '11f': not a valid Integer value
+         * "11.131"
+         *   com.fasterxml.jackson.databind.exc.InvalidFormatException
+         *   Can not construct instance of java.lang.Integer from String value '11.131': not a valid Integer value
+         * "111111111111"
+         *   com.fasterxml.jackson.databind.exc.InvalidFormatException:
+         *   Can not construct instance of java.lang.Integer from String value '111111111111':
+         *   Overflow: numeric value (111111111111) out of range of Integer (-2147483648 - 2147483647)
+         */
+        assertIntegerInvalidFormat("fuo");
+        assertIntegerInvalidFormat("true");
+        assertIntegerInvalidFormat("True");
+        assertIntegerInvalidFormat("false");
+        assertIntegerInvalidFormat("11f");
+        assertIntegerInvalidFormat("11.131");
+        assertIntegerInvalidFormat("111111111111");
+    }
+
+    @Test
+    public void testParseIntegerNull() {
+        assertIntegerNull("null");
+        assertIntegerNull("");
+        assertIntegerNull("  ");
+    }
+
+    @Test
+    public void testParseBoolean() {
+        assertBoolean("true", true, false);
+        assertBoolean("True", true, false);
+        assertBoolean("false", false, false);
+        assertBoolean("false", false, false);
+
+        assertBoolean("  true", true, true);
+        assertBoolean("  True", true, true);
+        assertBoolean(" false  ", false, true);
+        assertBoolean(" false  ", false, true);
+
+        assertBoolean("", false, false);
+        assertBoolean("", true, true);
+        assertBoolean("  ", false, false);
+        assertBoolean("  ", true, true);
+        assertBoolean("null", false, false);
+        assertBoolean("null", true, true);
+        assertBoolean(" null  ", false, false);
+        assertBoolean(" null  ", true, true);
+    }
+
+    @Test
+    public void testParseBooleanInvalidFormat() {
+        /*
+         * They failed originally like below with Jackson:
+         *
+         * "tRuE"
+         *   com.fasterxml.jackson.databind.exc.InvalidFormatException:
+         *   Can not construct instance of boolean from String value 'tRuE': only "true" or "false" recognized
+         * "TRUE"
+         *   com.fasterxml.jackson.databind.exc.InvalidFormatException:
+         *   Can not construct instance of boolean from String value 'TRUE': only "true" or "false" recognized
+         * "0"
+         *   com.fasterxml.jackson.databind.exc.InvalidFormatException:
+         *   Can not construct instance of boolean from String value '0': only "true" or "false" recognized
+         * "1"
+         *   com.fasterxml.jackson.databind.exc.InvalidFormatException:
+         *   Can not construct instance of boolean from String value '1': only "true" or "false" recognized
+         */
+        assertBooleanInvalidFormat("TRUE");
+        assertBooleanInvalidFormat("tRuE");
+        assertBooleanInvalidFormat("FALSE");
+        assertBooleanInvalidFormat("falsE");
+        assertBooleanInvalidFormat("0");
+        assertBooleanInvalidFormat("1");
+        assertBooleanInvalidFormat("123456");
+        assertBooleanInvalidFormat("foo");
+    }
+
+    private static void assertInteger(final String text, final int expectedValue, final int defaultValue) {
+        final Properties properties = new Properties();
+        properties.setProperty("key", text);
+        assertEquals(expectedValue, EmbulkSystemProperties.of(properties).getPropertyAsInteger("key", defaultValue));
+    }
+
+    private static void assertIntegerInvalidFormat(final String text) {
+        final Properties properties = new Properties();
+        properties.setProperty("key", text);
+        try {
+            final int unexpectedResult = EmbulkSystemProperties.of(properties).getPropertyAsInteger("key", 123456);
+            fail("\"" + text + "\" was unexpectedly parsed successfully: " + unexpectedResult);
+        } catch (final IllegalArgumentException ex) {
+            return;  // Success.
+        }
+    }
+
+    private static void assertIntegerNull(final String text) {
+        final Properties properties = new Properties();
+        properties.setProperty("key", text);
+        try {
+            final int unexpectedResult = EmbulkSystemProperties.of(properties).getPropertyAsInteger("key", 123456);
+            fail("\"" + text + "\" was unexpectedly parsed successfully: " + unexpectedResult);
+        } catch (final NullPointerException ex) {
+            return;  // Success.
+        }
+    }
+
+    private static void assertBoolean(final String text, final boolean expectedValue, final boolean defaultValue) {
+        final Properties properties = new Properties();
+        properties.setProperty("key", text);
+        assertEquals(expectedValue, EmbulkSystemProperties.of(properties).getPropertyAsBoolean("key", defaultValue));
+    }
+
+    private static void assertBooleanInvalidFormat(final String text) {
+        final Properties properties = new Properties();
+        properties.setProperty("key", text);
+        try {
+            final boolean unexpectedResult = EmbulkSystemProperties.of(properties).getPropertyAsBoolean("key", false);
+            fail("\"" + text + "\" was unexpectedly parsed successfully: " + unexpectedResult);
+        } catch (final IllegalArgumentException ex) {
+            return;  // Success.
+        }
+    }
+}

--- a/embulk-standards/src/main/java/org/embulk/standards/StandardPluginExtension.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StandardPluginExtension.java
@@ -3,11 +3,11 @@ package org.embulk.standards;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
 import java.util.List;
-import org.embulk.config.ConfigSource;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.spi.Extension;
 
 public class StandardPluginExtension implements Extension {
-    public List<Module> getModules(final ConfigSource systemConfig) {
-        return ImmutableList.<Module>of(new StandardPluginModule(systemConfig));
+    public List<Module> getModules(final EmbulkSystemProperties embulkSystemProperties) {
+        return ImmutableList.<Module>of(new StandardPluginModule(embulkSystemProperties));
     }
 }

--- a/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
@@ -6,7 +6,7 @@ import static org.embulk.plugin.InjectedPluginSource.registerPluginTo;
 import com.google.common.base.Preconditions;
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import org.embulk.config.ConfigSource;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.plugin.DefaultPluginType;
 import org.embulk.spi.DecoderPlugin;
 import org.embulk.spi.EncoderPlugin;
@@ -17,8 +17,8 @@ import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.ParserPlugin;
 
 public class StandardPluginModule implements Module {
-    public StandardPluginModule(final ConfigSource systemConfig) {
-        this.systemConfig = systemConfig;
+    public StandardPluginModule(final EmbulkSystemProperties embulkSystemProperties) {
+        this.embulkSystemProperties = embulkSystemProperties;
     }
 
     @Override
@@ -26,77 +26,77 @@ public class StandardPluginModule implements Module {
         Preconditions.checkNotNull(binder, "binder is null.");
 
         // input plugins
-        if (!systemConfig.get(boolean.class, "standards.input.config.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.input.config.disabled", false)) {
             registerPluginTo(binder, InputPlugin.class, "config", ConfigInputPlugin.class);
         }
-        if (!systemConfig.get(boolean.class, "standards.input.file.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.input.file.disabled", false)) {
             registerPluginTo(binder, InputPlugin.class, "file", LocalFileInputPlugin.class);
         }
 
         // parser plugins
-        if (!systemConfig.get(boolean.class, "standards.parser.csv.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.parser.csv.disabled", false)) {
             registerPluginTo(binder, ParserPlugin.class, "csv", CsvParserPlugin.class);
         }
-        if (!systemConfig.get(boolean.class, "standards.parser.json.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.parser.json.disabled", false)) {
             registerPluginTo(binder, ParserPlugin.class, "json", JsonParserPlugin.class);
         }
 
         // file decoder plugins
-        if (!systemConfig.get(boolean.class, "standards.decoder.gzip.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.decoder.gzip.disabled", false)) {
             registerPluginTo(binder, DecoderPlugin.class, "gzip", GzipFileDecoderPlugin.class);
         }
-        if (!systemConfig.get(boolean.class, "standards.decoder.bzip2.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.decoder.bzip2.disabled", false)) {
             registerPluginTo(binder, DecoderPlugin.class, "bzip2", Bzip2FileDecoderPlugin.class);
         }
 
         // output plugins
-        if (!systemConfig.get(boolean.class, "standards.output.file.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.output.file.disabled", false)) {
             registerPluginTo(binder, OutputPlugin.class, "file", LocalFileOutputPlugin.class);
         }
-        if (!systemConfig.get(boolean.class, "standards.output.null.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.output.null.disabled", false)) {
             registerPluginTo(binder, OutputPlugin.class, "null", NullOutputPlugin.class);
         }
-        if (!systemConfig.get(boolean.class, "standards.output.stdout.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.output.stdout.disabled", false)) {
             registerPluginTo(binder, OutputPlugin.class, "stdout", StdoutOutputPlugin.class);
         }
 
         // formatter plugins
-        if (!systemConfig.get(boolean.class, "standards.formatter.csv.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.formatter.csv.disabled", false)) {
             registerPluginTo(binder, FormatterPlugin.class, "csv", CsvFormatterPlugin.class);
         }
 
         // file encoder plugins
-        if (!systemConfig.get(boolean.class, "standards.encoder.gzip.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.encoder.gzip.disabled", false)) {
             registerPluginTo(binder, EncoderPlugin.class, "gzip", GzipFileEncoderPlugin.class);
         }
-        if (!systemConfig.get(boolean.class, "standards.encoder.bzip2.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.encoder.bzip2.disabled", false)) {
             registerPluginTo(binder, EncoderPlugin.class, "bzip2", Bzip2FileEncoderPlugin.class);
         }
 
         // filter plugins
-        if (!systemConfig.get(boolean.class, "standards.filter.rename.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.filter.rename.disabled", false)) {
             registerPluginTo(binder, FilterPlugin.class, "rename", RenameFilterPlugin.class);
         }
-        if (!systemConfig.get(boolean.class, "standards.filter.remove_columns.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.filter.remove_columns.disabled", false)) {
             registerPluginTo(binder, FilterPlugin.class, "remove_columns", RemoveColumnsFilterPlugin.class);
         }
 
         // default guess plugins
-        if (!systemConfig.get(boolean.class, "standards.decoder.gzip.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.decoder.gzip.disabled", false)) {
             registerDefaultGuessPluginTo(binder, DefaultPluginType.create("gzip"));
         }
-        if (!systemConfig.get(boolean.class, "standards.decoder.bzip2.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.decoder.bzip2.disabled", false)) {
             registerDefaultGuessPluginTo(binder, DefaultPluginType.create("bzip2"));
         }
-        if (!systemConfig.get(boolean.class, "standards.parser.json.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.parser.json.disabled", false)) {
             // should be registered before CsvGuessPlugin
             registerDefaultGuessPluginTo(binder, DefaultPluginType.create("json"));
         }
-        if (!systemConfig.get(boolean.class, "standards.parser.csv.disabled", false)) {
+        if (!embulkSystemProperties.getPropertyAsBoolean("standards.parser.csv.disabled", false)) {
             registerDefaultGuessPluginTo(binder, DefaultPluginType.create("csv"));
         }
         // charset and newline guess plugins are loaded and invoked by CsvGuessPlugin
     }
 
-    private final ConfigSource systemConfig;
+    private final EmbulkSystemProperties embulkSystemProperties;
 }


### PR DESCRIPTION
`EmbulkSystemProperties` was introduced in #1160 (v0.9.22) to replace the system config represented by `ConfigSource`.

After it is added in v0.9.22, starting to use it in embulk-core v0.10.
