### PR TITLE
Use OpenJDK8 for a CI environment to Travis CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:  # run "travis cache --delete" to delete caches
     - $HOME/.gradle


### PR DESCRIPTION
I got a CI failure on Travis CI
https://travis-ci.org/embulk/embulk/builds/569220317

```bash
Installing oraclejdk8
$ export JAVA_HOME=~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2019-07-17
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
Your build has been stopped.
```

It seems install process is asking us to agree with a license agreement or something.

Why don't you use OpenJDK8 instead of OracleJDK8?
