### PR TITLE
Support new rules for bundled Rename Filter plugin

### DIFF
--- a/embulk-docs/src/built-in.rst
+++ b/embulk-docs/src/built-in.rst
@@ -653,23 +653,27 @@ Renaming rules
 
 The ``rules`` is an array of rules as below applied top-down for all the columns.
 
-+-------------------------+----------------------------------------------------------------------------------------+
-| rule                    | description                                                                            |
-+=========================+========================================================================================+
-| character\_types        | Restrict characters by types. Replace restricted characteres.                          |
-+-------------------------+----------------------------------------------------------------------------------------+
-| first\_character\_types | Restrict the first character by types. Prefix or replace first restricted characters.  |
-+-------------------------+----------------------------------------------------------------------------------------+
-| lower\_to\_upper        | Convert lower-case alphabets to upper-case.                                            |
-+-------------------------+----------------------------------------------------------------------------------------+
-| regex\_replace          | Replace with a regular expressions.                                                    |
-+-------------------------+----------------------------------------------------------------------------------------+
-| truncate                | Truncate.                                                                              |
-+-------------------------+----------------------------------------------------------------------------------------+
-| upper\_to\_lower        | Convert upper-case alphabets to lower-case                                             |
-+-------------------------+----------------------------------------------------------------------------------------+
-| unique\_number\_suffix  | Make column names unique in the schema.                                                |
-+-------------------------+----------------------------------------------------------------------------------------+
++-----------------------------+----------------------------------------------------------------------------------------+
+| rule                        | description                                                                            |
++=============================+========================================================================================+
+| character\_types            | Restrict characters by types. Replace restricted characteres.                          |
++-----------------------------+----------------------------------------------------------------------------------------+
+| first\_character\_types     | Restrict the first character by types. Prefix or replace first restricted characters.  |
++-----------------------------+----------------------------------------------------------------------------------------+
+| lower\_to\_upper            | Convert lower-case alphabets to upper-case.                                            |
++-----------------------------+----------------------------------------------------------------------------------------+
+| regex\_replace              | Replace with a regular expressions.                                                    |
++-----------------------------+----------------------------------------------------------------------------------------+
+| truncate                    | Truncate.                                                                              |
++-----------------------------+----------------------------------------------------------------------------------------+
+| upper\_to\_lower            | Convert upper-case alphabets to lower-case                                             |
++-----------------------------+----------------------------------------------------------------------------------------+
+| upper\_to\_lower_underscore | Convert upper-case alphabets to lower-underscore-case (snake-case)                     |
++-----------------------------+----------------------------------------------------------------------------------------+
+| upper\_to\_lower_hyphen     | Convert upper-case alphabets to lower-hypen-case (kebab-case)                          |
++-----------------------------+----------------------------------------------------------------------------------------+
+| unique\_number\_suffix      | Make column names unique in the schema.                                                |
++-----------------------------+----------------------------------------------------------------------------------------+
 
 Renaming rule: character\_types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -819,6 +823,40 @@ Example
       - type: rename
         rules:
         - rule: upper_to_lower
+
+Renaming rule: upper\_to\_lower\_underscore
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The rule ``upper_to_lower_underscore`` converts upper-case alphabets to lower-underscore-case (as known as snake-case).
+
+Example
+""""""""
+
+.. code-block:: yaml
+
+    # This configuration converts all upper-case alphabets to lower-underscore-case.
+    filters:
+      ...
+      - type: rename
+        rules:
+        - rule: upper_to_lower_underscore
+
+Renaming rule: upper\_to\_lower\_hyphen
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The rule ``upper_to_lower_phyen`` converts upper-case alphabets to lower-hypen-case (as known as kebab-case).
+
+Example
+""""""""
+
+.. code-block:: yaml
+
+    # This configuration converts all upper-case alphabets to lower-hypen-case.
+    filters:
+      ...
+      - type: rename
+        rules:
+        - rule: upper_to_lower_hyphen
 
 Renaming rule: unique\_number\_suffix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/embulk-standards/src/main/java/org/embulk/standards/RenameFilterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/RenameFilterPlugin.java
@@ -180,6 +180,8 @@ public class RenameFilterPlugin implements FilterPlugin {
                 return applyUpperToLowerRule(inputSchema);
             case "upper_to_lower_underscore":
                 return applyUpperToLowerUnderscoreRule(inputSchema);
+            case "upper_to_lower_hyphen":
+                return applyUpperToLowerHyphenRule(inputSchema);
             case "unique_number_suffix":
                 return applyUniqueNumberSuffixRule(inputSchema, ruleConfig.loadConfig(UniqueNumberSuffixRule.class));
             default:
@@ -317,6 +319,14 @@ public class RenameFilterPlugin implements FilterPlugin {
         Schema.Builder builder = Schema.builder();
         for (Column column : inputSchema.getColumns()) {
             builder.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, column.getName()), column.getType());
+        }
+        return builder.build();
+    }
+
+    private Schema applyUpperToLowerHyphenRule(Schema inputSchema) {
+        Schema.Builder builder = Schema.builder();
+        for (Column column : inputSchema.getColumns()) {
+            builder.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, column.getName()), column.getType());
         }
         return builder.build();
     }

