### PR TITLE
Build with GitHub Actions to upload onto GitHub Package Registry every build

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,16 @@
+name: Upload Embulk's core packages to GitHub Package Registry
+on: [ push ]
+jobs:
+  embulk:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build and upload to GitHub Package Registry
+      run: ./gradlew publishMavenPublicationToGithubRepository
+      env:
+        ORG_GRADLE_PROJECT_github_package_user: ${{ secrets.GITHUB_PACKAGE_USER }}
+        ORG_GRADLE_PROJECT_github_package_token: ${{ secrets.GITHUB_PACKAGE_TOKEN }}


### PR DESCRIPTION
WIth the GitHub Action, artifacts are uploaded to GitHub Package Registery every build. 

For this Pull Request at `2d44f83bf15952360013b6d2d1d445201a835c00`,

Action :
* https://github.com/embulk/embulk/commit/2d44f83bf15952360013b6d2d1d445201a835c00/checks

Artifacts :
* https://github.com/embulk/embulk/packages/54702?version=0.9.21-SNAPSHOT-2d44f83bf15952360013b6d2d1d445201a835c00
* https://github.com/embulk/embulk/packages/54714?version=0.9.21-SNAPSHOT-2d44f83bf15952360013b6d2d1d445201a835c00
* https://github.com/embulk/embulk/packages/54715?version=0.9.21-SNAPSHOT-2d44f83bf15952360013b6d2d1d445201a835c00
* https://github.com/embulk/embulk/packages/54716?version=0.9.21-SNAPSHOT-2d44f83bf15952360013b6d2d1d445201a835c00
* https://github.com/embulk/embulk/packages/54717?version=0.9.21-SNAPSHOT-2d44f83bf15952360013b6d2d1d445201a835c00