### PR TITLE
Refactor dependency class loaders to be extensible easier

### DIFF
--- a/embulk-core/src/main/java/org/embulk/deps/DependencyCategory.java
+++ b/embulk-core/src/main/java/org/embulk/deps/DependencyCategory.java
@@ -1,0 +1,23 @@
+package org.embulk.deps;
+
+public enum DependencyCategory {
+    CLI("CLI", EmbulkSelfContainedJarFiles.Type.CLI),
+    MAVEN("Maven", EmbulkSelfContainedJarFiles.Type.MAVEN),
+    ;
+
+    private DependencyCategory(final String name, final EmbulkSelfContainedJarFiles.Type selfContainType) {
+        this.name = name;
+        this.selfContainType = selfContainType;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public EmbulkSelfContainedJarFiles.Type getSelfContainType() {
+        return this.selfContainType;
+    }
+
+    private final String name;
+    private final EmbulkSelfContainedJarFiles.Type selfContainType;
+}

--- a/embulk-core/src/main/java/org/embulk/deps/DependencyCategory.java
+++ b/embulk-core/src/main/java/org/embulk/deps/DependencyCategory.java
@@ -1,23 +1,23 @@
 package org.embulk.deps;
 
 public enum DependencyCategory {
-    CLI("CLI", EmbulkSelfContainedJarFiles.Type.CLI),
-    MAVEN("Maven", EmbulkSelfContainedJarFiles.Type.MAVEN),
+    CLI("CLI", "Embulk-Resource-Class-Path-Cli"),
+    MAVEN("Maven", "Embulk-Resource-Class-Path-Maven"),
     ;
 
-    private DependencyCategory(final String name, final EmbulkSelfContainedJarFiles.Type selfContainType) {
+    private DependencyCategory(final String name, final String manifestAttributeName) {
         this.name = name;
-        this.selfContainType = selfContainType;
+        this.manifestAttributeName = manifestAttributeName;
     }
 
     public String getName() {
         return this.name;
     }
 
-    public EmbulkSelfContainedJarFiles.Type getSelfContainType() {
-        return this.selfContainType;
+    public String getManifestAttributeName() {
+        return this.manifestAttributeName;
     }
 
     private final String name;
-    private final EmbulkSelfContainedJarFiles.Type selfContainType;
+    private final String manifestAttributeName;
 }

--- a/embulk-core/src/main/java/org/embulk/deps/DependencyClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/deps/DependencyClassLoader.java
@@ -31,10 +31,10 @@ final class DependencyClassLoader extends URLClassLoader {
     DependencyClassLoader(
             final Collection<Path> jarPaths,
             final ClassLoader parent,
-            final EmbulkSelfContainedJarFiles.Type selfContainedJarFilesType) {
+            final DependencyCategory category) {
         // The delegation parent ClassLoader is processed by the super class URLClassLoader.
         super(toUrls(jarPaths), parent);
-        this.selfContainedJarFilesType = selfContainedJarFilesType;
+        this.category = category;
         this.accessControlContext = AccessController.getContext();
     }
 
@@ -130,7 +130,7 @@ final class DependencyClassLoader extends URLClassLoader {
         }
 
         // TODO: Consider duplicated resources.
-        final Resource resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName, this.selfContainedJarFilesType);
+        final Resource resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName, this.category);
         if (resource == null) {
             return null;
         }
@@ -161,7 +161,7 @@ final class DependencyClassLoader extends URLClassLoader {
 
         // Even if some resources are found from the delegation parent class loader, it looks into self-contained JAR files.
         final Collection<Resource> resources =
-                EmbulkSelfContainedJarFiles.getMultipleResources(resourceName, this.selfContainedJarFilesType);
+                EmbulkSelfContainedJarFiles.getMultipleResources(resourceName, this.category);
 
         final Vector<URL> resourceUrls = new Vector<URL>();
         while (resourceUrlsFromSuper.hasMoreElements()) {
@@ -194,7 +194,7 @@ final class DependencyClassLoader extends URLClassLoader {
         final String resourceName = className.replace('.', '/').concat(".class");
 
         // Class must be singular.
-        final Resource resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName, this.selfContainedJarFilesType);
+        final Resource resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName, this.category);
         if (resource == null) {
             throw new ClassNotFoundException(className);
         }
@@ -299,6 +299,6 @@ final class DependencyClassLoader extends URLClassLoader {
         return jarUrls;
     }
 
-    private final EmbulkSelfContainedJarFiles.Type selfContainedJarFilesType;
+    private final DependencyCategory category;
     private final AccessControlContext accessControlContext;
 }

--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
@@ -111,8 +111,8 @@ public final class EmbulkDependencyClassLoaders {
                         DEPENDENCIES.get(category),
                         CLASS_LOADER,
                         USE_SELF_CONTAINED_JAR_FILES.get()
-                                ? category.getSelfContainType()
-                                : EmbulkSelfContainedJarFiles.Type.NONE));
+                                ? category
+                                : null));
             }
             DEPENDENCY_CLASS_LOADERS = Collections.unmodifiableMap(classLoaders);
         }

