### PR TITLE
Load ICU4J library in a separate DependencyClassLoader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ env:
     - GRADLE_TASK=':embulk-standards:check'
     - GRADLE_TASK=':embulk-test:check'
     - GRADLE_TASK=':embulk-deps-buffer:check'
+    - GRADLE_TASK=':embulk-deps-guess:check'

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext {
     summary = 'Embulk, a plugin-based parallel bulk data loader'
 }
 
-configure(subprojects.findAll { ['embulk-core', 'embulk-deps-buffer', 'embulk-deps-cli', 'embulk-deps-maven', 'embulk-standards', 'embulk-test'].contains(it.name) }) {
+configure(subprojects.findAll { ['embulk-core', 'embulk-deps-buffer', 'embulk-deps-cli', 'embulk-deps-guess', 'embulk-deps-maven', 'embulk-standards', 'embulk-test'].contains(it.name) }) {
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'maven'
@@ -213,6 +213,8 @@ dependencies {
 
     embed project(':embulk-deps-buffer')
 
+    embed project(':embulk-deps-guess')
+
     embed(project(':embulk-deps-maven')) {
         exclude group: 'org.apache.commons', module: 'commons-lang3'  // Included in embulk-core.
         exclude group: 'com.google.guava', module: 'guava'  // Included in embulk-core.
@@ -264,6 +266,7 @@ shadowJar {  // Builds a fat-JAR with recurred dependencies from the above ':emb
                    'Specification-Title': 'embulk',
                    'Specification-Version': project.version,
                    'Embulk-Resource-Class-Path-Buffer': listEmbedDependencies('embulk-deps-buffer', '/lib/'),
+                   'Embulk-Resource-Class-Path-Guess': listEmbedDependencies('embulk-deps-guess', '/lib/'),
                    'Embulk-Resource-Class-Path-Maven': listEmbedDependencies('embulk-deps-maven', '/lib/'),
                    'Embulk-Resource-Class-Path-Cli': listEmbedDependencies('embulk-deps-cli', '/lib/'),
                    'Main-Class': 'org.embulk.cli.Main'

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -53,9 +53,6 @@ dependencies {
     compile 'joda-time:joda-time:2.9.2'
     compile 'org.msgpack:msgpack-core:0.8.11'
 
-    // For embulk/guess/charset.rb. See also embulk.gemspec
-    compile 'com.ibm.icu:icu4j:54.1.1'
-
     // bval-jsr303:0.5 depends on commons-lang3:3.1,
     // but it was upgraded to 3.4 when maven-aether-provider:3.3.9 was introduced.
     // Maven-related dependencies are moved to embulk-deps-maven.
@@ -67,6 +64,7 @@ dependencies {
     // TODO: Remove this, and load it with the proper DependencyClassLoader.
     // This statement gets it loaded by the top-level ClassLoader.
     testCompile project(':embulk-deps-buffer')
+    testCompile project(':embulk-deps-guess')
 
     gems 'rubygems:bundler:1.16.0'
     gems 'rubygems:msgpack:1.1.0'
@@ -80,7 +78,7 @@ jruby {
     execVersion = rootProject.jrubyVersion
 }
 
-task rubyTestVanilla(type: JRubyExec, dependsOn: ["jar", "prepareDependencyJars", ":embulk-deps-buffer:prepareDependencyJars"]) {
+task rubyTestVanilla(type: JRubyExec, dependsOn: ["jar", "prepareDependencyJars", ":embulk-deps-buffer:prepareDependencyJars", ":embulk-deps-guess:prepareDependencyJars"]) {
     jrubyArgs '-Isrc/main/ruby', '-Isrc/test/ruby', '--debug', './src/test/ruby/vanilla/run-test.rb'
 }
 task rubyTestMonkeyStrptime(type: JRubyExec) {

--- a/embulk-core/src/main/java/org/embulk/deps/DependencyCategory.java
+++ b/embulk-core/src/main/java/org/embulk/deps/DependencyCategory.java
@@ -2,6 +2,7 @@ package org.embulk.deps;
 
 public enum DependencyCategory {
     BUFFER("Buffer", "Embulk-Resource-Class-Path-Buffer"),
+    GUESS("Guess", "Embulk-Resource-Class-Path-Guess"),
     CLI("CLI", "Embulk-Resource-Class-Path-Cli"),
     MAVEN("Maven", "Embulk-Resource-Class-Path-Maven"),
     ;

--- a/embulk-core/src/main/java/org/embulk/deps/guess/CharsetDetector.java
+++ b/embulk-core/src/main/java/org/embulk/deps/guess/CharsetDetector.java
@@ -1,0 +1,52 @@
+package org.embulk.deps.guess;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import org.embulk.deps.DependencyCategory;
+import org.embulk.deps.EmbulkDependencyClassLoaders;
+
+public abstract class CharsetDetector {
+    public static CharsetDetector create() {
+        try {
+            return CONSTRUCTOR.newInstance();
+        } catch (final IllegalAccessException | IllegalArgumentException | InstantiationException ex) {
+            throw new LinkageError("Dependencies for Guess are not loaded correctly: " + CLASS_NAME, ex);
+        } catch (final InvocationTargetException ex) {
+            final Throwable targetException = ex.getTargetException();
+            if (targetException instanceof RuntimeException) {
+                throw (RuntimeException) targetException;
+            } else if (targetException instanceof Error) {
+                throw (Error) targetException;
+            } else {
+                throw new RuntimeException("Unexpected Exception in creating: " + CLASS_NAME, ex);
+            }
+        }
+    }
+
+    public abstract CharsetDetector setText(final byte[] in);
+
+    public abstract CharsetMatch detect();
+
+    @SuppressWarnings("unchecked")
+    private static Class<CharsetDetector> loadImplClass() {
+        try {
+            return (Class<CharsetDetector>) CLASS_LOADER.loadClass(CLASS_NAME);
+        } catch (final ClassNotFoundException ex) {
+            throw new LinkageError("Dependencies for Guess are not loaded correctly: " + CLASS_NAME, ex);
+        }
+    }
+
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.of(DependencyCategory.GUESS);
+    private static final String CLASS_NAME = "org.embulk.deps.guess.CharsetDetectorImpl";
+
+    static {
+        final Class<CharsetDetector> clazz = loadImplClass();
+        try {
+            CONSTRUCTOR = clazz.getConstructor();
+        } catch (final NoSuchMethodException ex) {
+            throw new LinkageError("Dependencies for Guess are not loaded correctly: " + CLASS_NAME, ex);
+        }
+    }
+
+    private static final Constructor<CharsetDetector> CONSTRUCTOR;
+}

--- a/embulk-core/src/main/java/org/embulk/deps/guess/CharsetMatch.java
+++ b/embulk-core/src/main/java/org/embulk/deps/guess/CharsetMatch.java
@@ -1,0 +1,7 @@
+package org.embulk.deps.guess;
+
+public abstract class CharsetMatch {
+    public abstract int getConfidence();
+
+    public abstract String getName();
+}

--- a/embulk-core/src/main/ruby/embulk/guess/charset.rb
+++ b/embulk-core/src/main/ruby/embulk/guess/charset.rb
@@ -15,9 +15,8 @@ module Embulk
       }
 
       def guess(config, sample_buffer)
-        # ICU4J is always there as embulk.gem is no longer supported. rjack-icu is not required.
-        detector_class = com.ibm.icu.text.CharsetDetector
-        detector = detector_class.new
+        detector_class = org.embulk.deps.guess.CharsetDetector
+        detector = detector_class.create
         detector.setText(sample_buffer.to_java_bytes)
         best_match = detector.detect
         if best_match.getConfidence < 50

--- a/embulk-core/src/test/java/org/embulk/deps/TestDependencyCategory.java
+++ b/embulk-core/src/test/java/org/embulk/deps/TestDependencyCategory.java
@@ -14,12 +14,14 @@ public class TestDependencyCategory {
      */
     @Test
     public void testConstants() {
-        assertEquals(3, DependencyCategory.values().length);
+        assertEquals(4, DependencyCategory.values().length);
         assertEquals("CLI", DependencyCategory.CLI.getName());
         assertEquals("Embulk-Resource-Class-Path-Cli", DependencyCategory.CLI.getManifestAttributeName());
         assertEquals("Maven", DependencyCategory.MAVEN.getName());
         assertEquals("Embulk-Resource-Class-Path-Maven", DependencyCategory.MAVEN.getManifestAttributeName());
         assertEquals("Buffer", DependencyCategory.BUFFER.getName());
         assertEquals("Embulk-Resource-Class-Path-Buffer", DependencyCategory.BUFFER.getManifestAttributeName());
+        assertEquals("Guess", DependencyCategory.GUESS.getName());
+        assertEquals("Embulk-Resource-Class-Path-Guess", DependencyCategory.GUESS.getManifestAttributeName());
     }
 }

--- a/embulk-core/src/test/ruby/vanilla/run-test.rb
+++ b/embulk-core/src/test/ruby/vanilla/run-test.rb
@@ -26,6 +26,9 @@ static_initializer = Java::org.embulk.deps.EmbulkDependencyClassLoaders.staticIn
 each_jar_in(File.join(root_dir, 'embulk-deps', 'buffer', 'build', 'dependency_jars')) do |jar|
   static_initializer.addDependency(Java::org.embulk.deps.DependencyCategory::BUFFER, java.nio.file.Paths.get(jar.to_s))
 end
+each_jar_in(File.join(root_dir, 'embulk-deps', 'guess', 'build', 'dependency_jars')) do |jar|
+  static_initializer.addDependency(Java::org.embulk.deps.DependencyCategory::GUESS, java.nio.file.Paths.get(jar.to_s))
+end
 # https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#calling-masked-or-unreachable-java-methods-with-java_send
 static_initializer.java_send :initialize
 

--- a/embulk-deps/guess/build.gradle
+++ b/embulk-deps/guess/build.gradle
@@ -1,0 +1,26 @@
+description = "Wrapper of Embulk's Guess-related dependency libraries"
+ext {
+    summary = "Embulk's dependency wrapper for Guess"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly project(":embulk-core")
+
+    // For embulk/guess/charset.rb. See also embulk.gemspec
+    compile "com.ibm.icu:icu4j:54.1.1"
+
+    testCompile project(":embulk-core")
+    testCompile "junit:junit:4.12"
+}
+
+task prepareDependencyJars(type: Copy) {
+    doFirst {
+        delete("${buildDir}/dependency_jars")
+    }
+    from configurations.runtime + files("${project.libsDir}/${project.name}-${project.version}.jar")
+    into "${buildDir}/dependency_jars"
+}

--- a/embulk-deps/guess/config/checkstyle/suppressions.xml
+++ b/embulk-deps/guess/config/checkstyle/suppressions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress checks="JavadocMethod" files=".*"/>
+  <suppress checks="JavadocParagraph" files=".*"/>
+  <suppress checks="JavadocTagContinuationIndentation" files=".*"/>
+  <suppress checks="SingleLineJavadoc" files=".*"/>
+  <suppress checks="SummaryJavadoc" files=".*"/>
+</suppressions>

--- a/embulk-deps/guess/src/main/java/org/embulk/deps/guess/CharsetDetectorImpl.java
+++ b/embulk-deps/guess/src/main/java/org/embulk/deps/guess/CharsetDetectorImpl.java
@@ -1,0 +1,22 @@
+package org.embulk.deps.guess;
+
+import com.ibm.icu.text.CharsetDetector;
+
+public final class CharsetDetectorImpl extends org.embulk.deps.guess.CharsetDetector {
+    public CharsetDetectorImpl() {
+        this.detector = new CharsetDetector();
+    }
+
+    @Override
+    public CharsetDetectorImpl setText(final byte[] in) {
+        this.detector.setText(in);
+        return this;
+    }
+
+    @Override
+    public CharsetMatchImpl detect() {
+        return new CharsetMatchImpl(this.detector.detect());
+    }
+
+    private final CharsetDetector detector;
+}

--- a/embulk-deps/guess/src/main/java/org/embulk/deps/guess/CharsetMatchImpl.java
+++ b/embulk-deps/guess/src/main/java/org/embulk/deps/guess/CharsetMatchImpl.java
@@ -1,0 +1,21 @@
+package org.embulk.deps.guess;
+
+import com.ibm.icu.text.CharsetMatch;
+
+public final class CharsetMatchImpl extends org.embulk.deps.guess.CharsetMatch {
+    CharsetMatchImpl(final CharsetMatch match) {
+        this.match = match;
+    }
+
+    @Override
+    public int getConfidence() {
+        return this.match.getConfidence();
+    }
+
+    @Override
+    public String getName() {
+        return this.match.getName();
+    }
+
+    private final CharsetMatch match;
+}

--- a/embulk-deps/guess/src/test/java/org/embulk/deps/guess/TestCharsetDetectorImpl.java
+++ b/embulk-deps/guess/src/test/java/org/embulk/deps/guess/TestCharsetDetectorImpl.java
@@ -1,0 +1,16 @@
+package org.embulk.deps.guess;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public class TestCharsetDetectorImpl {
+    @Test
+    public void testDefault() {
+        final CharsetDetectorImpl detector = new CharsetDetectorImpl();
+        detector.setText("あいうえお".getBytes(StandardCharsets.UTF_8));
+        final CharsetMatchImpl match = detector.detect();
+        assertEquals("UTF-8", match.getName());
+    }
+}

--- a/embulk-standards/build.gradle
+++ b/embulk-standards/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     // TODO: Remove this, and load it with the proper DependencyClassLoader.
     // This statement gets it loaded by the top-level ClassLoader.
     testCompile project(':embulk-deps-buffer')
+    testCompile project(':embulk-deps-guess')
 
     jrubyExec 'rubygems:simplecov:0.10.+'
     jrubyExec 'rubygems:test-unit:3.0.+'
@@ -45,7 +46,7 @@ jruby {
     execVersion = rootProject.jrubyVersion
 }
 
-task rubyTestVanilla(type: JRubyExec, dependsOn: ["jar", "prepareDependencyJars", ":embulk-deps-buffer:prepareDependencyJars"]) {
+task rubyTestVanilla(type: JRubyExec, dependsOn: ["jar", "prepareDependencyJars", ":embulk-deps-buffer:prepareDependencyJars", ":embulk-deps-guess:prepareDependencyJars"]) {
     jrubyArgs '-Isrc/main/ruby', '-Isrc/test/ruby', '--debug', './src/test/ruby/vanilla/run-test.rb'
 }
 test.dependsOn(['rubyTestVanilla'])

--- a/embulk-standards/src/test/ruby/vanilla/run-test.rb
+++ b/embulk-standards/src/test/ruby/vanilla/run-test.rb
@@ -26,6 +26,9 @@ static_initializer = Java::org.embulk.deps.EmbulkDependencyClassLoaders.staticIn
 each_jar_in(File.join(root_dir, 'embulk-deps', 'buffer', 'build', 'dependency_jars')) do |jar|
   static_initializer.addDependency(Java::org.embulk.deps.DependencyCategory::BUFFER, java.nio.file.Paths.get(jar.to_s))
 end
+each_jar_in(File.join(root_dir, 'embulk-deps', 'guess', 'build', 'dependency_jars')) do |jar|
+  static_initializer.addDependency(Java::org.embulk.deps.DependencyCategory::GUESS, java.nio.file.Paths.get(jar.to_s))
+end
 # https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#calling-masked-or-unreachable-java-methods-with-java_send
 static_initializer.java_send :initialize
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,8 @@ include 'embulk-deps-buffer'
 project(':embulk-deps-buffer').projectDir = file('embulk-deps/buffer')
 include 'embulk-deps-cli'
 project(':embulk-deps-cli').projectDir = file('embulk-deps/cli')
+include 'embulk-deps-guess'
+project(':embulk-deps-guess').projectDir = file('embulk-deps/guess')
 include 'embulk-deps-maven'
 project(':embulk-deps-maven').projectDir = file('embulk-deps/maven')
 include 'embulk-standards'


### PR DESCRIPTION
Next to #1201 (Netty Buffer) and #1204 (Airlift Slice), we're moving ICU4J that has been used for charset detection in Embulk's guess.

The entry point is just `CharsetDetector`. But as `CharsetDetector#detect` returns `CharsetMatch`, we have `CharsetMatch`, too.
