### PR TITLE
Load Airlift Slice library in a separate DependencyClassLoader

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -50,7 +50,6 @@ dependencies {
     compile 'org.yaml:snakeyaml:1.18'
     compile 'javax.validation:validation-api:1.1.0.Final'
     compile 'org.apache.bval:bval-jsr303:0.5'
-    compile 'io.airlift:slice:0.9'
     compile 'joda-time:joda-time:2.9.2'
     compile 'org.msgpack:msgpack-core:0.8.11'
 

--- a/embulk-core/src/main/java/org/embulk/deps/buffer/Slice.java
+++ b/embulk-core/src/main/java/org/embulk/deps/buffer/Slice.java
@@ -1,0 +1,69 @@
+package org.embulk.deps.buffer;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import org.embulk.deps.DependencyCategory;
+import org.embulk.deps.EmbulkDependencyClassLoaders;
+import org.embulk.spi.Buffer;
+
+public abstract class Slice {
+    public static Slice createWithWrappedBuffer(final Buffer buffer) {
+        try {
+            return CONSTRUCTOR.newInstance(buffer.array(), buffer.offset(), buffer.capacity());
+        } catch (final IllegalAccessException | IllegalArgumentException | InstantiationException ex) {
+            throw new LinkageError("Dependencies for Buffer are not loaded correctly: " + CLASS_NAME, ex);
+        } catch (final InvocationTargetException ex) {
+            final Throwable targetException = ex.getTargetException();
+            if (targetException instanceof RuntimeException) {
+                throw (RuntimeException) targetException;
+            } else if (targetException instanceof Error) {
+                throw (Error) targetException;
+            } else {
+                throw new RuntimeException("Unexpected Exception in creating: " + CLASS_NAME, ex);
+            }
+        }
+    }
+
+    public abstract byte getByte(int index);
+
+    public abstract void getBytes(int index, byte[] destination, int destinationIndex, int length);
+
+    public abstract double getDouble(int index);
+
+    public abstract int getInt(int index);
+
+    public abstract long getLong(int index);
+
+    public abstract void setByte(int index, int value);
+
+    public abstract void setBytes(int index, byte[] source);
+
+    public abstract void setDouble(int index, double value);
+
+    public abstract void setInt(int index, int value);
+
+    public abstract void setLong(int index, long value);
+
+    @SuppressWarnings("unchecked")
+    private static Class<Slice> loadImplClass() {
+        try {
+            return (Class<Slice>) CLASS_LOADER.loadClass(CLASS_NAME);
+        } catch (final ClassNotFoundException ex) {
+            throw new LinkageError("Dependencies for Buffer are not loaded correctly: " + CLASS_NAME, ex);
+        }
+    }
+
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.of(DependencyCategory.BUFFER);
+    private static final String CLASS_NAME = "org.embulk.deps.buffer.SliceImpl";
+
+    static {
+        final Class<Slice> clazz = loadImplClass();
+        try {
+            CONSTRUCTOR = clazz.getConstructor(byte[].class, int.class, int.class);
+        } catch (final NoSuchMethodException ex) {
+            throw new LinkageError("Dependencies for Buffer are not loaded correctly: " + CLASS_NAME, ex);
+        }
+    }
+
+    private static final Constructor<Slice> CONSTRUCTOR;
+}

--- a/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
@@ -1,10 +1,9 @@
 package org.embulk.spi;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.embulk.deps.buffer.Slice;
 import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
@@ -45,7 +44,7 @@ public class PageBuilder implements AutoCloseable {
 
     private void newBuffer() {
         this.buffer = allocator.allocate(PageFormat.PAGE_HEADER_SIZE + fixedRecordSize);
-        this.bufferSlice = Slices.wrappedBuffer(buffer.array(), buffer.offset(), buffer.capacity());
+        this.bufferSlice = Slice.createWithWrappedBuffer(buffer);
         this.count = 0;
         this.position = PageFormat.PAGE_HEADER_SIZE;
         this.stringReferences = new ArrayList<>();

--- a/embulk-core/src/main/java/org/embulk/spi/PageReader.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageReader.java
@@ -1,7 +1,6 @@
 package org.embulk.spi;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
+import org.embulk.deps.buffer.Slice;
 import org.embulk.spi.time.Timestamp;
 import org.msgpack.value.Value;
 
@@ -27,7 +26,7 @@ public class PageReader implements AutoCloseable {
 
     public static int getRecordCount(Page page) {
         Buffer pageBuffer = page.buffer();
-        Slice pageSlice = Slices.wrappedBuffer(pageBuffer.array(), pageBuffer.offset(), pageBuffer.limit());
+        Slice pageSlice = Slice.createWithWrappedBuffer(pageBuffer);
         return pageSlice.getInt(0);  // see page format
     }
 
@@ -36,7 +35,7 @@ public class PageReader implements AutoCloseable {
         this.page = SENTINEL;
 
         Buffer pageBuffer = page.buffer();
-        Slice pageSlice = Slices.wrappedBuffer(pageBuffer.array(), pageBuffer.offset(), pageBuffer.limit());
+        Slice pageSlice = Slice.createWithWrappedBuffer(pageBuffer);
 
         pageRecordCount = pageSlice.getInt(0);  // see page format
         readCount = 0;

--- a/embulk-deps/buffer/build.gradle
+++ b/embulk-deps/buffer/build.gradle
@@ -10,6 +10,7 @@ repositories {
 dependencies {
     compileOnly project(":embulk-core")
     compile "io.netty:netty-buffer:4.0.44.Final"
+    compile "io.airlift:slice:0.9"
 
     testCompile project(":embulk-core")
     testCompile "junit:junit:4.12"

--- a/embulk-deps/buffer/src/main/java/org/embulk/deps/buffer/SliceImpl.java
+++ b/embulk-deps/buffer/src/main/java/org/embulk/deps/buffer/SliceImpl.java
@@ -1,0 +1,52 @@
+package org.embulk.deps.buffer;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+public final class SliceImpl extends org.embulk.deps.buffer.Slice {
+    public SliceImpl(final byte[] array, final int offset, final int length) {
+        this.slice = Slices.wrappedBuffer(array, offset, length);
+    }
+
+    public byte getByte(final int index) {
+        return this.slice.getByte(index);
+    }
+
+    public void getBytes(final int index, final byte[] destination, final int destinationIndex, final int length) {
+        this.slice.getBytes(index, destination, destinationIndex, length);
+    }
+
+    public double getDouble(final int index) {
+        return this.slice.getDouble(index);
+    }
+
+    public int getInt(final int index) {
+        return this.slice.getInt(index);
+    }
+
+    public long getLong(final int index) {
+        return this.slice.getLong(index);
+    }
+
+    public void setByte(final int index, final int value) {
+        this.slice.setByte(index, value);
+    }
+
+    public void setBytes(final int index, final byte[] source) {
+        this.slice.setBytes(index, source);
+    }
+
+    public void setDouble(final int index, final double value) {
+        this.slice.setDouble(index, value);
+    }
+
+    public void setInt(final int index, final int value) {
+        this.slice.setInt(index, value);
+    }
+
+    public void setLong(final int index, final long value) {
+        this.slice.setLong(index, value);
+    }
+
+    private final Slice slice;
+}


### PR DESCRIPTION
After refactoring at #1201, we are moving this Airlift's Slice to the separate DependencyClassLoader for `Buffer`, the same as Netty Buffer.

Airlift's Slice is called from `PageBuilder` and `PageReader`. The entry point is `io.airlift.slice.Slice` here.
