### PR TITLE
Load Maven dependencies only of "compile" and "runtime" scopes

### DIFF
--- a/embulk-deps/maven/src/main/java/org/embulk/deps/maven/MavenArtifactFinderImpl.java
+++ b/embulk-deps/maven/src/main/java/org/embulk/deps/maven/MavenArtifactFinderImpl.java
@@ -71,8 +71,11 @@ public class MavenArtifactFinderImpl extends MavenArtifactFinder {
         }
         final ArrayList<Path> dependencyPaths = new ArrayList<>();
         for (final Dependency dependency : result.getDependencies()) {
-            final Path dependencyPath = this.findMavenArtifact(dependency.getArtifact());
-            dependencyPaths.add(dependencyPath);
+            final String scope = dependency.getScope();
+            if (scope.equals("compile") || scope.equals("runtime")) {
+                final Path dependencyPath = this.findMavenArtifact(dependency.getArtifact());
+                dependencyPaths.add(dependencyPath);
+            }
         }
         final Path artifactPath = this.findMavenArtifact(result.getArtifact());
         return MavenPluginPaths.of(artifactPath, dependencyPaths);


### PR DESCRIPTION
By #1015, Maven-based plugins are loaded only with its "direct" dependency libraries, without its "transitive" dependencies ( == dependencies of dependencies).

This PR restricts the load only to `compile` and `runtime` scope. It will work with Embulk plugins built with the updated Gradle plugin: https://github.com/embulk/gradle-embulk-plugins/pull/24

----

@sakama Can you have a look? (No hurry.)

I plan to release v0.9.18 after this PR. The date may be a bit later, though.