### PR TITLE
Load Netty Buffer library in a separate DependencyClassLoader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ env:
     - GRADLE_TASK=':embulk-core:check'
     - GRADLE_TASK=':embulk-standards:check'
     - GRADLE_TASK=':embulk-test:check'
+    - GRADLE_TASK=':embulk-deps-buffer:check'

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext {
     summary = 'Embulk, a plugin-based parallel bulk data loader'
 }
 
-configure(subprojects.findAll { ['embulk-core', 'embulk-deps-cli', 'embulk-deps-maven', 'embulk-standards', 'embulk-test'].contains(it.name) }) {
+configure(subprojects.findAll { ['embulk-core', 'embulk-deps-buffer', 'embulk-deps-cli', 'embulk-deps-maven', 'embulk-standards', 'embulk-test'].contains(it.name) }) {
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'maven'
@@ -211,6 +211,8 @@ dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.3'
     compile 'org.fusesource.jansi:jansi:1.11'
 
+    embed project(':embulk-deps-buffer')
+
     embed(project(':embulk-deps-maven')) {
         exclude group: 'org.apache.commons', module: 'commons-lang3'  // Included in embulk-core.
         exclude group: 'com.google.guava', module: 'guava'  // Included in embulk-core.
@@ -261,6 +263,7 @@ shadowJar {  // Builds a fat-JAR with recurred dependencies from the above ':emb
                    'Implementation-Vendor-Id': project.group,
                    'Specification-Title': 'embulk',
                    'Specification-Version': project.version,
+                   'Embulk-Resource-Class-Path-Buffer': listEmbedDependencies('embulk-deps-buffer', '/lib/'),
                    'Embulk-Resource-Class-Path-Maven': listEmbedDependencies('embulk-deps-maven', '/lib/'),
                    'Embulk-Resource-Class-Path-Cli': listEmbedDependencies('embulk-deps-cli', '/lib/'),
                    'Main-Class': 'org.embulk.cli.Main'

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     compile 'org.apache.bval:bval-jsr303:0.5'
     compile 'io.airlift:slice:0.9'
     compile 'joda-time:joda-time:2.9.2'
-    compile 'io.netty:netty-buffer:4.0.44.Final'
     compile 'org.msgpack:msgpack-core:0.8.11'
 
     // For embulk/guess/charset.rb. See also embulk.gemspec
@@ -66,6 +65,10 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'ch.qos.logback:logback-classic:1.1.3'
 
+    // TODO: Remove this, and load it with the proper DependencyClassLoader.
+    // This statement gets it loaded by the top-level ClassLoader.
+    testCompile project(':embulk-deps-buffer')
+
     gems 'rubygems:bundler:1.16.0'
     gems 'rubygems:msgpack:1.1.0'
     gems 'rubygems:liquid:4.0.0'
@@ -78,7 +81,7 @@ jruby {
     execVersion = rootProject.jrubyVersion
 }
 
-task rubyTestVanilla(type: JRubyExec, dependsOn: ["jar", "prepareDependencyJars"]) {
+task rubyTestVanilla(type: JRubyExec, dependsOn: ["jar", "prepareDependencyJars", ":embulk-deps-buffer:prepareDependencyJars"]) {
     jrubyArgs '-Isrc/main/ruby', '-Isrc/test/ruby', '--debug', './src/test/ruby/vanilla/run-test.rb'
 }
 task rubyTestMonkeyStrptime(type: JRubyExec) {

--- a/embulk-core/src/main/java/org/embulk/deps/DependencyCategory.java
+++ b/embulk-core/src/main/java/org/embulk/deps/DependencyCategory.java
@@ -1,6 +1,7 @@
 package org.embulk.deps;
 
 public enum DependencyCategory {
+    BUFFER("Buffer", "Embulk-Resource-Class-Path-Buffer"),
     CLI("CLI", "Embulk-Resource-Class-Path-Cli"),
     MAVEN("Maven", "Embulk-Resource-Class-Path-Maven"),
     ;

--- a/embulk-core/src/main/java/org/embulk/deps/buffer/PooledBufferAllocator.java
+++ b/embulk-core/src/main/java/org/embulk/deps/buffer/PooledBufferAllocator.java
@@ -1,0 +1,62 @@
+package org.embulk.deps.buffer;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import org.embulk.deps.DependencyCategory;
+import org.embulk.deps.EmbulkDependencyClassLoaders;
+import org.embulk.spi.Buffer;
+import org.embulk.spi.BufferAllocator;
+
+public abstract class PooledBufferAllocator implements BufferAllocator {
+    public static PooledBufferAllocator create(final int pageSize) {
+        try {
+            return CONSTRUCTOR.newInstance(pageSize);
+        } catch (final IllegalAccessException | IllegalArgumentException | InstantiationException ex) {
+            throw new LinkageError("Dependencies for Buffer are not loaded correctly: " + CLASS_NAME, ex);
+        } catch (final InvocationTargetException ex) {
+            final Throwable targetException = ex.getTargetException();
+            if (targetException instanceof RuntimeException) {
+                throw (RuntimeException) targetException;
+            } else if (targetException instanceof Error) {
+                throw (Error) targetException;
+            } else {
+                throw new RuntimeException("Unexpected Exception in creating: " + CLASS_NAME, ex);
+            }
+        }
+    }
+
+    public static PooledBufferAllocator create() {
+        return create(DEFAULT_PAGE_SIZE);
+    }
+
+    @Override
+    public abstract Buffer allocate();
+
+    @Override
+    public abstract Buffer allocate(final int minimumCapacity);
+
+    @SuppressWarnings("unchecked")
+    private static Class<PooledBufferAllocator> loadImplClass() {
+        try {
+            return (Class<PooledBufferAllocator>) CLASS_LOADER.loadClass(CLASS_NAME);
+        } catch (final ClassNotFoundException ex) {
+            throw new LinkageError("Dependencies for Buffer are not loaded correctly: " + CLASS_NAME, ex);
+        }
+    }
+
+    private static final int DEFAULT_PAGE_SIZE = 32 * 1024;
+
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.of(DependencyCategory.BUFFER);
+    private static final String CLASS_NAME = "org.embulk.deps.buffer.PooledBufferAllocatorImpl";
+
+    static {
+        final Class<PooledBufferAllocator> clazz = loadImplClass();
+        try {
+            CONSTRUCTOR = clazz.getConstructor(int.class);
+        } catch (final NoSuchMethodException ex) {
+            throw new LinkageError("Dependencies for Buffer are not loaded correctly: " + CLASS_NAME, ex);
+        }
+    }
+
+    private static final Constructor<PooledBufferAllocator> CONSTRUCTOR;
+}

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -15,6 +15,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.ModelManager;
+import org.embulk.deps.buffer.PooledBufferAllocator;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.ExecutorPlugin;
 import org.embulk.spi.ParserPlugin;
@@ -65,10 +66,10 @@ public class ExecModule implements Module {
     private BufferAllocator createBufferAllocatorFromSystemConfig() {
         final String byteSizeRepresentation = this.systemConfig.get(String.class, "page_size", null);
         if (byteSizeRepresentation == null) {
-            return new PooledBufferAllocator();
+            return PooledBufferAllocator.create();
         } else {
             final int byteSize = parseByteSizeRepresentation(byteSizeRepresentation);
-            return new PooledBufferAllocator(byteSize);
+            return PooledBufferAllocator.create(byteSize);
         }
     }
 

--- a/embulk-core/src/test/java/org/embulk/deps/TestDependencyCategory.java
+++ b/embulk-core/src/test/java/org/embulk/deps/TestDependencyCategory.java
@@ -14,10 +14,12 @@ public class TestDependencyCategory {
      */
     @Test
     public void testConstants() {
-        assertEquals(2, DependencyCategory.values().length);
+        assertEquals(3, DependencyCategory.values().length);
         assertEquals("CLI", DependencyCategory.CLI.getName());
         assertEquals("Embulk-Resource-Class-Path-Cli", DependencyCategory.CLI.getManifestAttributeName());
         assertEquals("Maven", DependencyCategory.MAVEN.getName());
         assertEquals("Embulk-Resource-Class-Path-Maven", DependencyCategory.MAVEN.getManifestAttributeName());
+        assertEquals("Buffer", DependencyCategory.BUFFER.getName());
+        assertEquals("Embulk-Resource-Class-Path-Buffer", DependencyCategory.BUFFER.getManifestAttributeName());
     }
 }

--- a/embulk-core/src/test/ruby/vanilla/run-test.rb
+++ b/embulk-core/src/test/ruby/vanilla/run-test.rb
@@ -1,7 +1,15 @@
 # Tests guess, and org.embulk.spi.time.TimestampParser which parses timestamp strings into Embulk's Timestamp.
 
+def each_jar_in(path)
+  Dir.entries(path).select{|f| f =~ /\.jar$/}.map{|f| File.join(path, f)}.each do |jar|
+    yield jar
+  end
+end
+
 this_dir = File.dirname(__FILE__)
 core_dir = File.expand_path(File.join(this_dir, '..', '..', '..', '..'))
+root_dir = File.expand_path(File.join(core_dir, '..'))
+
 embulk_jar_dir = File.join(core_dir, 'build', 'libs')
 dependency_jars_dir = File.join(core_dir, 'build', 'dependency_jars')
 
@@ -13,6 +21,13 @@ dependency_jars = Dir.entries(dependency_jars_dir).select{|f| f =~ /\.jar$/}.map
 dependency_jars.each do |dependency_jar|
   $CLASSPATH << dependency_jar
 end
+
+static_initializer = Java::org.embulk.deps.EmbulkDependencyClassLoaders.staticInitializer()
+each_jar_in(File.join(root_dir, 'embulk-deps', 'buffer', 'build', 'dependency_jars')) do |jar|
+  static_initializer.addDependency(Java::org.embulk.deps.DependencyCategory::BUFFER, java.nio.file.Paths.get(jar.to_s))
+end
+# https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#calling-masked-or-unreachable-java-methods-with-java_send
+static_initializer.java_send :initialize
 
 Gem.path << File.join(core_dir, 'build', 'dependency_gems_as_resources')
 Gem.path << File.join(core_dir, 'build', 'embulk_gems_as_resources')

--- a/embulk-deps/buffer/build.gradle
+++ b/embulk-deps/buffer/build.gradle
@@ -1,0 +1,24 @@
+description = "Wrapper of Embulk's Buffer-related dependency libraries"
+ext {
+    summary = "Embulk's dependency wrapper for Buffer"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly project(":embulk-core")
+    compile "io.netty:netty-buffer:4.0.44.Final"
+
+    testCompile project(":embulk-core")
+    testCompile "junit:junit:4.12"
+}
+
+task prepareDependencyJars(type: Copy) {
+    doFirst {
+        delete("${buildDir}/dependency_jars")
+    }
+    from configurations.runtime + files("${project.libsDir}/${project.name}-${project.version}.jar")
+    into "${buildDir}/dependency_jars"
+}

--- a/embulk-deps/buffer/config/checkstyle/suppressions.xml
+++ b/embulk-deps/buffer/config/checkstyle/suppressions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress checks="JavadocMethod" files=".*"/>
+  <suppress checks="JavadocParagraph" files=".*"/>
+  <suppress checks="JavadocTagContinuationIndentation" files=".*"/>
+  <suppress checks="SingleLineJavadoc" files=".*"/>
+  <suppress checks="SummaryJavadoc" files=".*"/>
+</suppressions>

--- a/embulk-deps/buffer/src/main/java/org/embulk/deps/buffer/PooledBufferAllocatorImpl.java
+++ b/embulk-deps/buffer/src/main/java/org/embulk/deps/buffer/PooledBufferAllocatorImpl.java
@@ -1,20 +1,15 @@
-package org.embulk.exec;
+package org.embulk.deps.buffer;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import org.embulk.spi.Buffer;
-import org.embulk.spi.BufferAllocator;
 
-class PooledBufferAllocator implements BufferAllocator {
-    PooledBufferAllocator(final int pageSize) {
+public class PooledBufferAllocatorImpl extends org.embulk.deps.buffer.PooledBufferAllocator {
+    public PooledBufferAllocatorImpl(final int pageSize) {
         this.pageSize = pageSize;
 
         // PooledByteBufAllocator(preferDirect = false): buffers are allocated on Java heap.
         this.nettyByteBufAllocator = new PooledByteBufAllocator(false);
-    }
-
-    PooledBufferAllocator() {
-        this(DEFAULT_PAGE_SIZE);
     }
 
     @Override
@@ -60,8 +55,6 @@ class PooledBufferAllocator implements BufferAllocator {
             super("A Buffer detected double release() calls. The buffer has already been released at:", alreadyReleasedAt);
         }
     }
-
-    private static final int DEFAULT_PAGE_SIZE = 32 * 1024;
 
     private final PooledByteBufAllocator nettyByteBufAllocator;
     private final int pageSize;

--- a/embulk-deps/buffer/src/test/java/org/embulk/deps/buffer/TestPooledBufferAllocatorImpl.java
+++ b/embulk-deps/buffer/src/test/java/org/embulk/deps/buffer/TestPooledBufferAllocatorImpl.java
@@ -1,0 +1,36 @@
+package org.embulk.deps.buffer;
+
+import static org.junit.Assert.assertEquals;
+
+import org.embulk.spi.Buffer;
+import org.junit.Test;
+
+public class TestPooledBufferAllocatorImpl {
+    @Test
+    public void testDefault() throws Exception {
+        final PooledBufferAllocatorImpl allocator = new PooledBufferAllocatorImpl(4096);
+        final Buffer buffer = allocator.allocate();
+        assertEquals(0, buffer.offset());
+        assertEquals(0, buffer.limit());
+        assertEquals(4096, buffer.capacity());
+        buffer.release();
+    }
+
+    @Test
+    public void testWithBiggerMinimumCapacity() throws Exception {
+        final PooledBufferAllocatorImpl allocator = new PooledBufferAllocatorImpl(4096);
+        final Buffer buffer = allocator.allocate(10000);
+        assertEquals(0, buffer.offset());
+        assertEquals(0, buffer.limit());
+        assertEquals(16384, buffer.capacity());
+        buffer.release();
+    }
+
+    @Test
+    public void testDoubleRelease() throws Exception {
+        final PooledBufferAllocatorImpl allocator = new PooledBufferAllocatorImpl(4096);
+        final Buffer buffer = allocator.allocate(10000);
+        buffer.release();
+        buffer.release();  // To printStackTrace of the first release, but no errors.
+    }
+}

--- a/embulk-standards/build.gradle
+++ b/embulk-standards/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     testCompile project(':embulk-test')
     testCompile 'ch.qos.logback:logback-classic:1.1.3'
 
+    // TODO: Remove this, and load it with the proper DependencyClassLoader.
+    // This statement gets it loaded by the top-level ClassLoader.
+    testCompile project(':embulk-deps-buffer')
+
     jrubyExec 'rubygems:simplecov:0.10.+'
     jrubyExec 'rubygems:test-unit:3.0.+'
 }
@@ -41,7 +45,7 @@ jruby {
     execVersion = rootProject.jrubyVersion
 }
 
-task rubyTestVanilla(type: JRubyExec, dependsOn: ["jar", "prepareDependencyJars"]) {
+task rubyTestVanilla(type: JRubyExec, dependsOn: ["jar", "prepareDependencyJars", ":embulk-deps-buffer:prepareDependencyJars"]) {
     jrubyArgs '-Isrc/main/ruby', '-Isrc/test/ruby', '--debug', './src/test/ruby/vanilla/run-test.rb'
 }
 test.dependsOn(['rubyTestVanilla'])

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,8 @@
 rootProject.name = 'embulk'
 
 include 'embulk-core'
+include 'embulk-deps-buffer'
+project(':embulk-deps-buffer').projectDir = file('embulk-deps/buffer')
 include 'embulk-deps-cli'
 project(':embulk-deps-cli').projectDir = file('embulk-deps/cli')
 include 'embulk-deps-maven'


### PR DESCRIPTION
After refactoring at #1197 and #1203, as the first effort of isolating existing dependency libraries, we are moving this Netty Buffer to a separate `DependencyClassLoader`.

Because the caller of Netty Buffer was only `PooledBufferAllocator`, made it an entry point to the `DependencyClassLoader` part.