### PR TITLE
Throw a readable Exception against illegal prefix/suffix for a temp file (Fixes #1193)

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TempFileSpace.java
@@ -105,7 +105,18 @@ public class TempFileSpace {
         try {
             this.createTempDirectoryIfRequired();
 
-            final Path tempFile = Files.createTempFile(this.tempDirectoryCreated.get(), prefix, "." + fileExt);
+            final Path tempFile;
+            try {
+                tempFile = Files.createTempFile(this.tempDirectoryCreated.get(), prefix, "." + fileExt);
+            } catch (final IllegalArgumentException ex) {
+                throw new IOException(
+                        "Failed to create a temp file with illegal prefix or suffix given. "
+                                + "For example, \"/\" is not accepted in prefix nor suffix since Embulk v0.9.20. "
+                                + "Please advise the plugin developer about it. "
+                                + "(prefix: \"" + prefix + "\", suffix: \"" + fileExt + "\")",
+                        ex);
+            }
+
             logger.debug("TempFile \"{}\" is created.", tempFile);
             return tempFile.toFile();
         } catch (final IOException ex) {


### PR DESCRIPTION
It throws a more readable Exception against illegal prefix/suffix for a temp file (#1193).

@shroman Can you have a look?