### PR TITLE
Fix refactored EmbulkDependencyClassLoaders to process JARs out of executable-JAR

### DIFF
--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
@@ -126,7 +126,7 @@ public final class EmbulkDependencyClassLoaders {
         synchronized (DEPENDENCIES) {
             for (final DependencyCategory category : DependencyCategory.values()) {
                 if (dependencies.containsKey(category)) {
-                    if (dependencies.get(category).isEmpty()) {
+                    if (DEPENDENCIES.get(category).isEmpty()) {
                         DEPENDENCIES.get(category).addAll(dependencies.get(category));
                     } else {
                         throw new LinkageError("Double initialization of dependencies for " + category.getName() + ".");


### PR DESCRIPTION
The "double initialization" check for JARs out of self-contained JAR was wrong in: 1d2a6aca582315e45e78875815ac7d82da04ef74
It was working for self-contained executable JAR, but it was not working for the EmbulkEmbed case, or other testing cases.