### PR TITLE
Upgrade to Gradle 6.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,10 @@
-buildscript {
-    repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
-    }
-    dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'org.ajoberstar.grgit:grgit-gradle:3.0.0'
-        classpath "org.owasp:dependency-check-gradle:5.2.1"
-    }
+plugins {
+    id "java"
+    id "maven-publish"
+    id "jacoco"
+    id "com.github.johnrengelman.shadow" version "5.2.0"
+    id "com.jfrog.bintray" version "1.8.4"
+    id "org.ajoberstar.grgit" version "4.0.1"
 }
 
 def getRevision = { ->
@@ -37,12 +34,6 @@ allprojects {  // Applies all projects including the root project as well.
     }
 }
 
-apply plugin: 'maven-publish'
-apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: 'com.jfrog.bintray'
-apply plugin: 'org.ajoberstar.grgit'
-apply plugin: "org.owasp.dependencycheck"
-
 version = '0.10.0-SNAPSHOT'
 
 description = 'Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control.'
@@ -55,7 +46,6 @@ ext {
 configure(subprojects.findAll { ['embulk-core', 'embulk-deps-buffer', 'embulk-deps-cli', 'embulk-deps-guess', 'embulk-deps-config', 'embulk-deps-maven', 'embulk-standards', 'embulk-test'].contains(it.name) }) {
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
-    apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
     // TODO: Enable SpotBugs instead of FindBugs which was used in Embulk until v0.9.17.
@@ -195,12 +185,12 @@ configurations {
 }
 
 dependencies {
-    compile project(':embulk-core')
-    compile project(':embulk-standards')
+    implementation project(':embulk-core')
+    implementation project(':embulk-standards')
 
     // Logback and jansi are included only in the executable package. (jansi for logback colors to work on Windows.)
-    compile 'ch.qos.logback:logback-classic:1.1.3'
-    compile 'org.fusesource.jansi:jansi:1.11'
+    implementation 'ch.qos.logback:logback-classic:1.1.3'
+    implementation 'org.fusesource.jansi:jansi:1.11'
 
     embed project(':embulk-deps-buffer')
 
@@ -236,10 +226,11 @@ def listEmbedDependencies = { rootModuleName, prefix ->
 task embeddedJarsJar(type: Jar) {
     doFirst {
         delete file("$buildDir/embeddedJars")
+        mkdir file("$buildDir/embeddedJars")
     }
-    baseName = 'embulk-embedded'
+    archiveBaseName = "embulk-embedded"
     classifier = null
-    destinationDir file("$buildDir/embeddedJars")
+    destinationDirectory = file("$buildDir/embeddedJars")
     exclude 'META-INF/**'
     into('/lib') {
         from configurations.embed

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -11,8 +11,10 @@ processResources.from("${buildDir}/embulk_gem_as_resources", "${buildDir}/depend
 configurations {
     // com.google.inject:guice depends on asm and cglib but version of the libraries conflict
     // with ones bundled in jruby-complete and cause bytecode compatibility error
-    compile.exclude group: 'asm', module: 'asm'
-    compile.exclude group: 'org.sonatype.sisu.inject', module: 'cglib'
+    implementation.exclude group: "asm", module: "asm"
+    implementation.exclude group: "org.sonatype.sisu.inject", module: "cglib"
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
 }
 
 repositories {
@@ -21,37 +23,37 @@ repositories {
 
 // determine which dependencies have updates: $ gradle dependencyUpdates
 dependencies {
-    compile 'com.google.guava:guava:18.0'
-    compile 'com.google.inject:guice:4.0'
-    compile 'com.google.inject.extensions:guice-multibindings:4.0'
-    compile 'javax.inject:javax.inject:1'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.6.7'
-    compile 'com.fasterxml.jackson.core:jackson-core:2.6.7'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.6.7'
-    compile 'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7'
-    compile 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7'
-    compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7'
-    compile 'com.fasterxml.jackson.module:jackson-module-guice:2.6.7'
-    compile 'org.slf4j:slf4j-api:1.7.12'
-    compile 'org.jruby:jruby-complete:' + rootProject.jrubyVersion
-    compile 'javax.validation:validation-api:1.1.0.Final'
-    compile 'org.apache.bval:bval-jsr303:0.5'
-    compile 'joda-time:joda-time:2.9.2'
-    compile 'org.msgpack:msgpack-core:0.8.11'
+    implementation "com.google.guava:guava:18.0"
+    implementation "com.google.inject:guice:4.0"
+    implementation "com.google.inject.extensions:guice-multibindings:4.0"
+    implementation "javax.inject:javax.inject:1"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.6.7"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.6.7"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7"
+    implementation "com.fasterxml.jackson.module:jackson-module-guice:2.6.7"
+    implementation "org.slf4j:slf4j-api:1.7.12"
+    implementation "org.jruby:jruby-complete:" + rootProject.jrubyVersion
+    implementation "javax.validation:validation-api:1.1.0.Final"
+    implementation "org.apache.bval:bval-jsr303:0.5"
+    implementation "joda-time:joda-time:2.9.2"
+    implementation "org.msgpack:msgpack-core:0.8.11"
 
     // bval-jsr303:0.5 depends on commons-lang3:3.1,
     // but it was upgraded to 3.4 when maven-aether-provider:3.3.9 was introduced.
     // Maven-related dependencies are moved to embulk-deps-maven.
-    compile 'org.apache.commons:commons-lang3:3.4'
+    implementation "org.apache.commons:commons-lang3:3.4"
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'ch.qos.logback:logback-classic:1.1.3'
+    testImplementation "junit:junit:4.12"
+    testImplementation "ch.qos.logback:logback-classic:1.1.3"
 
     // TODO: Remove this, and load it with the proper DependencyClassLoader.
     // This statement gets it loaded by the top-level ClassLoader.
-    testCompile project(':embulk-deps-buffer')
-    testCompile project(':embulk-deps-config')
-    testCompile project(':embulk-deps-guess')
+    testImplementation project(":embulk-deps-buffer")
+    testImplementation project(":embulk-deps-config")
+    testImplementation project(":embulk-deps-guess")
 }
 
 task rubyTestVanilla(type: JavaExec, dependsOn: [
@@ -222,8 +224,10 @@ task updateResources(dependsOn: 'prepareDependencyJars') {
 
 task prepareDependencyJars(type: Copy) {
     doFirst {
-        delete("${buildDir}/dependency_jars")
+        delete file("${buildDir}/dependency_jars")
+        mkdir file("${buildDir}/dependency_jars")
     }
-    from configurations.runtime + files("${project.libsDir}/${project.name}-${project.version}.jar")
     into "${buildDir}/dependency_jars"
+    from configurations.runtimeClasspath
+    from jar.outputs.files
 }

--- a/embulk-core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-core/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,24 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
+com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
+com.google.inject:guice:4.0
+commons-beanutils:commons-beanutils-core:1.8.3
+javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
+org.apache.commons:commons-lang3:3.4
+org.jruby:jruby-complete:9.1.15.0
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12

--- a/embulk-core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,24 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
+com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
+com.google.inject:guice:4.0
+commons-beanutils:commons-beanutils-core:1.8.3
+javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
+org.apache.commons:commons-lang3:3.4
+org.jruby:jruby-complete:9.1.15.0
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12

--- a/embulk-deps/buffer/build.gradle
+++ b/embulk-deps/buffer/build.gradle
@@ -7,19 +7,26 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
+
 dependencies {
     compileOnly project(":embulk-core")
-    compile "io.netty:netty-buffer:4.0.44.Final"
-    compile "io.airlift:slice:0.9"
+    implementation "io.netty:netty-buffer:4.0.44.Final"
+    implementation "io.airlift:slice:0.9"
 
-    testCompile project(":embulk-core")
-    testCompile "junit:junit:4.12"
+    testImplementation project(":embulk-core")
+    testImplementation "junit:junit:4.12"
 }
 
 task prepareDependencyJars(type: Copy, dependsOn: "jar") {
     doFirst {
-        delete("${buildDir}/dependency_jars")
+        delete file("${buildDir}/dependency_jars")
+        mkdir file("${buildDir}/dependency_jars")
     }
-    from configurations.runtime + files("${project.libsDir}/${project.name}-${project.version}.jar")
     into "${buildDir}/dependency_jars"
+    from configurations.runtimeClasspath
+    from jar.outputs.files
 }

--- a/embulk-deps/buffer/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/buffer/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,6 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+io.airlift:slice:0.9
+io.netty:netty-buffer:4.0.44.Final
+io.netty:netty-common:4.0.44.Final

--- a/embulk-deps/buffer/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-deps/buffer/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,6 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+io.airlift:slice:0.9
+io.netty:netty-buffer:4.0.44.Final
+io.netty:netty-common:4.0.44.Final

--- a/embulk-deps/cli/build.gradle
+++ b/embulk-deps/cli/build.gradle
@@ -7,12 +7,17 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
+
 dependencies {
     compileOnly project(':embulk-core')
 
-    compile 'commons-cli:commons-cli:1.3.1'
-    compile 'org.apache.velocity:velocity:1.7'
+    implementation "commons-cli:commons-cli:1.3.1"
+    implementation "org.apache.velocity:velocity:1.7"
 
-    testCompile project(':embulk-core')
-    testCompile 'junit:junit:4.12'
+    testImplementation project(":embulk-core")
+    testImplementation "junit:junit:4.12"
 }

--- a/embulk-deps/cli/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/cli/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,7 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+commons-cli:commons-cli:1.3.1
+commons-collections:commons-collections:3.2.1
+commons-lang:commons-lang:2.4
+org.apache.velocity:velocity:1.7

--- a/embulk-deps/cli/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-deps/cli/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,7 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+commons-cli:commons-cli:1.3.1
+commons-collections:commons-collections:3.2.1
+commons-lang:commons-lang:2.4
+org.apache.velocity:velocity:1.7

--- a/embulk-deps/config/build.gradle
+++ b/embulk-deps/config/build.gradle
@@ -7,19 +7,26 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
+
 dependencies {
     compileOnly project(":embulk-core")
 
-    compile 'org.yaml:snakeyaml:1.18'
+    implementation 'org.yaml:snakeyaml:1.18'
 
-    testCompile project(":embulk-core")
-    testCompile "junit:junit:4.12"
+    testImplementation project(":embulk-core")
+    testImplementation "junit:junit:4.12"
 }
 
 task prepareDependencyJars(type: Copy, dependsOn: "jar") {
     doFirst {
-        delete("${buildDir}/dependency_jars")
+        delete file("${buildDir}/dependency_jars")
+        mkdir file("${buildDir}/dependency_jars")
     }
-    from configurations.runtime + files("${project.libsDir}/${project.name}-${project.version}.jar")
     into "${buildDir}/dependency_jars"
+    from configurations.runtimeClasspath
+    from jar.outputs.files
 }

--- a/embulk-deps/config/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/config/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.yaml:snakeyaml:1.18

--- a/embulk-deps/config/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-deps/config/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.yaml:snakeyaml:1.18

--- a/embulk-deps/guess/build.gradle
+++ b/embulk-deps/guess/build.gradle
@@ -7,20 +7,27 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
+
 dependencies {
     compileOnly project(":embulk-core")
 
     // For embulk/guess/charset.rb. See also embulk.gemspec
-    compile "com.ibm.icu:icu4j:54.1.1"
+    implementation "com.ibm.icu:icu4j:54.1.1"
 
-    testCompile project(":embulk-core")
-    testCompile "junit:junit:4.12"
+    testImplementation project(":embulk-core")
+    testImplementation "junit:junit:4.12"
 }
 
 task prepareDependencyJars(type: Copy, dependsOn: "jar") {
     doFirst {
-        delete("${buildDir}/dependency_jars")
+        delete file("${buildDir}/dependency_jars")
+        mkdir file("${buildDir}/dependency_jars")
     }
-    from configurations.runtime + files("${project.libsDir}/${project.name}-${project.version}.jar")
     into "${buildDir}/dependency_jars"
+    from configurations.runtimeClasspath
+    from jar.outputs.files
 }

--- a/embulk-deps/guess/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/guess/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+com.ibm.icu:icu4j:54.1.1

--- a/embulk-deps/guess/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-deps/guess/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+com.ibm.icu:icu4j:54.1.1

--- a/embulk-deps/maven/build.gradle
+++ b/embulk-deps/maven/build.gradle
@@ -7,22 +7,27 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
+
 dependencies {
     compileOnly project(":embulk-core")
 
-    compile "org.apache.maven:maven-artifact:3.6.1"
-    compile "org.apache.maven.resolver:maven-resolver-api:1.3.3"
-    compile "org.apache.maven.resolver:maven-resolver-spi:1.3.3"
-    compile "org.apache.maven.resolver:maven-resolver-util:1.3.3"
-    compile("org.apache.maven.resolver:maven-resolver-impl:1.3.3") {
+    implementation "org.apache.maven:maven-artifact:3.6.1"
+    implementation "org.apache.maven.resolver:maven-resolver-api:1.3.3"
+    implementation "org.apache.maven.resolver:maven-resolver-spi:1.3.3"
+    implementation "org.apache.maven.resolver:maven-resolver-util:1.3.3"
+    implementation("org.apache.maven.resolver:maven-resolver-impl:1.3.3") {
         exclude group: "org.slf4j", module: "slf4j-api"  // Included in embulk-core.
     }
-    compile("org.apache.maven:maven-resolver-provider:3.6.1") {
+    implementation("org.apache.maven:maven-resolver-provider:3.6.1") {
         exclude group: "javax.inject", module: "javax.inject"  // Included in embulk-core.
         exclude group: "com.google.inject", module: "guice"  // Included in embulk-core.
         exclude group: "org.slf4j", module: "slf4j-api"  // Included in embulk-core.
     }
 
-    testCompile project(":embulk-core")
-    testCompile "junit:junit:4.12"
+    testImplementation project(":embulk-core")
+    testImplementation "junit:junit:4.12"
 }

--- a/embulk-deps/maven/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/maven/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,17 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apache.commons:commons-lang3:3.8.1
+org.apache.maven.resolver:maven-resolver-api:1.3.3
+org.apache.maven.resolver:maven-resolver-impl:1.3.3
+org.apache.maven.resolver:maven-resolver-spi:1.3.3
+org.apache.maven.resolver:maven-resolver-util:1.3.3
+org.apache.maven:maven-artifact:3.6.1
+org.apache.maven:maven-builder-support:3.6.1
+org.apache.maven:maven-model-builder:3.6.1
+org.apache.maven:maven-model:3.6.1
+org.apache.maven:maven-repository-metadata:3.6.1
+org.apache.maven:maven-resolver-provider:3.6.1
+org.codehaus.plexus:plexus-component-annotations:1.7.1
+org.codehaus.plexus:plexus-interpolation:1.25
+org.codehaus.plexus:plexus-utils:3.2.0

--- a/embulk-deps/maven/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-deps/maven/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,17 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apache.commons:commons-lang3:3.8.1
+org.apache.maven.resolver:maven-resolver-api:1.3.3
+org.apache.maven.resolver:maven-resolver-impl:1.3.3
+org.apache.maven.resolver:maven-resolver-spi:1.3.3
+org.apache.maven.resolver:maven-resolver-util:1.3.3
+org.apache.maven:maven-artifact:3.6.1
+org.apache.maven:maven-builder-support:3.6.1
+org.apache.maven:maven-model-builder:3.6.1
+org.apache.maven:maven-model:3.6.1
+org.apache.maven:maven-repository-metadata:3.6.1
+org.apache.maven:maven-resolver-provider:3.6.1
+org.codehaus.plexus:plexus-component-annotations:1.7.1
+org.codehaus.plexus:plexus-interpolation:1.25
+org.codehaus.plexus:plexus-utils:3.2.0

--- a/embulk-standards/build.gradle
+++ b/embulk-standards/build.gradle
@@ -12,20 +12,46 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    compile project(':embulk-core')
-    compile 'org.apache.commons:commons-compress:1.10'
+configurations {
+    jruby
+    rubyTestRuntime
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
 
-    testCompile 'junit:junit:4.12'
-    testCompile project(':embulk-core').sourceSets.test.output
-    testCompile project(':embulk-test')
-    testCompile 'ch.qos.logback:logback-classic:1.1.3'
+dependencies {
+    compileOnly project(":embulk-core")
+    compileOnly "com.google.guava:guava:18.0"
+    compileOnly "com.google.inject:guice:4.0"
+    compileOnly "com.fasterxml.jackson.core:jackson-core:2.6.7"
+    compileOnly "com.fasterxml.jackson.core:jackson-databind:2.6.7"
+    compileOnly "javax.validation:validation-api:1.1.0.Final"
+    compileOnly "joda-time:joda-time:2.9.2"
+    compileOnly "org.msgpack:msgpack-core:0.8.11"
+    compileOnly "org.slf4j:slf4j-api:1.7.12"
+
+    implementation "org.apache.commons:commons-compress:1.10"
+
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.hamcrest:hamcrest-library:1.3"
+    testImplementation project(":embulk-core")
+    testImplementation project(":embulk-core").sourceSets.test.output
+    testImplementation project(":embulk-test")
+    testImplementation "ch.qos.logback:logback-classic:1.1.3"
+
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.6.7"
+    testImplementation "com.google.guava:guava:18.0"
+    testImplementation "joda-time:joda-time:2.9.2"
+    testImplementation "org.msgpack:msgpack-core:0.8.11"
 
     // TODO: Remove this, and load it with the proper DependencyClassLoader.
     // This statement gets it loaded by the top-level ClassLoader.
-    testCompile project(':embulk-deps-buffer')
-    testCompile project(':embulk-deps-config')
-    testCompile project(':embulk-deps-guess')
+    testImplementation project(":embulk-deps-buffer")
+    testImplementation project(":embulk-deps-config")
+    testImplementation project(":embulk-deps-guess")
+
+    jruby "org.jruby:jruby-complete:" + rootProject.jrubyVersion
+    rubyTestRuntime project(":embulk-core")
 }
 
 task rubyTestVanilla(type: JavaExec, dependsOn: [
@@ -37,7 +63,7 @@ task rubyTestVanilla(type: JavaExec, dependsOn: [
         ":embulk-deps-guess:prepareDependencyJars",
         ]) {
     workingDir = file("${project.projectDir}");
-    classpath = sourceSets.main.runtimeClasspath  // Not "configurations.runtimeClasspath" to use compiled embulk-core
+    classpath = configurations.rubyTestRuntime
     main = "org.jruby.Main"
     args = ["-Isrc/main/ruby", "-Isrc/test/ruby", "--debug", "./src/test/ruby/vanilla/run-test.rb"]
     environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
@@ -51,7 +77,7 @@ task installDependencyGems(type: JavaExec) {
     }
 
     workingDir = file("${projectDir}")
-    classpath = configurations.runtimeClasspath  // Not "sourceSets.main.runtimeClasspath" not to depend on "jar"
+    classpath = configurations.jruby
     main = "org.jruby.Main"
     args = ["-S", "gem", "install", "simplecov:0.10.0", "test-unit:3.0.9"]
     environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
@@ -72,10 +98,11 @@ String buildRubyStyleVersionFromJavaStyleVersion(String javaStyleVersion) {
 
 task prepareDependencyJars(type: Copy) {
     doFirst {
-        delete("${buildDir}/dependency_jars")
+        delete file("${buildDir}/dependency_jars")
+        mkdir file("${buildDir}/dependency_jars")
     }
-    from configurations.runtime
     into "${buildDir}/dependency_jars"
+    from configurations.runtimeClasspath
 }
 
 task complementEmbulkGem {

--- a/embulk-standards/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-standards/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,15 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.0
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.google.guava:guava:18.0
+com.google.inject:guice:4.0
+javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
+org.apache.commons:commons-compress:1.10
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12

--- a/embulk-standards/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-standards/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apache.commons:commons-compress:1.10

--- a/embulk-test/build.gradle
+++ b/embulk-test/build.gradle
@@ -8,9 +8,17 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    compile 'junit:junit:4.12'
-    compile 'org.hamcrest:hamcrest-library:1.3'
+configurations {
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
 
-    compile project(':embulk-core')
+dependencies {
+    implementation "junit:junit:4.12"
+    implementation "org.hamcrest:hamcrest-library:1.3"
+
+    implementation project(":embulk-core")
+    compileOnly "org.slf4j:slf4j-api:1.7.12"
+    compileOnly "com.google.guava:guava:18.0"
+    compileOnly "com.google.inject:guice:4.0"
 }

--- a/embulk-test/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-test/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,11 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.google.guava:guava:18.0
+com.google.inject:guice:4.0
+javax.inject:javax.inject:1
+junit:junit:4.12
+org.hamcrest:hamcrest-core:1.3
+org.hamcrest:hamcrest-library:1.3
+org.slf4j:slf4j-api:1.7.12

--- a/embulk-test/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-test/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,27 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
+com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
+com.google.inject:guice:4.0
+commons-beanutils:commons-beanutils-core:1.8.3
+javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
+junit:junit:4.12
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
+org.apache.commons:commons-lang3:3.4
+org.hamcrest:hamcrest-core:1.3
+org.hamcrest:hamcrest-library:1.3
+org.jruby:jruby-complete:9.1.15.0
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip

--- a/test-helpers/build.gradle
+++ b/test-helpers/build.gradle
@@ -28,7 +28,7 @@ task buildFlatJarForEmbulkTestMavenPlugin(type: Jar) {
                 "Embulk-Plugin-Main-Class": "org.embulk.plugin.jar.ExampleJarSpiV0"
         )
     }
-    archiveName = "embulk-test-maven-plugin-flat.jar"
+    archiveBaseName = "embulk-test-maven-plugin-flat"
 }
 
 task buildDepsJarForEmbulkTestMavenPlugin(type: Jar) {
@@ -36,5 +36,5 @@ task buildDepsJarForEmbulkTestMavenPlugin(type: Jar) {
         include "org/embulk/plugin/jar/ExampleDependencyJar.class"
         include "embulk-test-maven-plugin/deps.txt"
     }
-    archiveName = "embulk-test-maven-plugin-deps.jar"
+    archiveBaseName = "embulk-test-maven-plugin-deps"
 }


### PR DESCRIPTION
Through v0.10, we don't take too much care about compatibility. Then, we try updating things to the latest!

It enables dependency locks along with that.