--- a/embulk-standards/src/main/java/org/embulk/standards/RenameFilterPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/RenameFilterPlugin.java
@@ -1,5 +1,6 @@
 package org.embulk.standards;
 
+import com.google.common.base.CaseFormat;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -177,6 +178,8 @@ public class RenameFilterPlugin implements FilterPlugin {
                 return applyTruncateRule(inputSchema, ruleConfig.loadConfig(TruncateRule.class));
             case "upper_to_lower":
                 return applyUpperToLowerRule(inputSchema);
+            case "upper_to_lower_underscore":
+                return applyUpperToLowerUnderscoreRule(inputSchema);
             case "unique_number_suffix":
                 return applyUniqueNumberSuffixRule(inputSchema, ruleConfig.loadConfig(UniqueNumberSuffixRule.class));
             default:
@@ -306,6 +309,14 @@ public class RenameFilterPlugin implements FilterPlugin {
         Schema.Builder builder = Schema.builder();
         for (Column column : inputSchema.getColumns()) {
             builder.add(column.getName().toLowerCase(Locale.ENGLISH), column.getType());
+        }
+        return builder.build();
+    }
+
+    private Schema applyUpperToLowerUnderscoreRule(Schema inputSchema) {
+        Schema.Builder builder = Schema.builder();
+        for (Column column : inputSchema.getColumns()) {
+            builder.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, column.getName()), column.getType());
         }
         return builder.build();
     }

--- a/embulk-standards/src/test/java/org/embulk/standards/TestRenameFilterPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestRenameFilterPlugin.java
@@ -208,6 +208,15 @@ public class TestRenameFilterPlugin {
     }
 
     @Test
+    public void checkRuleUpperToLowerHyphenRule() {
+        final String[] original = { "Foo", "fooBarBaz", "_Foo", "__Foo", "-Foo" };
+        final String[] expected = { "foo", "foo-bar-baz", "_-foo", "__-foo", "--foo" };
+        ConfigSource config = Exec.newConfigSource().set("rules",
+                ImmutableList.of(ImmutableMap.of("rule", "upper_to_lower_hyphen")));
+        renameAndCheckSchema(config, original, expected);
+    }
+
+    @Test
     public void checkCharacterTypesRulePassAlphabet() {
         final String[] original = { "Internal$Foo0123--Bar" };
         final String[] expected = { "Internal_Foo______Bar" };

--- a/embulk-standards/src/test/java/org/embulk/standards/TestRenameFilterPlugin.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestRenameFilterPlugin.java
@@ -199,6 +199,15 @@ public class TestRenameFilterPlugin {
     }
 
     @Test
+    public void checkRuleUpperToLowerUnderscoreRule() {
+        final String[] original = { "Foo", "fooBarBaz", "_Foo", "__Foo" };
+        final String[] expected = { "foo", "foo_bar_baz", "__foo", "___foo" };
+        ConfigSource config = Exec.newConfigSource().set("rules",
+                ImmutableList.of(ImmutableMap.of("rule", "upper_to_lower_underscore")));
+        renameAndCheckSchema(config, original, expected);
+    }
+
+    @Test
     public void checkCharacterTypesRulePassAlphabet() {
         final String[] original = { "Internal$Foo0123--Bar" };
         final String[] expected = { "Internal_Foo______Bar" };


### PR DESCRIPTION
This PR is a proposal of new options that introduces 2 new rename rules for bundled Rename Filter plugin.

* `upper_to_lower_underscore` as known as **"snake case"**
  e.g. "UserData" to "user_data"
* `upper_to_lower_hyphen` as known as **"kebab case"**
  e.g. "UserData" to "user-data"

I think both of them are popular formats.
With the current rename rule, we have to set all 1 to 1 convert rule manually. This is the only way but the official document says "not recommended"
https://www.embulk.org/docs/built-in.html#columns-not-recommended

```yaml
filters:
- type: rename
  columns:
    Name: name
    UsersData: user_data
```

### Note

There might be some variations for both formats when the string starts with `_` or `-`.
I used `com.google.common.base.CaseFormat` for both rules and this library adds `_` or `-` even if the string starts with such characters.

* To lower underscore case

| Original string | CaseFormat (guava) | Other valiation (doesn't add new "_") |
----|---- |---- 
| _UserData       | __user_data        | _user_data      |
| __UserData      | ___user_data        | __user_data      |

* To lower hyphen case

| Original string | CaseFormat (guava) | Other valiation (doesn't add new "-") |
----|---- |---- 
| -UserData       | --user-data        | -user-data      |
| --UserData      | ---user_data        | --user_data      |