### PR TITLE
hashCode() for classes overriding equals(). fixes #1185

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/time/RubyTimeFormat.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/RubyTimeFormat.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * RubyTimeFormat represents a Ruby-compatible time format.
@@ -33,6 +34,11 @@ class RubyTimeFormat implements Iterable<RubyTimeFormat.TokenWithNext> {
         }
         final RubyTimeFormat other = (RubyTimeFormat) otherObject;
         return this.compiledPattern.equals(other.compiledPattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(compiledPattern);
     }
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/spi/time/RubyTimeFormatToken.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/RubyTimeFormatToken.java
@@ -1,5 +1,7 @@
 package org.embulk.spi.time;
 
+import java.util.Objects;
+
 /**
  * RubyTimeFormatToken represents a token in Ruby-compatible time format strings.
  *
@@ -23,6 +25,11 @@ abstract class RubyTimeFormatToken {
             }
             final Directive other = (Directive) otherObject;
             return this.formatDirective.equals(other.formatDirective);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(formatDirective);
         }
 
         @Override
@@ -58,6 +65,11 @@ abstract class RubyTimeFormatToken {
             }
             final Immediate other = (Immediate) otherObject;
             return this.string.equals(other.string);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(string);
         }
 
         @Override

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
+import java.util.Objects;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigException;
@@ -29,8 +30,6 @@ import org.embulk.spi.util.LineDecoder;
 import org.embulk.spi.util.Timestamps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Objects;
 
 public class CsvParserPlugin implements ParserPlugin {
     private static final ImmutableSet<String> TRUE_STRINGS =

--- a/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java
@@ -30,6 +30,8 @@ import org.embulk.spi.util.Timestamps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 public class CsvParserPlugin implements ParserPlugin {
     private static final ImmutableSet<String> TRUE_STRINGS =
             ImmutableSet.of(
@@ -158,6 +160,11 @@ public class CsvParserPlugin implements ParserPlugin {
             QuoteCharacter o = (QuoteCharacter) obj;
             return character == o.character;
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(character);
+        }
     }
 
     public static class EscapeCharacter {
@@ -201,6 +208,11 @@ public class CsvParserPlugin implements ParserPlugin {
             }
             EscapeCharacter o = (EscapeCharacter) obj;
             return character == o.character;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(character);
         }
     }
 


### PR DESCRIPTION
adding missing hashCode() for classes overriding equals().