### PR TITLE
Create a TempFileSpace with ISO 8601's basic format

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -1,6 +1,9 @@
 package org.embulk.spi;
 
 import com.google.inject.Injector;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -19,6 +22,9 @@ import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 
 public class ExecSession {
+    private static final DateTimeFormatter ISO8601_BASIC =
+            DateTimeFormatter.ofPattern("uuuuMMdd'T'HHmmss'Z'", Locale.ENGLISH).withZone(ZoneOffset.UTC);
+
     private final Injector injector;
 
     // TODO: Remove it.
@@ -97,7 +103,7 @@ public class ExecSession {
         this.transactionTime = transactionTime;
 
         final TempFileSpaceAllocator tempFileSpaceAllocator = injector.getInstance(TempFileSpaceAllocator.class);
-        this.tempFileSpace = tempFileSpaceAllocator.newSpace(transactionTime.toString());
+        this.tempFileSpace = tempFileSpaceAllocator.newSpace(ISO8601_BASIC.format(transactionTime.getInstant()));
 
         this.preview = false;
     }

--- a/embulk-core/src/test/java/org/embulk/exec/TestSimpleTempFileSpaceAllocator.java
+++ b/embulk-core/src/test/java/org/embulk/exec/TestSimpleTempFileSpaceAllocator.java
@@ -1,0 +1,43 @@
+package org.embulk.exec;
+
+import org.embulk.spi.TempFileSpaceAllocator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestSimpleTempFileSpaceAllocator {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setJavaTmpDir() {
+        this.systemPropertyTmpDir = System.getProperty("java.io.tmpdir");
+        System.setProperty("java.io.tmpdir", temporaryFolder.getRoot().getAbsolutePath());
+    }
+
+    @After
+    public void resetJavaTmpDir() {
+        if (this.systemPropertyTmpDir == null) {
+            System.clearProperty("java.io.tmpdir");
+        } else {
+            System.setProperty("java.io.tmpdir", this.systemPropertyTmpDir);
+        }
+    }
+
+    @Test
+    public void testNewSpaceWithIso8601Basic() {
+        final TempFileSpaceAllocator allocator = new SimpleTempFileSpaceAllocator();
+        allocator.newSpace("20191031T123456Z");
+    }
+
+    @Test
+    public void testNewSpaceWithNonIso8601Basic() {
+        // TODO: Make it fail from the v0.10 series.
+        final TempFileSpaceAllocator allocator = new SimpleTempFileSpaceAllocator();
+        allocator.newSpace("2019-10-31 12:34:56 UTC");
+    }
+
+    private String systemPropertyTmpDir;
+}


### PR DESCRIPTION
`TempFileSpace`'s directory names have been like `"2019-05-15 11:35:48.617 UTC"`,
but whitespaces and colons could make everything weird.

This change makes it in ISO 8601's basic format, such as `"20190515T113548Z"`.