### PR TITLE
Download dependency gems without JRuby/Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,9 @@
-// TODO: Remove this block once we re-upgrade jruby-gradle-jar-plugin..
-// See #1: https://github.com/embulk/embulk/issues/954
-// See #2: https://github.com/jruby-gradle/jruby-gradle-plugin/issues/297
-repositories {
-    mavenLocal()
-    maven { url 'http://rubygems-proxy.torquebox.org/releases' }
-}
-
 buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
-        // TODO: Re-upgrade jruby-gradle-jar-plugin.
-        // See: https://github.com/embulk/embulk/issues/954
-        classpath 'com.github.jruby-gradle:jruby-gradle-jar-plugin:1.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'org.ajoberstar.grgit:grgit-gradle:3.0.0'
         classpath "org.owasp:dependency-check-gradle:5.2.1"

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -1,13 +1,3 @@
-// TODO: Remove this block once we re-upgrade jruby-gradle-jar-plugin..
-// See #1: https://github.com/embulk/embulk/issues/954
-// See #2: https://github.com/jruby-gradle/jruby-gradle-plugin/issues/297
-repositories {
-    mavenLocal()
-    maven { url 'http://rubygems-proxy.torquebox.org/releases' }
-}
-
-apply plugin: 'com.github.jruby-gradle.jar'
-
 // TODO: Have more details in description and summary.
 description = 'Embulk core'
 ext {
@@ -24,9 +14,6 @@ configurations {
     compile.exclude group: 'asm', module: 'asm'
     compile.exclude group: 'org.sonatype.sisu.inject', module: 'cglib'
 }
-
-import com.github.jrubygradle.JRubyExec
-import com.github.jrubygradle.JRubyPrepare
 
 repositories {
     mavenCentral()
@@ -65,25 +52,31 @@ dependencies {
     testCompile project(':embulk-deps-buffer')
     testCompile project(':embulk-deps-config')
     testCompile project(':embulk-deps-guess')
-
-    gems 'rubygems:bundler:1.16.0'
-    gems 'rubygems:msgpack:1.1.0'
-    gems 'rubygems:liquid:4.0.0'
-
-    jrubyExec 'rubygems:simplecov:0.10.+'
-    jrubyExec 'rubygems:test-unit:3.0.+'
 }
 
-jruby {
-    execVersion = rootProject.jrubyVersion
+task rubyTestVanilla(type: JavaExec, dependsOn: [
+        "jar",
+        "prepareDependencyJars",
+        "installDependencyGems",
+        ":embulk-deps-buffer:prepareDependencyJars",
+        ":embulk-deps-config:prepareDependencyJars",
+        ":embulk-deps-guess:prepareDependencyJars",
+        ]) {
+    workingDir = file("${projectDir}");
+    classpath = sourceSets.main.runtimeClasspath  // Not "configurations.runtimeClasspath" to use compiled embulk-core
+    main = "org.jruby.Main"
+    args = ["-Isrc/main/ruby", "-Isrc/test/ruby", "--debug", "./src/test/ruby/vanilla/run-test.rb"]
+    environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
 }
 
-task rubyTestVanilla(type: JRubyExec, dependsOn: ["jar", "prepareDependencyJars", ":embulk-deps-buffer:prepareDependencyJars", ":embulk-deps-config:prepareDependencyJars", ":embulk-deps-guess:prepareDependencyJars"]) {
-    jrubyArgs '-Isrc/main/ruby', '-Isrc/test/ruby', '--debug', './src/test/ruby/vanilla/run-test.rb'
+task rubyTestMonkeyStrptime(type: JavaExec, dependsOn: ["jar"]) {
+    workingDir = file("${project.projectDir}");
+    classpath = sourceSets.main.runtimeClasspath  // Not "configurations.runtimeClasspath" to use compiled embulk-core
+    main = "org.jruby.Main"
+    args = ["-Isrc/main/ruby", "-Isrc/test/ruby", "--debug", "./src/test/ruby/monkey_strptime/run-test.rb"]
+    environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
 }
-task rubyTestMonkeyStrptime(type: JRubyExec) {
-    jrubyArgs '-Isrc/main/ruby', '-Isrc/test/ruby', '--debug', './src/test/ruby/monkey_strptime/run-test.rb'
-}
+
 test.dependsOn(['rubyTestVanilla', 'rubyTestMonkeyStrptime', ":test-helpers:deploy"])
 
 String buildRubyStyleVersionFromJavaStyleVersion(String javaStyleVersion) {
@@ -99,24 +92,34 @@ String buildRubyStyleVersionFromJavaStyleVersion(String javaStyleVersion) {
     }
 }
 
-task unpackDependencyGems(type: JRubyPrepare) {
+task installDependencyGems(type: JavaExec) {
+    doFirst {
+        delete("${buildDir}/dependency_gems_installed")
+        mkdir("${buildDir}/dependency_gems_installed")
+    }
+
+    workingDir = file("${projectDir}")
+    classpath = configurations.runtimeClasspath  // Not "sourceSets.main.runtimeClasspath" not to depend on "jar"
+    main = "org.jruby.Main"
+    args = ["-S", "gem", "install", "msgpack:1.1.0", "bundler:1.16.0", "liquid:4.0.0", "simplecov:0.10.0", "test-unit:3.0.9"]
+    environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
+}
+
+task unpackDependencyGems(type: Copy, dependsOn: "installDependencyGems") {
     doFirst {
         delete("${buildDir}/dependency_gems_as_resources")
     }
-    outputDir file("${buildDir}/dependency_gems_installed")
-    dependencies configurations.gems
+
+    from "${buildDir}/dependency_gems_installed"
+    into "${buildDir}/dependency_gems_as_resources"
+    include "gems/bundler-1.16.0/**"
+    include "gems/liquid-4.0.0/**"
+    include "gems/msgpack-1.1.0-java/**"
+    include "specifications/bundler-1.16.0.gemspec"
+    include "specifications/liquid-4.0.0.gemspec"
+    include "specifications/msgpack-1.1.0-java.gemspec"
+
     doLast {
-        configurations.gems.each { gemFilePath ->
-            copy {
-                from "${buildDir}/dependency_gems_installed"
-                into "${buildDir}/dependency_gems_as_resources"
-                // These "include" may contain both pure-Ruby and JRuby gems, e.g. "msgpack" and "msgpack-java".
-                // TODO: Specify exact pure-Ruby or JRuby gems.
-                include "gems/${gemFilePath.name.take(gemFilePath.name.lastIndexOf('.'))}/**"
-                include "gems/${gemFilePath.name.take(gemFilePath.name.lastIndexOf('.'))}-java/**"
-                include "specifications/${gemFilePath.name.take(gemFilePath.name.lastIndexOf('.'))}*.gemspec"
-            }
-        }
         fileTree(dir: "${buildDir}/dependency_gems_as_resources", include: "**/.jrubydir").each { f -> f.delete() }
     }
 }

--- a/embulk-deps/buffer/build.gradle
+++ b/embulk-deps/buffer/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testCompile "junit:junit:4.12"
 }
 
-task prepareDependencyJars(type: Copy) {
+task prepareDependencyJars(type: Copy, dependsOn: "jar") {
     doFirst {
         delete("${buildDir}/dependency_jars")
     }

--- a/embulk-deps/config/build.gradle
+++ b/embulk-deps/config/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testCompile "junit:junit:4.12"
 }
 
-task prepareDependencyJars(type: Copy) {
+task prepareDependencyJars(type: Copy, dependsOn: "jar") {
     doFirst {
         delete("${buildDir}/dependency_jars")
     }

--- a/embulk-deps/guess/build.gradle
+++ b/embulk-deps/guess/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testCompile "junit:junit:4.12"
 }
 
-task prepareDependencyJars(type: Copy) {
+task prepareDependencyJars(type: Copy, dependsOn: "jar") {
     doFirst {
         delete("${buildDir}/dependency_jars")
     }

--- a/embulk-docs/build.gradle
+++ b/embulk-docs/build.gradle
@@ -1,20 +1,13 @@
-// TODO: Remove this block once we re-upgrade jruby-gradle-jar-plugin..
-// See #1: https://github.com/embulk/embulk/issues/954
-// See #2: https://github.com/jruby-gradle/jruby-gradle-plugin/issues/297
 repositories {
-    mavenLocal()
-    maven { url 'http://rubygems-proxy.torquebox.org/releases' }
+    mavenCentral()
 }
 
-apply plugin: 'com.github.jruby-gradle.base'
-
-import com.github.jrubygradle.JRubyExec
-jruby {
-    execVersion = rootProject.jrubyVersion
+configurations {
+    rdocRuntime
 }
 
 dependencies {
-    jrubyExec 'rubygems:yard:0.9.12'
+    rdocRuntime "org.jruby:jruby-complete:" + rootProject.jrubyVersion
 }
 
 task sphinxHtml(type: Exec) {
@@ -29,11 +22,25 @@ task javadocHtml(type: Copy, dependsOn: [':embulk-core:javadoc']) {
     into 'build/html/javadoc'
 }
 
-task rdocHtml(type: JRubyExec) {
+task installGems(type: JavaExec) {
+    doFirst {
+        delete("${buildDir}/gems")
+        mkdir("${buildDir}/gems")
+    }
+
+    workingDir = file("${projectDir}")
+    classpath = configurations.rdocRuntime
+    main = "org.jruby.Main"
+    args = ["-S", "gem", "install", "yard:0.9.12"]
+    environment "GEM_HOME": "${buildDir}/gems"
+}
+
+task rdocHtml(type: JavaExec, dependsOn: "installGems") {
     workingDir '..'
-    jrubyArgs '-ryard', '-eYARD::CLI::Yardoc.run(*ARGV)'
-    script './embulk-core/src/main/ruby/embulk/version.rb'  // dummy
-    scriptArgs 'embulk-core/src/main/ruby', '-o', 'embulk-docs/build/html/rdoc'
+    classpath = configurations.rdocRuntime
+    main = "org.jruby.Main"
+    args = ["-ryard", "-eYARD::CLI::Yardoc.run('embulk-core/src/main/ruby', '-o', 'embulk-docs/build/html/rdoc')"]
+    environment "GEM_HOME": "${buildDir}/gems"
 }
 
 task site(type: Copy, dependsOn: ['sphinxHtml', 'rdocHtml', 'javadocHtml']) {

--- a/embulk-standards/build.gradle
+++ b/embulk-standards/build.gradle
@@ -1,13 +1,3 @@
-// TODO: Remove this block once we re-upgrade jruby-gradle-jar-plugin..
-// See #1: https://github.com/embulk/embulk/issues/954
-// See #2: https://github.com/jruby-gradle/jruby-gradle-plugin/issues/297
-repositories {
-    mavenLocal()
-    maven { url 'http://rubygems-proxy.torquebox.org/releases' }
-}
-
-apply plugin: 'com.github.jruby-gradle.jar'
-
 // TODO: Have more details in description and summary.
 description = 'Embulk standard plugins'
 ext {
@@ -17,8 +7,6 @@ ext {
 // include ruby scripts to jar. don't use sourceSets.main.resources.srcDirs
 // because IntelliJ causes error if srcDirs includes files out of projectDir.
 processResources.from("${buildDir}/embulk_gem_complements")
-
-import com.github.jrubygradle.JRubyExec
 
 repositories {
     mavenCentral()
@@ -38,19 +26,36 @@ dependencies {
     testCompile project(':embulk-deps-buffer')
     testCompile project(':embulk-deps-config')
     testCompile project(':embulk-deps-guess')
-
-    jrubyExec 'rubygems:simplecov:0.10.+'
-    jrubyExec 'rubygems:test-unit:3.0.+'
 }
 
-jruby {
-    execVersion = rootProject.jrubyVersion
-}
-
-task rubyTestVanilla(type: JRubyExec, dependsOn: ["jar", "prepareDependencyJars", ":embulk-deps-buffer:prepareDependencyJars", ":embulk-deps-config:prepareDependencyJars", ":embulk-deps-guess:prepareDependencyJars"]) {
-    jrubyArgs '-Isrc/main/ruby', '-Isrc/test/ruby', '--debug', './src/test/ruby/vanilla/run-test.rb'
+task rubyTestVanilla(type: JavaExec, dependsOn: [
+        "jar",
+        "prepareDependencyJars",
+        "installDependencyGems",
+        ":embulk-deps-buffer:prepareDependencyJars",
+        ":embulk-deps-config:prepareDependencyJars",
+        ":embulk-deps-guess:prepareDependencyJars",
+        ]) {
+    workingDir = file("${project.projectDir}");
+    classpath = sourceSets.main.runtimeClasspath  // Not "configurations.runtimeClasspath" to use compiled embulk-core
+    main = "org.jruby.Main"
+    args = ["-Isrc/main/ruby", "-Isrc/test/ruby", "--debug", "./src/test/ruby/vanilla/run-test.rb"]
+    environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
 }
 test.dependsOn(['rubyTestVanilla'])
+
+task installDependencyGems(type: JavaExec) {
+    doFirst {
+        delete("${buildDir}/dependency_gems_installed")
+        mkdir("${buildDir}/dependency_gems_installed")
+    }
+
+    workingDir = file("${projectDir}")
+    classpath = configurations.runtimeClasspath  // Not "sourceSets.main.runtimeClasspath" not to depend on "jar"
+    main = "org.jruby.Main"
+    args = ["-S", "gem", "install", "simplecov:0.10.0", "test-unit:3.0.9"]
+    environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
+}
 
 String buildRubyStyleVersionFromJavaStyleVersion(String javaStyleVersion) {
     if (javaStyleVersion.contains('-')) {


### PR DESCRIPTION
Unfortunately, `rubygems-proxy.torquebox.org` stopped working as well as `rubygems.lasagna.io`.
* https://twitter.com/ysb33r/status/1207616778320465927
* https://twitter.com/ysb33r/status/1207617136069361664
* https://twitter.com/ysb33r/status/1207617434569641984

`rubygems-proxy.torquebox.org` has been an alternative workaround against JRuby/Gradle plugin's originally expected `rubygems.lasagna.io`. But neither is working now.
* https://github.com/jruby-gradle/jruby-gradle-plugin/issues/384

They are expected to take a long time to recover. It's time to drop the JRuby/Gradle plugin, and download those gems by ourselves in `build.gradle`.

----

This PR :
* Drops the use of JRuby/Gradle plugin
* Removes the references to the RubyGems/Maven proxy repository
* Downloads the dependency and test gems by itself with invoking `gem` command with JRuby