### PR TITLE
Update the repo for https://www.embulk.org/docs from "www.embulk.org" to "docs"

### DIFF
--- a/embulk-docs/push-gh-pages.sh
+++ b/embulk-docs/push-gh-pages.sh
@@ -31,6 +31,7 @@ re git fetch travis_push
 re git checkout -b gh-pages travis_push/master
 re rm -rf docs
 re cp -a ../embulk-docs/build/html docs
+re touch docs/.nojekyll
 re git add --all docs
 
 re git config user.name "$GIT_USER_NAME"

--- a/embulk-docs/push-gh-pages.sh
+++ b/embulk-docs/push-gh-pages.sh
@@ -16,7 +16,7 @@ function r() {
 [ "$TRAVIS_BRANCH" != "master" -a "$TRAVIS_BRANCH" != "$(git describe --tags --always HEAD)" ] && exit 0
 
 revision="$(git rev-parse HEAD)"
-remote="https://github.com/embulk/www.embulk.org.git"
+remote="https://github.com/embulk/docs.git"
 re ./gradlew site
 
 r git fetch --unshallow || echo "using complete repository."


### PR DESCRIPTION
@shroman Can you have a look?

We had had maintained the entire www.embulk.org website in the repo "www.embulk.org".
But, the repo is now renamed to "docs". This commit is to catch up with the latest status.

https://www.embulk.org/docs/ has been the main website, and it has been updated from
the "embulk-docs" directory of this "embulk" repository.

Later on, we plan to manage the website like:
* https://www.embulk.org/* (except for docs): https://github.com/embulk/embulk.github.io
* https://www.embulk.org/docs/: in https://github.com/embulk/docs