### PR TITLE
Warn if TempFileSpaceAllocator#newSpace is called with non-ISO 8601 basic format

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/SimpleTempFileSpaceAllocator.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SimpleTempFileSpaceAllocator.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.regex.Pattern;
 import org.embulk.spi.TempFileSpace;
 import org.embulk.spi.TempFileSpaceAllocator;
 import org.slf4j.Logger;
@@ -26,6 +27,11 @@ class SimpleTempFileSpaceAllocator implements TempFileSpaceAllocator {
 
     @Override
     public TempFileSpace newSpace(final String subdirectoryPrefix) {
+        // TODO: Accept only ISO 8601-style timestamp in the v0.10 series.
+        if (!ISO8601_BASIC_PATTERN.matcher(subdirectoryPrefix).matches()) {
+            logger.warn("TempFileSpaceAllocator#newSpace should be called with ISO 8601 basic format: {}", subdirectoryPrefix);
+        }
+
         // It is originally intended to support multiple files/directories, but the reasons are missing.
         // https://github.com/embulk/embulk/commit/a7643573ecb39e6dd71a08edce77c8e64dc70a77
         // https://github.com/embulk/embulk/commit/5a78270a4fc20e3c113c68e4c0f6c66c1bd45886
@@ -41,6 +47,8 @@ class SimpleTempFileSpaceAllocator implements TempFileSpaceAllocator {
     }
 
     private static final String DEFAULT_TEMP_DIR = "/tmp";
+
+    private static final Pattern ISO8601_BASIC_PATTERN = Pattern.compile("^\\d\\d\\d\\d\\d\\d\\d\\dT\\d\\d\\d\\d\\d\\dZ$");
 
     private static final Logger logger = LoggerFactory.getLogger(SimpleTempFileSpaceAllocator.class);
 


### PR DESCRIPTION
From the discussion in #1189, adding a warning message for non-ISO 8601 format.