### PR TITLE
Guarantee TempFileSpace to be unique

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/SimpleTempFileSpaceAllocator.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SimpleTempFileSpaceAllocator.java
@@ -1,29 +1,48 @@
 package org.embulk.exec;
 
-import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.embulk.spi.TempFileSpace;
 import org.embulk.spi.TempFileSpaceAllocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class SimpleTempFileSpaceAllocator implements TempFileSpaceAllocator {
     SimpleTempFileSpaceAllocator() {
         // It is originally intended to use `temp_dirs` in system config, but the reasons are missing.
         // https://github.com/embulk/embulk/commit/a7643573ecb39e6dd71a08edce77c8e64dc70a77
-        final String systemPropertyTmpDir = System.getProperty("java.io.tmpdir", DEFAULT_TEMP_DIR);
-        this.dir = new File(systemPropertyTmpDir.isEmpty() ? DEFAULT_TEMP_DIR : systemPropertyTmpDir, "embulk");
+
+        final String systemPropertyTmpDir = System.getProperty("java.io.tmpdir");
+        if (systemPropertyTmpDir == null || systemPropertyTmpDir.isEmpty()) {
+            // TODO: Error when java.io.tmpdir is not set?
+            logger.warn("Property java.io.tmpdir should be set properly.");
+            this.tempDirectoryBase = Paths.get(DEFAULT_TEMP_DIR);
+        } else {
+            this.tempDirectoryBase = Paths.get(systemPropertyTmpDir);
+        }
     }
 
     @Override
-    public TempFileSpace newSpace(final String subdirectoryName) {
+    public TempFileSpace newSpace(final String subdirectoryPrefix) {
         // It is originally intended to support multiple files/directories, but the reasons are missing.
         // https://github.com/embulk/embulk/commit/a7643573ecb39e6dd71a08edce77c8e64dc70a77
         // https://github.com/embulk/embulk/commit/5a78270a4fc20e3c113c68e4c0f6c66c1bd45886
 
         // UNIX/Linux cannot include '/' as file name.
         // Windows cannot include ':' as file name.
-        return new TempFileSpace(new File(this.dir, subdirectoryName.replace('/', '-').replace(':', '-')));
+        try {
+            return TempFileSpace.with(
+                    this.tempDirectoryBase, "embulk" + subdirectoryPrefix.replace('/', '-').replace(':', '-'));
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
     private static final String DEFAULT_TEMP_DIR = "/tmp";
 
-    private final File dir;
+    private static final Logger logger = LoggerFactory.getLogger(SimpleTempFileSpaceAllocator.class);
+
+    private final Path tempDirectoryBase;
 }

--- a/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
@@ -7,58 +7,131 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Responsible to manage a temporary directory (a space for temporary files) for a task.
+ *
+ * <p>Plugins are expected to get this through {@link Exec#getTempFileSpace}. Do not create an instance of this directly.
+ */
 public class TempFileSpace {
-    public TempFileSpace(final File dir) {
-        if (dir == null) {
-            throw new IllegalArgumentException("dir is null");
+    private TempFileSpace(final boolean isUnique, final Path baseDir, final String prefix, final File exactDir) {
+        this.isUnique = isUnique;
+        if (isUnique) {
+            this.baseDir = baseDir;
+            this.prefix = prefix;
+            this.exactDir = null;
+        } else {  // Backward-compatible behavior for `new TempFileSpace(File)`. To be removed.
+            if (exactDir == null) {
+                throw new IllegalArgumentException("dir is null");
+            }
+            this.baseDir = null;
+            this.prefix = null;
+            this.exactDir = exactDir;
         }
-        this.dir = dir;
+
+        this.tempDirectoryCreated = Optional.empty();
     }
 
+    /**
+     * Creates an instance of {@link TempFileSpace}.
+     *
+     * <p>It creates {@link TempFileSpace} exactly at the specified {@link java.io.File}.
+     *
+     * <p>Note that the corresponding directory is created lazily when the first temporary file is created there.
+     *
+     * @deprecated It has been deprecated because it may use the same directory from different processes and/or tasks.
+     * Use {@link #with(java.nio.file.Path, java.lang.String)} instead. It is to be removed.
+     */
+    @Deprecated
+    public TempFileSpace(final File dir) {
+        this(false, null, null, dir);
+    }
+
+    /**
+     * Creates an instance of {@link TempFileSpace}.
+     *
+     * <p>Note that the corresponding directory is created lazily when the first temporary file is created there.
+     *
+     * <p>It creates {@link TempFileSpace} under the specified {@code baseDir} with the {@code prefix}.
+     */
+    public static TempFileSpace with(final Path baseDir, final String prefix) throws IOException {
+        if (baseDir == null || prefix == null) {
+            throw new IllegalArgumentException("TempFileSpace is created with null.");
+        }
+        if (!baseDir.isAbsolute()) {
+            throw new IllegalArgumentException("TempFileSpace is created under a relative path.");
+        }
+        if (!Files.isDirectory(baseDir)) {  // Following symlinks -- no LinkOption.NOFOLLOW_LINKS.
+            throw new IOException("TempFileSpace is created under non-directory.");
+        }
+
+        return new TempFileSpace(true, baseDir, prefix, null);
+    }
+
+    /**
+     * Creates a temporary file with the default file name prefix, and the default file extension suffix.
+     *
+     * @return A temporary {@link java.io.File} created
+     */
     public File createTempFile() {
         return this.createTempFile("tmp");
     }
 
+    /**
+     * Creates a temporary file with the default file name prefix, and the specified file extension suffix.
+     *
+     * @param fileExt  The file extension suffix without a leading dot ({@code '.'})
+     * @return A temporary {@link java.io.File} created
+     */
     public File createTempFile(final String fileExt) {
         // Thread names contain ':' which is not valid as file names in Windows.
         return this.createTempFile(Thread.currentThread().getName().replaceAll(":", "_") + "_", fileExt);
     }
 
+    /**
+     * Creates a temporary file with the specified file name prefix, and the specified file extension suffix.
+     *
+     * @param prefix  The file name prefix
+     * @param fileExt  The file extension suffix without a leading dot ({@code '.'})
+     * @return A temporary {@link java.io.File} created
+     */
     public synchronized File createTempFile(final String prefix, final String fileExt) {
         try {
-            if (!this.dirCreated) {
-                this.dir.mkdirs();
-                this.dirCreated = true;
-            }
-            return File.createTempFile(prefix, "." + fileExt, this.dir);
+            this.createTempDirectoryIfRequired();
+
+            final Path tempFile = Files.createTempFile(this.tempDirectoryCreated.get(), prefix, "." + fileExt);
+            logger.debug("TempFile \"{}\" is created.", tempFile);
+            return tempFile.toFile();
         } catch (final IOException ex) {
             throw new TempFileException(ex);
         }
     }
 
+    /**
+     * Cleans up the temporary file space, and everything in the space.
+     *
+     * <p>It is to be called along with Embulk's cleanup process. Plugins should not call this directly.
+     */
     public synchronized void cleanup() {
-        if (this.dirCreated && logger.isDebugEnabled()) {
-            final StringBuilder builder = new StringBuilder();
-            builder.append("TempFileSpace \"").append(this.dir.toString()).append("\" is cleaned up at :");
-            for (final StackTraceElement stack : (new Throwable()).getStackTrace()) {
-                builder.append("\n  > ").append(stack.toString());
-            }
-            logger.debug(builder.toString());
+        if (this.tempDirectoryCreated.isPresent()) {
+            logDebugWithStackTraces("TempFileSpace \"" + this.tempDirectoryCreated.get().toString() + "\" is cleaned up at");
         }
 
         try {
-            this.deleteFilesIfExistsRecursively(this.dir);
+            if (this.tempDirectoryCreated.isPresent()) {
+                this.deleteFilesIfExistsRecursively(this.tempDirectoryCreated.get());
+            }
         } catch (final IOException ex) {
             // ignore IOException
         }
-        this.dirCreated = false;
+        this.tempDirectoryCreated = Optional.empty();
     }
 
-    private void deleteFilesIfExistsRecursively(final File dirToDelete) throws IOException {
-        Files.walkFileTree(dirToDelete.toPath(), new SimpleFileVisitor<Path>() {
+    private void deleteFilesIfExistsRecursively(final Path dirToDelete) throws IOException {
+        Files.walkFileTree(dirToDelete, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(final Path fileOnVisit, final BasicFileAttributes attrs) {
                     try {
@@ -81,8 +154,57 @@ public class TempFileSpace {
             });
     }
 
+    private void createTempDirectoryIfRequired() throws IOException {
+        if (this.tempDirectoryCreated.isPresent()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("TempFileSpace \"{}\" is already there.", this.tempDirectoryCreated.get());
+            }
+            return;
+        }
+
+        if (this.baseDir != null) {
+            this.tempDirectoryCreated = Optional.of(Files.createTempDirectory(this.baseDir, this.prefix));
+        } else if (this.exactDir != null) {
+            this.exactDir.mkdirs();
+            this.tempDirectoryCreated = Optional.of(this.exactDir.toPath());
+        }
+    }
+
+    private static void logDebugWithStackTraces(final String message) {
+        if (logger.isDebugEnabled()) {
+            final StringBuilder builder = new StringBuilder();
+            builder.append(message).append(" :");
+            for (final StackTraceElement stack : (new Throwable()).getStackTrace()) {
+                builder.append("\n  > ").append(stack.toString());
+            }
+            logger.debug(builder.toString());
+        }
+    }
+
     private static final Logger logger = LoggerFactory.getLogger(TempFileSpace.class);
 
-    private final File dir;
-    private boolean dirCreated;
+    // true if it is created through TempFileSpace.with.
+    //
+    // TODO: Remove it once the constructor TempFileSpace(File) goes away.
+    private final boolean isUnique;
+
+    // The base directory to create a temporary directory under this.
+    //
+    // Available only when created through TempFileSpace.with.
+    private final Path baseDir;
+
+    // The prefix when creating a temporary directory under |baseDir|.
+    //
+    // Available only when created through TempFileSpace.with.
+    private final String prefix;
+
+    // The exact directory specified through the constructor TempFileSpace(File).
+    //
+    // Available only when created through the constructor TempFileSpace(File).
+    //
+    // TODO: Remove it once the constructor TempFileSpace(File) goes away.
+    private final File exactDir;
+
+    // The temporary directory created when creating the first temporary file.
+    private Optional<Path> tempDirectoryCreated;
 }

--- a/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
@@ -56,16 +56,19 @@ public class TempFileSpace {
      * <p>Note that the corresponding directory is created lazily when the first temporary file is created there.
      *
      * <p>It creates {@link TempFileSpace} under the specified {@code baseDir} with the {@code prefix}.
+     *
+     * @param baseDir  the base directory to create a temporary directory, which must be an absolute {@link java.nio.file.Path}
+     * @param prefix  the prefix of the temporary directory to be created
      */
     public static TempFileSpace with(final Path baseDir, final String prefix) throws IOException {
         if (baseDir == null || prefix == null) {
-            throw new IllegalArgumentException("TempFileSpace is created with null.");
+            throw new IllegalArgumentException("TempFileSpace cannot be created with null.");
         }
         if (!baseDir.isAbsolute()) {
-            throw new IllegalArgumentException("TempFileSpace is created under a relative path.");
+            throw new IllegalArgumentException("TempFileSpace cannot be created under a relative path.");
         }
         if (!Files.isDirectory(baseDir)) {  // Following symlinks -- no LinkOption.NOFOLLOW_LINKS.
-            throw new IOException("TempFileSpace is created under non-directory.");
+            throw new IOException("TempFileSpace cannot be created under non-directory.");
         }
 
         return new TempFileSpace(true, baseDir, prefix, null);

--- a/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
@@ -130,6 +130,10 @@ public class TempFileSpace {
         this.tempDirectoryCreated = Optional.empty();
     }
 
+    Optional<Path> getTempDirectoryForTesting() {
+        return this.tempDirectoryCreated;
+    }
+
     private void deleteFilesIfExistsRecursively(final Path dirToDelete) throws IOException {
         Files.walkFileTree(dirToDelete, new SimpleFileVisitor<Path>() {
                 @Override

--- a/embulk-core/src/test/java/org/embulk/spi/TestTempFileSpace.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestTempFileSpace.java
@@ -1,0 +1,124 @@
+package org.embulk.spi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestTempFileSpace {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullBaseDir() throws IOException {
+        TempFileSpace.with(null, "embulk20191030T000000Z");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullPrefix() throws IOException {
+        TempFileSpace.with(temporaryFolder.getRoot().toPath(), null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRelativePath() throws IOException {
+        final Path path = temporaryFolder.getRoot().toPath();
+        TempFileSpace.with(path.subpath(path.getNameCount() - 1, path.getNameCount()), "embulk20191030T000001Z");
+    }
+
+    @Test(expected = IOException.class)
+    public void testNonexistent() throws IOException {
+        TempFileSpace.with(temporaryFolder.getRoot().toPath().resolve("somenonexistentdir"), "embulk20191030T000002Z");
+    }
+
+    @Test
+    public void testCreateTempFile() {
+        final String prefix = "embulk20191030T000003Z";
+
+        final TempFileSpace space = create(prefix);
+        // The temporary directory should not have been created before the first createTempFile().
+        assertFalse(space.getTempDirectoryForTesting().isPresent());
+        assertEquals(0, entriesPrefixedWith(prefix));
+
+        final File tempFile = space.createTempFile();
+        System.out.println(tempFile.getAbsolutePath());
+        assertTrue(space.getTempDirectoryForTesting().isPresent());
+        assertEquals(1, entriesPrefixedWith(prefix));
+        assertTrue(tempFile.exists());
+        assertTrue(tempFile.getName().endsWith(".tmp"));
+
+        space.cleanup();
+        assertFalse(space.getTempDirectoryForTesting().isPresent());
+        assertEquals(0, entriesPrefixedWith(prefix));
+        assertFalse(tempFile.exists());
+    }
+
+    @Test
+    public void testCreateTempFileWithExt() {
+        final String prefix = "embulk20191030T000004Z";
+
+        final TempFileSpace space = create(prefix);
+        // The temporary directory should not have been created before the first createTempFile().
+        assertFalse(space.getTempDirectoryForTesting().isPresent());
+        assertEquals(0, entriesPrefixedWith(prefix));
+
+        final File tempFile = space.createTempFile("myext");
+        System.out.println(tempFile.getAbsolutePath());
+        assertTrue(space.getTempDirectoryForTesting().isPresent());
+        assertEquals(1, entriesPrefixedWith(prefix));
+        assertTrue(tempFile.exists());
+        assertTrue(tempFile.getName().endsWith(".myext"));
+
+        space.cleanup();
+        assertFalse(space.getTempDirectoryForTesting().isPresent());
+        assertEquals(0, entriesPrefixedWith(prefix));
+        assertFalse(tempFile.exists());
+    }
+
+    @Test
+    public void testCreateTempFileWithPrefixAndExt() {
+        final String prefix = "embulk20191030T000005Z";
+
+        final TempFileSpace space = create(prefix);
+        // The temporary directory should not have been created before the first createTempFile().
+        assertFalse(space.getTempDirectoryForTesting().isPresent());
+        assertEquals(0, entriesPrefixedWith(prefix));
+
+        final File tempFile = space.createTempFile("filenameprefix", "myext");
+        System.out.println(tempFile.getAbsolutePath());
+        assertTrue(space.getTempDirectoryForTesting().isPresent());
+        assertEquals(1, entriesPrefixedWith(prefix));
+        assertTrue(tempFile.exists());
+        assertTrue(tempFile.getName().startsWith("filenameprefix"));
+        assertTrue(tempFile.getName().endsWith(".myext"));
+
+        space.cleanup();
+        assertFalse(space.getTempDirectoryForTesting().isPresent());
+        assertEquals(0, entriesPrefixedWith(prefix));
+        assertFalse(tempFile.exists());
+    }
+
+    private long entriesPrefixedWith(final String prefix) {
+        try (final Stream<Path> stream = Files.list(temporaryFolder.getRoot().toPath())) {
+            return stream.filter(entry -> entry.getFileName().toString().startsWith(prefix)).count();
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    private TempFileSpace create(final String prefix) {
+        try {
+            return TempFileSpace.with(temporaryFolder.getRoot().toPath(), prefix);
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+}


### PR DESCRIPTION
A `TempFileSpace` has been created in a directory with a timestamp, such as `"/tmp/2019-05-15 11:35:48.617 UTC"`.
But, when multiple Embulk processes (or tasks) are running, they can easily conflict.

To avoid such conflicts, this change starts to use `Files#createTempDirectory` to create a `TempFileSpace`.
Java VM guarantees that the directory created is unique.

https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#createTempDirectory-java.nio.file.Path-java.lang.String-java.nio.file.attribute.FileAttribute...-

The old constructor `TempFileSpace(File)` keeps the original behavior for compatibility,
but it is now deprecated. It should not be called from plugins, though.