### PR TITLE
Check dependency vulnerability semi-automatically with org.owasp:dependency-check-gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         classpath 'com.github.jruby-gradle:jruby-gradle-jar-plugin:1.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'org.ajoberstar.grgit:grgit-gradle:3.0.0'
+        classpath "org.owasp:dependency-check-gradle:5.2.1"
     }
 }
 
@@ -51,6 +52,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'org.ajoberstar.grgit'
+apply plugin: "org.owasp.dependencycheck"
 
 version = '0.9.21-SNAPSHOT'
 


### PR DESCRIPTION
GitHub's vulnerability alert does not support Gradle unfortunately, but we'd want some checks for vulnerability. As the very first step, introducing a dependency checker Gradle plugin in our build.gradle.