### PR TITLE
Bundled JsonParser plugin throws TimestampParseException when JSON data contains invalid timestamp value

### DIFF
--- a/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestJsonParserPlugin.java
@@ -139,6 +139,25 @@ public class TestJsonParserPlugin {
     }
 
     @Test
+    public void readInvalidTimestampColumn() {
+        final List<Object> schemaConfig = new ArrayList<>();
+        schemaConfig.add(config().set("name", "_c0").set("type", "long"));
+        schemaConfig.add(config().set("name", "_c1").set("type", "timestamp"));
+
+        ConfigSource config = this.config.deepCopy()
+                .set("stop_on_invalid_record", true)
+                .set("columns", schemaConfig);
+        try {
+            transaction(config, fileInput(
+                    "{\"_c0\":true,\"_c1\":\"\"," // throw DataException
+            ));
+            fail();
+        } catch (Throwable t) {
+            assertTrue(t instanceof DataException);
+        }
+    }
+
+    @Test
     public void useDefaultInvalidEscapeStringFunction() throws Exception {
         try {
             transaction(config, fileInput(


### PR DESCRIPTION
I found that bundled JsonParser plugin always throws TimestampParseException when JSON data contains invalid timestamp value.
The problem happens with both of `stop_on_invalid_record: true/false`
This PR fixes the problem.

## Problem

### Expected behavior

* when `stop_on_invalid_record: true`
`DataException` is thrown

* when `stop_on_invalid_record: false`
Warn log is shown in cmdout but no exception is thrown 

### Actual behavior

Below Exception is always thrown regardless of `stop_on_invalid_record` value
```bash
org.embulk.exec.PartialExecutionException: org.embulk.spi.time.TimestampParseException: text is null or empty string.
	at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:340)
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:566)
	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:35)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:353)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:350)
	at org.embulk.spi.Exec.doWith(Exec.java:22)
	at org.embulk.exec.BulkLoader.run(BulkLoader.java:350)
	at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:178)
	at org.embulk.EmbulkRunner.runInternal(EmbulkRunner.java:292)
	at org.embulk.EmbulkRunner.run(EmbulkRunner.java:156)
	at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:433)
	at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:90)
	at org.embulk.cli.Main.main(Main.java:64)
Caused by: org.embulk.spi.time.TimestampParseException: text is null or empty string.
	at org.embulk.spi.time.TimestampParserLegacy.parseInternal(TimestampParserLegacy.java:74)
	at org.embulk.spi.time.TimestampParser.parse(TimestampParser.java:229)
	at org.embulk.standards.JsonParserPlugin$1.timestampColumn(JsonParserPlugin.java:280)
	at org.embulk.spi.Column.visit(Column.java:54)
	at org.embulk.standards.JsonParserPlugin.setValueWithCustomSchema(JsonParserPlugin.java:239)
	at org.embulk.standards.JsonParserPlugin.addRecord(JsonParserPlugin.java:197)
	at org.embulk.standards.JsonParserPlugin.run(JsonParserPlugin.java:159)
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:140)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.runInputTask(LocalExecutorPlugin.java:269)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.access$100(LocalExecutorPlugin.java:194)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:233)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:230)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

Error: org.embulk.spi.time.TimestampParseException: text is null or empty string.
```

## Reproduce procedure

* test.yml
```yaml
in:
  type: file
  path_prefix: path/to/sample.json
  parser:
    type: json
    stop_on_invalid_record: false
    columns:
    - {name: name, type: string}
    - {name: created_at, type: timestamp, format: '%Y-%m-%d'}
out:
  type: stdout
```

* sample.json
Second record contains empty timestamp value
```json
{"name": "test1", "created_at": "2019-08-01 02:00:28.718+0000"}
{"name": "test2", "created_at": ""}
{"name": "test3", "created_at": "2019-08-02 02:00:28.718+0000"}
{"name": "test4", "created_at": "2019-08-03 02:00:28.718+0000"}
```

## After the fix

* `stop_on_invalid_record: true`
DataException is thrown
```bash
org.embulk.exec.PartialExecutionException: org.embulk.spi.DataException: Invalid record in /path/to/sample.json: {"created_at":"","name":"test2"}
	at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:340)
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:566)
	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:35)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:353)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:350)
	at org.embulk.spi.Exec.doWith(Exec.java:22)
	at org.embulk.exec.BulkLoader.run(BulkLoader.java:350)
	at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:205)
	at org.embulk.EmbulkRunner.runInternal(EmbulkRunner.java:292)
	at org.embulk.EmbulkRunner.run(EmbulkRunner.java:156)
	at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:433)
	at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:90)
	at org.embulk.cli.Main.main(Main.java:64)
Caused by: org.embulk.spi.DataException: Invalid record in /path/to/sample.json: {"created_at":"","name":"test2"}
	at org.embulk.standards.JsonParserPlugin.run(JsonParserPlugin.java:165)
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:140)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.runInputTask(LocalExecutorPlugin.java:269)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.access$100(LocalExecutorPlugin.java:194)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:233)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:230)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.embulk.standards.JsonParserPlugin$JsonRecordValidateException: A Json record must have valid timestamp value but it's MAP
	at org.embulk.standards.JsonParserPlugin.addRecord(JsonParserPlugin.java:206)
	at org.embulk.standards.JsonParserPlugin.run(JsonParserPlugin.java:160)
	... 9 more

Error: org.embulk.spi.DataException: Invalid record in /path/to/sample.json: {"created_at":"","name":"test2"}
```

* `stop_on_invalid_record: false`
Only warn log is shown and no exception is thrown
```bash
2019-08-08 16:29:40.801 +0900 [WARN] (0014:task-0000): Skipped record in /path/to/sample.json (A Json record must have valid timestamp value but it's MAP): {"created_at":"","name":"test2"}
test1,2019-08-01
test3,2019-08-02
test4,2019-08-03
```