--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
@@ -4,13 +4,14 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Represents a set of class loaders to load dependency libraries for the Embulk core.
+ * Represents a pre-defined set of class loaders to load dependency libraries for the Embulk core.
  *
  * <p>It is intentionally designed to be a singleton. {@link DependencyClassLoader} is introduced only for dependency
  * visibility, not for customizability. It should not be customizable so flexibly.
@@ -23,8 +24,10 @@ public final class EmbulkDependencyClassLoaders {
     public static final class StaticInitializer {
         private StaticInitializer() {
             this.useSelfContainedJarFiles = false;
-            this.mavenDependencies = new ArrayList<>();
-            this.cliDependencies = new ArrayList<>();
+            this.dependencies = new EnumMap<>(DependencyCategory.class);
+            for (final DependencyCategory category : DependencyCategory.values()) {
+                this.dependencies.put(category, new ArrayList<>());
+            }
         }
 
         public StaticInitializer useSelfContainedJarFiles() {
@@ -32,78 +35,86 @@ public final class EmbulkDependencyClassLoaders {
             return this;
         }
 
+        public StaticInitializer addDependency(final DependencyCategory category, final Path path) {
+            this.dependencies.get(category).add(path);
+            return this;
+        }
+
+        public StaticInitializer addDependencies(final DependencyCategory category, final Collection<Path> paths) {
+            this.dependencies.get(category).addAll(paths);
+            return this;
+        }
+
+        @Deprecated
         public StaticInitializer addMavenDependency(final Path path) {
-            this.mavenDependencies.add(path);
-            return this;
+            return this.addDependency(DependencyCategory.MAVEN, path);
         }
 
+        @Deprecated
         public StaticInitializer addMavenDependencies(final Collection<Path> paths) {
-            this.mavenDependencies.addAll(paths);
-            return this;
+            return this.addDependencies(DependencyCategory.MAVEN, paths);
         }
 
+        @Deprecated
         public StaticInitializer addCliDependency(final Path path) {
-            this.cliDependencies.add(path);
-            return this;
+            return this.addDependency(DependencyCategory.CLI, path);
         }
 
+        @Deprecated
         public StaticInitializer addCliDependencies(final Collection<Path> paths) {
-            this.cliDependencies.addAll(paths);
-            return this;
+            return this.addDependencies(DependencyCategory.CLI, paths);
         }
 
         public void initialize() {
             initializeUseSelfContainedJarFiles(this.useSelfContainedJarFiles);
-            initializeMaven(Collections.unmodifiableList(this.mavenDependencies));
-            initializeCli(Collections.unmodifiableList(this.cliDependencies));
+            initializeDependencies(this.dependencies);
         }
 
         private boolean useSelfContainedJarFiles;
-        private final ArrayList<Path> mavenDependencies;
-        private final ArrayList<Path> cliDependencies;
+        private final EnumMap<DependencyCategory, ArrayList<Path>> dependencies;
     }
 
     public static StaticInitializer staticInitializer() {
         return new StaticInitializer();
     }
 
-    public static ClassLoader ofMaven() {
-        return MavenHolder.MAVEN_DEPENDENCY_CLASS_LOADER;
-    }
-
-    public static ClassLoader ofCli() {
-        return CliHolder.CLI_DEPENDENCY_CLASS_LOADER;
-    }
-
-    private static class MavenHolder {  // Initialization-on-demand holder
-        public static final DependencyClassLoader MAVEN_DEPENDENCY_CLASS_LOADER;
-
-        static {
-            if (MAVEN_DEPENDENCIES.isEmpty() && !USE_SELF_CONTAINED_JAR_FILES.get()) {
-                logger.warn(messageUninitialized("Maven"));
-            }
-            MAVEN_DEPENDENCY_CLASS_LOADER = new DependencyClassLoader(
-                    MAVEN_DEPENDENCIES,
-                    CLASS_LOADER,
-                    USE_SELF_CONTAINED_JAR_FILES.get()
-                            ? EmbulkSelfContainedJarFiles.Type.MAVEN
-                            : EmbulkSelfContainedJarFiles.Type.NONE);
+    public static ClassLoader of(final DependencyCategory category) {
+        if (category == null) {
+            throw new LinkageError("No appropriate DependencyClassLoader for null.");
         }
+        return Holder.DEPENDENCY_CLASS_LOADERS.get(category);
     }
 
-    private static class CliHolder {  // Initialization-on-demand holder
-        public static final DependencyClassLoader CLI_DEPENDENCY_CLASS_LOADER;
+    @Deprecated
+    public static ClassLoader ofMaven() {
+        return of(DependencyCategory.MAVEN);
+    }
+
+    @Deprecated
+    public static ClassLoader ofCli() {
+        return of(DependencyCategory.CLI);
+    }
+
+    private static class Holder {  // Initialization-on-demand holder
+        public static final Map<DependencyCategory, DependencyClassLoader> DEPENDENCY_CLASS_LOADERS;
 
         static {
-            if (CLI_DEPENDENCIES.isEmpty() && !USE_SELF_CONTAINED_JAR_FILES.get()) {
-                logger.warn(messageUninitialized("CLI"));
+            final EnumMap<DependencyCategory, DependencyClassLoader> classLoaders = new EnumMap<>(DependencyCategory.class);
+            for (final DependencyCategory category : DependencyCategory.values()) {
+                if (DEPENDENCIES.get(category).isEmpty() && !USE_SELF_CONTAINED_JAR_FILES.get()) {
+                    logger.warn(
+                            "Dependencies for {} are uninitialized. Expected to use classes loaded by the parent ClassLoader.",
+                            category.getName());
+                }
+
+                classLoaders.put(category, new DependencyClassLoader(
+                        DEPENDENCIES.get(category),
+                        CLASS_LOADER,
+                        USE_SELF_CONTAINED_JAR_FILES.get()
+                                ? category.getSelfContainType()
+                                : EmbulkSelfContainedJarFiles.Type.NONE));
             }
-            CLI_DEPENDENCY_CLASS_LOADER = new DependencyClassLoader(
-                    CLI_DEPENDENCIES,
-                    CLASS_LOADER,
-                    USE_SELF_CONTAINED_JAR_FILES.get()
-                            ? EmbulkSelfContainedJarFiles.Type.CLI
-                            : EmbulkSelfContainedJarFiles.Type.NONE);
+            DEPENDENCY_CLASS_LOADERS = Collections.unmodifiableMap(classLoaders);
         }
     }
 
@@ -111,37 +122,32 @@ public final class EmbulkDependencyClassLoaders {
         USE_SELF_CONTAINED_JAR_FILES.set(useSelfContainedJarFile);
     }
 
-    private static void initializeMaven(final List<Path> mavenDependencies) {
-        synchronized (MAVEN_DEPENDENCIES) {
-            if (MAVEN_DEPENDENCIES.isEmpty()) {
-                MAVEN_DEPENDENCIES.addAll(mavenDependencies);
-            } else {
-                throw new LinkageError("Double initialization of dependencies for Maven.");
+    private static void initializeDependencies(final EnumMap<DependencyCategory, ArrayList<Path>> dependencies) {
+        synchronized (DEPENDENCIES) {
+            for (final DependencyCategory category : DependencyCategory.values()) {
+                if (dependencies.containsKey(category)) {
+                    if (dependencies.get(category).isEmpty()) {
+                        DEPENDENCIES.get(category).addAll(dependencies.get(category));
+                    } else {
+                        throw new LinkageError("Double initialization of dependencies for " + category.getName() + ".");
+                    }
+                }
             }
         }
     }
 
-    private static void initializeCli(final List<Path> cliDependencies) {
-        synchronized (CLI_DEPENDENCIES) {
-            if (CLI_DEPENDENCIES.isEmpty()) {
-                CLI_DEPENDENCIES.addAll(cliDependencies);
-            } else {
-                throw new LinkageError("Double initialization of dependencies for CLI.");
-            }
+    static {
+        final EnumMap<DependencyCategory, ArrayList<Path>> dependencies = new EnumMap<>(DependencyCategory.class);
+        for (final DependencyCategory category : DependencyCategory.values()) {
+            dependencies.put(category, new ArrayList<>());
         }
-    }
-
-    private static String messageUninitialized(final String target) {
-        return String.format(
-                "Dependencies for %s are uninitialized. Expected to use classes loaded by the parent ClassLoader.", target);
+        DEPENDENCIES = Collections.unmodifiableMap(dependencies);
     }
 
     private static final Logger logger = LoggerFactory.getLogger(EmbulkDependencyClassLoaders.class);
 
     private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.class.getClassLoader();
-
-    private static final ArrayList<Path> MAVEN_DEPENDENCIES = new ArrayList<>();
-    private static final ArrayList<Path> CLI_DEPENDENCIES = new ArrayList<>();
+    private static final Map<DependencyCategory, ArrayList<Path>> DEPENDENCIES;
 
     private static final AtomicBoolean USE_SELF_CONTAINED_JAR_FILES = new AtomicBoolean(false);
 }

--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkSelfContainedJarFiles.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkSelfContainedJarFiles.java
@@ -15,7 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Represents a set of self-contained JAR file resources in the Embulk JAR file.
+ * Represents a pre-defined set of self-contained JAR file resources in the Embulk JAR file.
  *
  * <p>It is intentionally designed to be a singleton. {@link DependencyClassLoader} is introduced only for dependency
  * visibility, not for customizability. It should not be customizable so flexibly.
@@ -25,54 +25,57 @@ public final class EmbulkSelfContainedJarFiles {
         // No instantiation.
     }
 
-    public enum Type {
-        NONE,
-        MAVEN,
-        CLI,
-        ;
-    }
-
     public static final class StaticInitializer {
         private StaticInitializer() {
-            this.mavenJarFileResourceNames = new ArrayList<>();
-            this.cliJarFileResourceNames = new ArrayList<>();
+            this.jarFileResources = new EnumMap<>(DependencyCategory.class);
+            for (final DependencyCategory category : DependencyCategory.values()) {
+                this.jarFileResources.put(category, new ArrayList<>());
+            }
         }
 
+        public StaticInitializer addJarFileResource(final DependencyCategory category, final String resource) {
+            this.jarFileResources.get(category).add(resource);
+            return this;
+        }
+
+        public StaticInitializer addJarFileResources(final DependencyCategory category, final Collection<String> resources) {
+            this.jarFileResources.get(category).addAll(resources);
+            return this;
+        }
+
+        @Deprecated
         public StaticInitializer addMavenJarFileResourceName(final String resourceName) {
-            this.mavenJarFileResourceNames.add(resourceName);
-            return this;
+            return this.addJarFileResource(DependencyCategory.MAVEN, resourceName);
         }
 
+        @Deprecated
         public StaticInitializer addMavenJarFileResourceNames(final Collection<String> resourceNames) {
-            this.mavenJarFileResourceNames.addAll(resourceNames);
-            return this;
+            return this.addJarFileResources(DependencyCategory.MAVEN, resourceNames);
         }
 
+        @Deprecated
         public StaticInitializer addCliJarFileResourceName(final String resourceName) {
-            this.cliJarFileResourceNames.add(resourceName);
-            return this;
+            return this.addJarFileResource(DependencyCategory.CLI, resourceName);
         }
 
+        @Deprecated
         public StaticInitializer addCliJarFileResourceNames(final Collection<String> resourceNames) {
-            this.cliJarFileResourceNames.addAll(resourceNames);
-            return this;
+            return this.addJarFileResources(DependencyCategory.CLI, resourceNames);
         }
 
         public StaticInitializer addFromManifest(final Manifest manifest) {
             final Attributes attributes = manifest.getMainAttributes();
-            this.addMavenJarFileResourceNames(splitAttribute(attributes.getValue("Embulk-Resource-Class-Path-Maven")));
-            this.addCliJarFileResourceNames(splitAttribute(attributes.getValue("Embulk-Resource-Class-Path-Cli")));
+            for (final DependencyCategory category : DependencyCategory.values()) {
+                this.addJarFileResources(category, splitAttribute(attributes.getValue(category.getManifestAttributeName())));
+            }
             return this;
         }
 
         public void initialize() {
-            initializeAll(
-                    Collections.unmodifiableList(this.mavenJarFileResourceNames),
-                    Collections.unmodifiableList(this.cliJarFileResourceNames));
+            initializeAll(jarFileResources);
         }
 
-        private final ArrayList<String> mavenJarFileResourceNames;
-        private final ArrayList<String> cliJarFileResourceNames;
+        private final EnumMap<DependencyCategory, ArrayList<String>> jarFileResources;
     }
 
     public static StaticInitializer staticInitializer() {
@@ -84,24 +87,26 @@ public final class EmbulkSelfContainedJarFiles {
      *
      * public to be called from org.embulk.cli. Not for plugins. Not guaranteed.
      */
-    private static void initializeAll(
-            final List<String> mavenJarResourceNames,
-            final List<String> cliJarResourceNames) {
+    private static void initializeAll(final EnumMap<DependencyCategory, ArrayList<String>> jarFileResources) {
         synchronized (JAR_RESOURCE_NAMES) {
             if (JAR_RESOURCE_NAMES.isEmpty()) {
-                JAR_RESOURCE_NAMES.put(Type.NONE, Collections.unmodifiableList(new ArrayList<String>()));
-                JAR_RESOURCE_NAMES.put(Type.MAVEN, Collections.unmodifiableList(new ArrayList<String>(mavenJarResourceNames)));
-                JAR_RESOURCE_NAMES.put(Type.CLI, Collections.unmodifiableList(new ArrayList<String>(cliJarResourceNames)));
+                for (final DependencyCategory category : DependencyCategory.values()) {
+                    JAR_RESOURCE_NAMES.put(category, jarFileResources.get(category));
+                }
             } else {
                 throw new LinkageError("Doubly-initialized a set of self-contained JAR files.");
             }
         }
     }
 
-    static Resource getSingleResource(final String targetResourceName, final Type type) {
+    static Resource getSingleResource(final String targetResourceName, final DependencyCategory category) {
+        if (category == null) {
+            return null;
+        }
+
         String foundJarResourceName = null;
         Resource resourceToReturn = null;
-        for (final String jarResourceName : JAR_RESOURCE_NAMES.get(type)) {
+        for (final String jarResourceName : JAR_RESOURCE_NAMES.get(category)) {
             final SelfContainedJarFile selfContainedJarFile = Holder.INSTANCE.get(jarResourceName);
             final Resource resourceFound = selfContainedJarFile.getResource(targetResourceName);
             if (resourceFound != null) {
@@ -115,9 +120,13 @@ public final class EmbulkSelfContainedJarFiles {
         return resourceToReturn;
     }
 
-    static Collection<Resource> getMultipleResources(final String targetResourceName, final Type type) {
+    static Collection<Resource> getMultipleResources(final String targetResourceName, final DependencyCategory category) {
+        if (category == null) {
+            return null;
+        }
+
         final ArrayList<Resource> resourcesToReturn = new ArrayList<>();
-        for (final String jarResourceName : JAR_RESOURCE_NAMES.get(type)) {
+        for (final String jarResourceName : JAR_RESOURCE_NAMES.get(category)) {
             final SelfContainedJarFile selfContainedJarFile = Holder.INSTANCE.get(jarResourceName);
             final Resource resourceFound = selfContainedJarFile.getResource(targetResourceName);
             if (resourceFound != null) {
@@ -132,11 +141,10 @@ public final class EmbulkSelfContainedJarFiles {
 
         static {
             final HashSet<String> allJarResourceNames = new HashSet<>();
-            for (final String jarResourceName : JAR_RESOURCE_NAMES.get(Type.MAVEN)) {
-                allJarResourceNames.add(jarResourceName);
-            }
-            for (final String jarResourceName : JAR_RESOURCE_NAMES.get(Type.CLI)) {
-                allJarResourceNames.add(jarResourceName);
+            for (final DependencyCategory category : DependencyCategory.values()) {
+                for (final String jarResourceName : JAR_RESOURCE_NAMES.get(category)) {
+                    allJarResourceNames.add(jarResourceName);
+                }
             }
 
             final HashMap<String, SelfContainedJarFile> instanceBuilt = new HashMap<>();
@@ -162,5 +170,5 @@ public final class EmbulkSelfContainedJarFiles {
 
     private static final Logger logger = LoggerFactory.getLogger(EmbulkSelfContainedJarFiles.class);
 
-    private static final EnumMap<Type, List<String>> JAR_RESOURCE_NAMES = new EnumMap<>(Type.class);
+    private static final EnumMap<DependencyCategory, List<String>> JAR_RESOURCE_NAMES = new EnumMap<>(DependencyCategory.class);
 }

--- a/embulk-core/src/main/java/org/embulk/deps/cli/CliParser.java
+++ b/embulk-core/src/main/java/org/embulk/deps/cli/CliParser.java
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import org.embulk.cli.EmbulkCommandLine;
+import org.embulk.deps.DependencyCategory;
 import org.embulk.deps.EmbulkDependencyClassLoaders;
 
 public abstract class CliParser {
@@ -107,7 +108,7 @@ public abstract class CliParser {
         }
     }
 
-    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.ofCli();
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.of(DependencyCategory.CLI);
     private static final String CLASS_NAME = "org.embulk.deps.cli.CliParserImpl";
 
     static {

--- a/embulk-core/src/main/java/org/embulk/deps/cli/HelpMessageLineDefinition.java
+++ b/embulk-core/src/main/java/org/embulk/deps/cli/HelpMessageLineDefinition.java
@@ -2,6 +2,7 @@ package org.embulk.deps.cli;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import org.embulk.deps.DependencyCategory;
 import org.embulk.deps.EmbulkDependencyClassLoaders;
 
 // It is public just to be accessible from HelpMessageLineDefinitionImpl.
@@ -32,7 +33,7 @@ public abstract class HelpMessageLineDefinition extends AbstractHelpLineDefiniti
         }
     }
 
-    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.ofCli();
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.of(DependencyCategory.CLI);
     private static final String CLASS_NAME = "org.embulk.deps.cli.HelpMessageLineDefinitionImpl";
 
     static {

--- a/embulk-core/src/main/java/org/embulk/deps/cli/OptionDefinition.java
+++ b/embulk-core/src/main/java/org/embulk/deps/cli/OptionDefinition.java
@@ -3,6 +3,7 @@ package org.embulk.deps.cli;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import org.embulk.cli.EmbulkCommandLine;
+import org.embulk.deps.DependencyCategory;
 import org.embulk.deps.EmbulkDependencyClassLoaders;
 
 public abstract class OptionDefinition extends AbstractHelpLineDefinition {
@@ -101,7 +102,7 @@ public abstract class OptionDefinition extends AbstractHelpLineDefinition {
         }
     }
 
-    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.ofCli();
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.of(DependencyCategory.CLI);
     private static final String CLASS_NAME = "org.embulk.deps.cli.OptionDefinitionImpl";
 
     static {

--- a/embulk-core/src/main/java/org/embulk/deps/cli/VelocityEngineDelegate.java
+++ b/embulk-core/src/main/java/org/embulk/deps/cli/VelocityEngineDelegate.java
@@ -5,6 +5,7 @@ import java.io.Writer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import org.embulk.deps.DependencyCategory;
 import org.embulk.deps.EmbulkDependencyClassLoaders;
 
 public abstract class VelocityEngineDelegate {
@@ -40,7 +41,7 @@ public abstract class VelocityEngineDelegate {
         }
     }
 
-    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.ofCli();
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.of(DependencyCategory.CLI);
     private static final String CLASS_NAME = "org.embulk.deps.cli.VelocityEngineDelegateImpl";
 
     static {

--- a/embulk-core/src/main/java/org/embulk/deps/maven/ComparableVersion.java
+++ b/embulk-core/src/main/java/org/embulk/deps/maven/ComparableVersion.java
@@ -2,6 +2,7 @@ package org.embulk.deps.maven;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import org.embulk.deps.DependencyCategory;
 import org.embulk.deps.EmbulkDependencyClassLoaders;
 
 public abstract class ComparableVersion implements Comparable<ComparableVersion> {
@@ -34,7 +35,7 @@ public abstract class ComparableVersion implements Comparable<ComparableVersion>
         }
     }
 
-    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.ofMaven();
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.of(DependencyCategory.MAVEN);
     private static final String CLASS_NAME = "org.embulk.deps.maven.ComparableVersionImpl";
 
     static {

--- a/embulk-core/src/main/java/org/embulk/deps/maven/MavenArtifactFinder.java
+++ b/embulk-core/src/main/java/org/embulk/deps/maven/MavenArtifactFinder.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
+import org.embulk.deps.DependencyCategory;
 import org.embulk.deps.EmbulkDependencyClassLoaders;
 
 public abstract class MavenArtifactFinder {
@@ -47,7 +48,7 @@ public abstract class MavenArtifactFinder {
         }
     }
 
-    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.ofMaven();
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.of(DependencyCategory.MAVEN);
     private static final String CLASS_NAME = "org.embulk.deps.maven.MavenArtifactFinderImpl";
 
     static {

--- a/embulk-core/src/test/java/org/embulk/deps/TestDependencyCategory.java
+++ b/embulk-core/src/test/java/org/embulk/deps/TestDependencyCategory.java
@@ -1,0 +1,23 @@
+package org.embulk.deps;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TestDependencyCategory {
+    /**
+     * Tests the constants as a design contract.
+     *
+     * The manifest attribute name ({@link DependencyCategory#getManifestAttributeName}) is used to
+     * generate an executable JAR file. When changing / adding constant(s), remember to take care of
+     * the attribute names written in {@code build.gradle} as well.
+     */
+    @Test
+    public void testConstants() {
+        assertEquals(2, DependencyCategory.values().length);
+        assertEquals("CLI", DependencyCategory.CLI.getName());
+        assertEquals("Embulk-Resource-Class-Path-Cli", DependencyCategory.CLI.getManifestAttributeName());
+        assertEquals("Maven", DependencyCategory.MAVEN.getName());
+        assertEquals("Embulk-Resource-Class-Path-Maven", DependencyCategory.MAVEN.getManifestAttributeName());
+    }
+}


### PR DESCRIPTION
We plan to load more dependency libraries to be loaded through `DependencyClassLoader`. But now, we need annoying messy steps to extend them.

This pull request refactors `EmbulkDependencyClassLoaders` and `EmbulkSelfContainedJarFiles` to be parameterized so that it can be extended more easily.

The pull request consists of two steps:
* 1d2a6aca582315e45e78875815ac7d82da04ef74: focuses on `EmbulkDependencyClassLoaders`
* 3f2ed2f34d570322402964bc21a61fad87a59e42: focuses on `EmbulkSelfContainedJarFiles`

---

They are expected to be used like below. It is for the case of Embulk as the all-in-one executable package from CLI.
https://github.com/embulk/embulk/blob/v0.9.20/embulk-core/src/main/java/org/embulk/cli/Main.java#L60-L61

Users with `EmbulkEmbed` will need to call them by themselves.

Unfortunately it has been difficult to test as a unit test because it runs in the `static` context intentionally.

---

To find a corresponding `ClassLoader`, we need :

```
// Before
ClassLoader loader = EmbulkDependencyClassLoaders.ofMaven();
```

```
// After
ClassLoader loader = EmbulkDependencyClassLoaders.of(DependencyCategory.MAVEN);
```
