### PR TITLE
Split `org.embulk.spi.Buffer` into a separate artifact `embulk-api`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
         # - macOS-latest
         # - windows-latest
         gradle_task:
+        - ":embulk-api:check"
         - ":embulk-core:check"
         - ":embulk-standards:check"
         - ":embulk-junit4:check"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "java"
     id "maven-publish"
     id "jacoco"
-    id "com.jfrog.bintray" version "1.8.4"
+    id "com.jfrog.bintray" version "1.8.4" apply false
     id "org.ajoberstar.grgit" version "4.0.1"
 }
 
@@ -42,7 +42,11 @@ ext {
     summary = 'Embulk, a plugin-based parallel bulk data loader'
 }
 
-def subprojectNamesReleased = [
+def subprojectNamesReleasedInMavenCentral = [
+    "embulk-api",
+]
+
+def subprojectNamesReleasedInBintray = [
     "embulk-core",
     "embulk-deps-buffer",
     "embulk-deps-cli",
@@ -53,16 +57,22 @@ def subprojectNamesReleased = [
     "embulk-junit4",
 ]
 
+def subprojectNamesReleased = subprojectNamesReleasedInMavenCentral + subprojectNamesReleasedInBintray
+
 configure(subprojects.findAll { subprojectNamesReleased.contains(it.name) }) {
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'maven-publish'
-    apply plugin: 'com.jfrog.bintray'
     // TODO: Enable SpotBugs instead of FindBugs which was used in Embulk until v0.9.17.
 
     // The version needs to be declared here, not in each build.gradle, so that "bintray" can get the value.
     version = "${rootProject.version}"
     project.ext.setProperty("revision", revision)
+
+    java {
+        withJavadocJar()
+        withSourcesJar()
+    }
 
     tasks.withType(JavaCompile) {
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
@@ -109,26 +119,18 @@ configure(subprojects.findAll { subprojectNamesReleased.contains(it.name) }) {
                        'Specification-Version': project.version
         }
     }
+}
+
+configure(subprojects.findAll { subprojectNamesReleasedInBintray.contains(it.name) }) {
+    apply plugin: "com.jfrog.bintray"
 
     task testsJar(type: Jar, dependsOn: classes) {
         classifier = 'tests'
         from sourceSets.test.output
     }
 
-    task sourcesJar(type: Jar, dependsOn: classes) {
-        classifier = 'sources'
-        from sourceSets.main.allSource
-    }
-
-    task javadocJar(type: Jar, dependsOn: javadoc) {
-        classifier = 'javadoc'
-        from javadoc.destinationDir
-    }
-
     artifacts {
         archives testsJar
-        archives sourcesJar
-        archives javadocJar
     }
 
     publishing {
@@ -137,22 +139,11 @@ configure(subprojects.findAll { subprojectNamesReleased.contains(it.name) }) {
                 if (project.version.endsWith("-SNAPSHOT")) {
                     version = "${project.version}-${revision}"
                 }
-                from components.java
-                artifact testsJar
-                artifact sourcesJar
-                artifact javadocJar
-            }
-        }
 
-        // publishMavenPublicationToGithubRepository
-        repositories {
-            maven {
-                name = "github"
-                url "https://maven.pkg.github.com/embulk/embulk"
-                credentials {
-                    username = project.hasProperty("github_package_user") ? github_package_user : ""
-                    password = project.hasProperty("github_package_token") ? github_package_token : ""
-                }
+                from components.java
+                // javadocJar and sourcesJar are added by java.withJavadocJar() and java.withSourcesJar() above.
+                // See: https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaPluginExtension.html
+                artifact testsJar
             }
         }
     }
@@ -183,6 +174,103 @@ configure(subprojects.findAll { subprojectNamesReleased.contains(it.name) }) {
                 name = project.version
             }
         }
+    }
+}
+
+configure(subprojects.findAll { subprojectNamesReleasedInMavenCentral.contains(it.name) }) {
+    apply plugin: "signing"
+
+    jar {
+        from rootProject.file("LICENSE")
+    }
+
+    javadoc {
+        options {
+            overview = "src/main/html/overview.html"
+            links "https://docs.oracle.com/javase/8/docs/api/"
+        }
+    }
+
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                groupId = "${project.group}"
+                artifactId = "${project.name}"
+
+                from components.java
+                // javadocJar and sourcesJar are added by java.withJavadocJar() and java.withSourcesJar() above.
+                // See: https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaPluginExtension.html
+
+                pom {  // https://central.sonatype.org/pages/requirements.html
+                    name = "${project.name}"
+                    afterEvaluate { project ->
+                        // "description" is declared in subproject's build.gradle. It needs to be configured after evaluation.
+                        description = "${project.description}"
+                    }
+                    url = "https://www.embulk.org/"
+
+                    licenses {
+                        license {
+                            // http://central.sonatype.org/pages/requirements.html#license-information
+                            name = "The Apache License, Version 2.0"
+                            url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            name = "Sadayuki Furuhashi"
+                            email = "frsyuki@gmail.com"
+                        }
+                        developer {
+                            name = "Muga Nishizawa"
+                            email = "muga.nishizawa@gmail.com"
+                        }
+                        developer {
+                            name = "Satoshi Akama"
+                            email = "satoshiakama@gmail.com"
+                        }
+                        developer {
+                            name = "Dai MIKURUBE"
+                            email = "dmikurube@treasure-data.com"
+                        }
+                        developer {
+                            name = "Shinichi Ishimura"
+                            email = "shiketaudonko41@gmail.com"
+                        }
+                        developer {
+                            name = "Roman Shtykh"
+                            email = "rshtykh@yahoo.com"
+                        }
+                    }
+
+                    scm {
+                        connection = "scm:git:git://github.com/embulk/embulk.git"
+                        developerConnection = "scm:git:git@github.com:embulk/embulk.git"
+                        url = "https://github.com/embulk/embulk"
+                    }
+                }
+            }
+        }
+
+        repositories {
+            maven {  // publishMavenPublicationToMavenCentralRepository
+                name = "mavenCentral"
+                if (project.version.endsWith("-SNAPSHOT")) {
+                    url "https://oss.sonatype.org/content/repositories/snapshots"
+                } else {
+                    url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                }
+                credentials {
+                    username = project.hasProperty("sonatype_username") ? sonatype_username : ""
+                    password = project.hasProperty("sonatype_password") ? sonatype_password : ""
+                }
+            }
+        }
+    }
+
+    signing {
+        sign publishing.publications.maven
     }
 }
 
@@ -307,7 +395,11 @@ task releaseCheck {
 task release {
     dependsOn "releaseCheck"
     dependsOn "executableJar"
-    subprojectNamesReleased.each { subprojectName ->
+    subprojectNamesReleasedInMavenCentral.each { subprojectName ->
+        dependsOn ":${subprojectName}:publishMavenPublicationToMavenCentralRepository"
+        tasks.findByPath(":${subprojectName}:publishMavenPublicationToMavenCentralRepository").mustRunAfter(":releaseCheck")
+    }
+    subprojectNamesReleasedInBintray.each { subprojectName ->
         dependsOn ":${subprojectName}:bintrayUpload"
         tasks.findByPath(":${subprojectName}:bintrayUpload").mustRunAfter(":releaseCheck")
     }

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -5,6 +5,7 @@ This directory contains Embulk project's internal design documentation in Markdo
 
 ## Document Index
 
+* [API and SPI](api_and_spi.md) - Embulk API and SPI
 * [External Variables](external_variables.md) - Listing of external variables affecting Embulk's execution
 * [SLF4J Logging](slf4j.md) - How SLF4J works in Embulk
 * [Timestamp Parsing](timestamp_parsing.md) - Basic design policy to parse timestamps in the Embulk core framework

--- a/docs/design/api_and_spi.md
+++ b/docs/design/api_and_spi.md
@@ -1,0 +1,11 @@
+Embulk API and SPI
+===================
+
+Embulk is going to have separate `embulk-api` and `embulk-spi` artifacts isolated from `embulk-core`, so that Embulk plugins will need to depend only on them, not to have a direct dependency on `embulk-core`. Changes on the core side would impact plugins less easily.
+
+Along with the isolation, "utility" classes in `embulk-core` are to be externalized as separate libraries. [`embulk-util-timestamp`](https://search.maven.org/artifact/org.embulk/embulk-util-timestamp) is an early example. Such utility classes are loaded in plugin's `ClassLoader`. Plugins would be responsible to choose utility libraries on their own.
+
+* `embulk-api` contains accessors for Embulk core features. Utility libraries for Embulk plugins may also depend on `embulk-api` to help plugins accessing Embulk core features.
+* `embulk-spi` consists of interfaces and abstract classes for Embulk plugins to inherit.
+
+`embulk-api` and `embulk-spi` are loaded in the same `ClassLoadder` with `embulk-core`. `embulk-core` depends on `embulk-api` and `embulk-spi`. The executable all-in-one binary contains both `embulk-api` and `embulk-spi` extracted.

--- a/embulk-api/build.gradle
+++ b/embulk-api/build.gradle
@@ -1,0 +1,13 @@
+description = "Java APIs for Embulk plugins"
+
+repositories {
+    mavenCentral()
+}
+
+configurations {
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
+
+dependencies {
+}

--- a/embulk-api/config/checkstyle/suppressions.xml
+++ b/embulk-api/config/checkstyle/suppressions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress checks="JavadocMethod" files=".*"/>
+  <suppress checks="JavadocParagraph" files=".*"/>
+  <suppress checks="JavadocTagContinuationIndentation" files=".*"/>
+  <suppress checks="SingleLineJavadoc" files=".*"/>
+  <suppress checks="SummaryJavadoc" files=".*"/>
+</suppressions>

--- a/embulk-api/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-api/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/embulk-api/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-api/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/embulk-api/src/main/html/overview.html
+++ b/embulk-api/src/main/html/overview.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>embulk-api</title>
+  </head>
+  <body>
+    <p>Java APIs for Embulk plugins.</p>
+  </body>
+</html>

--- a/embulk-api/src/main/java/org/embulk/spi/Buffer.java
+++ b/embulk-api/src/main/java/org/embulk/spi/Buffer.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+
+/**
+ * A buffer used in and between plugins. It wraps a {@code byte} array.
+ *
+ * <p>It will be a pure {@code abstract class}, but it now has some {@code static} creator methods implemented.
+ *
+ * <p>Those {@code static} creator methods, {@link #allocate(int)}, {@link #copyOf(byte[])},
+ * {@link #copyOf(byte[], int, int)}, {@link #wrap(byte[])}, and {@link #wrap(byte[], int, int)}
+ * are implemented for compatibility for some legacy plugins calling them. They will be removed
+ * before Embulk v1. Plugins should no longer call them, even in tests.
+ *
+ * <p>At the same time, a constant {@code Buffer.EMPTY} has already been removed. Plugins cannot use it anymore.
+ */
+public abstract class Buffer {
+    Buffer() {
+    }
+
+    /**
+     * Returns the internal {@code byte} array of this {@link Buffer}.
+     *
+     * @deprecated Accessing the internal {@code byte} array is not safe.
+     * @return the internal {@code byte} array
+     */
+    @Deprecated  // Not for removal, but deprecated.
+    public abstract byte[] array();
+
+    /**
+     * Returns the current offset of this {@link Buffer}.
+     *
+     * @return the current offset
+     */
+    public abstract int offset();
+
+    /**
+     * Sets the current offset of this {@link Buffer}.
+     *
+     * @param offset  the offset to set
+     * @return this {@link Buffer} itself
+     */
+    public abstract Buffer offset(int offset);
+
+    /**
+     * Returns the current limit of this {@link Buffer}.
+     *
+     * @return the current limit
+     */
+    public abstract int limit();
+
+    /**
+     * Sets the current limit of this {@link Buffer}.
+     *
+     * @param limit  the limit to set
+     * @return this {@link Buffer} itself
+     */
+    public abstract Buffer limit(int limit);
+
+    /**
+     * Returns the capacity of this {@link Buffer}.
+     *
+     * <p>The capacity does not change once created.
+     *
+     * @return the capacity
+     */
+    public abstract int capacity();
+
+    /**
+     * Copies an array from {@code source}, beginning at {@code sourceIndex}, to {@code index} of this {@link Buffer}.
+     *
+     * @param index  starting position in this destination {@link Buffer}
+     * @param source  the source array
+     * @param sourceIndex  starting position in the source array
+     * @param length  the number of bytes to be copied
+     */
+    public abstract void setBytes(int index, byte[] source, int sourceIndex, int length);
+
+    /**
+     * Copies an array from {@code source}, beginning at {@code sourceIndex}, to {@code index} of this {@link Buffer}.
+     *
+     * @param index  starting position in this destination {@link Buffer}
+     * @param source  the source {@link Buffer}
+     * @param sourceIndex  starting position in the source {@link Buffer}
+     * @param length  the number of bytes to be copied
+     */
+    public abstract void setBytes(int index, Buffer source, int sourceIndex, int length);
+
+    /**
+     * Copies an array from this {@link Buffer}, beginning at {@code index}, to {@code destIndex} of {@code dest}.
+     *
+     * @param index  starting position in this source {@link Buffer}
+     * @param dest  the destination array
+     * @param destIndex  starting position in the destination array
+     * @param length  the number of bytes to be copied
+     */
+    public abstract void getBytes(int index, byte[] dest, int destIndex, int length);
+
+    /**
+     * Copies an array from this {@link Buffer}, beginning at {@code index}, to {@code destIndex} of {@code dest}.
+     *
+     * @param index  starting position in this source {@link Buffer}
+     * @param dest  the destination {@link Buffer}
+     * @param destIndex  starting position in the destination {@link Buffer}
+     * @param length  the number of bytes to be copied
+     */
+    public abstract void getBytes(int index, Buffer dest, int destIndex, int length);
+
+    /**
+     * Releases this {@link Buffer}.
+     */
+    public abstract void release();
+
+    /**
+     * Creates a new {@link Buffer} instance.
+     *
+     * @deprecated  This method is to be removed. Plugins should no longer call it directly.
+     * @param length  length of the created {@link Buffer}
+     * @return created {@link Buffer}
+     */
+    @Deprecated
+    public static Buffer allocate(final int length) {
+        try {
+            return Holder.CONSTRUCTOR.newInstance(new byte[length], 0, length);
+        } catch (final IllegalAccessException | IllegalArgumentException | InstantiationException ex) {
+            throw new LinkageError("[FATAL] org.embulk.spi.BufferImpl is invalid.", ex);
+        } catch (final InvocationTargetException ex) {
+            throwCheckedForcibly(ex.getTargetException());
+            return null;  // Should never reach.
+        }
+    }
+
+    /**
+     * Creates a new {@link Buffer} instance copied from {@code src}.
+     *
+     * @deprecated  This method is to be removed. Plugins should no longer call it directly.
+     * @param src  the source byte array
+     * @return created {@link Buffer}
+     */
+    @Deprecated
+    public static Buffer copyOf(final byte[] src) {
+        return copyOf(src, 0, src.length);
+    }
+
+    /**
+     * Creates a new {@link Buffer} instance copied from {@code src}.
+     *
+     * @deprecated  This method is to be removed. Plugins should no longer call it directly.
+     * @param src  the source byte array
+     * @param index  starting position in the source array
+     * @param length  the number of bytes to be copied
+     * @return created {@link Buffer}
+     */
+    @Deprecated
+    public static Buffer copyOf(final byte[] src, final int index, final int length) {
+        return wrap(Arrays.copyOfRange(src, index, length));
+    }
+
+    /**
+     * Creates a new {@link Buffer} instance wrapping {@code src} as the internal array.
+     *
+     * @deprecated  This method is to be removed. Plugins should no longer call it directly.
+     * @param src  the source byte array
+     * @return created {@link Buffer}
+     */
+    @Deprecated
+    public static Buffer wrap(final byte[] src) {
+        return wrap(src, 0, src.length);
+    }
+
+    /**
+     * Creates a new {@link Buffer} instance wrapping {@code src} as the internal array.
+     *
+     * @deprecated  This method is to be removed. Plugins should no longer call it directly.
+     * @param src  the source byte array
+     * @param offset  starting position in the source array
+     * @param size  the number of bytes to be wrapped
+     * @return created {@link Buffer}
+     */
+    @Deprecated
+    public static Buffer wrap(final byte[] src, final int offset, final int size) {
+        try {
+            return Holder.CONSTRUCTOR.newInstance(src, offset, size).limit(size);
+        } catch (final IllegalAccessException | IllegalArgumentException | InstantiationException ex) {
+            throw new LinkageError("[FATAL] org.embulk.spi.BufferImpl is invalid.", ex);
+        } catch (final InvocationTargetException ex) {
+            throwCheckedForcibly(ex.getTargetException());
+            return null;  // Should never reach.
+        }
+    }
+
+    private static class Holder {  // Initialization-on-demand holder idiom.
+        private static final Class<Buffer> IMPL_CLASS;
+        private static final Constructor<Buffer> CONSTRUCTOR;
+
+        static {
+            try {
+                IMPL_CLASS = loadBufferImpl();
+            } catch (final ClassNotFoundException ex) {
+                throw new LinkageError("[FATAL] org.embulk.spi.BufferImpl is not found.", ex);
+            }
+
+            try {
+                CONSTRUCTOR = IMPL_CLASS.getConstructor(byte[].class, int.class, int.class);
+            } catch (final NoSuchMethodException ex) {
+                throw new LinkageError("[FATAL] org.embulk.spi.BufferImpl does not have an expected constructor.", ex);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<Buffer> loadBufferImpl() throws ClassNotFoundException {
+        return (Class<Buffer>) CLASS_LOADER.loadClass("org.embulk.spi.BufferImpl");
+    }
+
+    private static void throwCheckedForcibly(final Throwable ex) {
+        Buffer.<RuntimeException>throwCheckedForciblyInternal(ex);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable> void throwCheckedForciblyInternal(final Throwable ex) throws E {
+        throw (E) ex;
+    }
+
+    private static final ClassLoader CLASS_LOADER = Buffer.class.getClassLoader();
+}

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -23,6 +23,8 @@ repositories {
 
 // determine which dependencies have updates: $ gradle dependencyUpdates
 dependencies {
+    implementation project(":embulk-api")
+
     implementation "com.google.guava:guava:18.0"
     implementation "com.google.inject:guice:4.0"
     implementation "com.google.inject.extensions:guice-multibindings:4.0"

--- a/embulk-core/src/main/java/org/embulk/deps/buffer/Slice.java
+++ b/embulk-core/src/main/java/org/embulk/deps/buffer/Slice.java
@@ -7,6 +7,7 @@ import org.embulk.deps.EmbulkDependencyClassLoaders;
 import org.embulk.spi.Buffer;
 
 public abstract class Slice {
+    @SuppressWarnings("deprecation")  // Calling Buffer#array().
     public static Slice createWithWrappedBuffer(final Buffer buffer) {
         try {
             return CONSTRUCTOR.newInstance(buffer.array(), buffer.offset(), buffer.capacity());

--- a/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
@@ -20,6 +20,7 @@ import org.embulk.config.TaskSource;
 import org.embulk.plugin.DefaultPluginType;
 import org.embulk.plugin.PluginType;
 import org.embulk.spi.Buffer;
+import org.embulk.spi.BufferImpl;
 import org.embulk.spi.Exec;
 import org.embulk.spi.ExecAction;
 import org.embulk.spi.ExecSession;
@@ -242,7 +243,7 @@ public class GuessExecutor {
         }
 
         private static Buffer readSample(FileInput fileInput, int sampleSize) {
-            Buffer sample = Buffer.allocate(sampleSize);
+            Buffer sample = BufferImpl.allocate(sampleSize);
             try {
                 SamplingParserPlugin.readSample(fileInput, sample, 0, sampleSize);
             } catch (RuntimeException ex) {

--- a/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
@@ -14,6 +14,7 @@ import org.embulk.config.Task;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Buffer;
+import org.embulk.spi.BufferImpl;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FileInput;
 import org.embulk.spi.FileInputRunner;
@@ -162,7 +163,7 @@ public class SamplingParserPlugin implements ParserPlugin {
     }
 
     public static Buffer readSample(FileInput fileInput, int sampleBufferBytes) {
-        return readSample(fileInput, Buffer.allocate(sampleBufferBytes), 0, sampleBufferBytes);
+        return readSample(fileInput, BufferImpl.allocate(sampleBufferBytes), 0, sampleBufferBytes);
     }
 
     public static Buffer readSample(FileInput fileInput, Buffer sample, int offset, int sampleBufferBytes) {

--- a/embulk-core/src/main/java/org/embulk/spi/BufferImpl.java
+++ b/embulk-core/src/main/java/org/embulk/spi/BufferImpl.java
@@ -2,15 +2,15 @@ package org.embulk.spi;
 
 import java.util.Arrays;
 
-public class Buffer {
-    public static final Buffer EMPTY = Buffer.allocate(0);
+public class BufferImpl extends Buffer {
+    public static final Buffer EMPTY = BufferImpl.allocate(0);
 
     private final byte[] array;
     private int offset;
     private int filled;
     private final int capacity;
 
-    protected Buffer(byte[] wrap, int offset, int capacity) {
+    public BufferImpl(byte[] wrap, int offset, int capacity) {
         this.array = wrap;
         this.offset = offset;
         this.capacity = capacity;
@@ -21,44 +21,55 @@ public class Buffer {
         }
     }
 
+    @SuppressWarnings("deprecation")  // Buffer#allocate(int) is deprecated.
     public static Buffer allocate(int length) {
-        return new Buffer(new byte[length], 0, length);
+        return new BufferImpl(new byte[length], 0, length);
     }
 
+    @SuppressWarnings("deprecation")  // Buffer#copyOf(byte[]) is deprecated.
     public static Buffer copyOf(byte[] src) {
         return copyOf(src, 0, src.length);
     }
 
+    @SuppressWarnings("deprecation")  // Buffer#copyOf(byte[], int, int) is deprecated.
     public static Buffer copyOf(byte[] src, int index, int length) {
         return wrap(Arrays.copyOfRange(src, index, length));
     }
 
+    @SuppressWarnings("deprecation")  // Buffer#wrap(byte[]) is deprecated.
     public static Buffer wrap(byte[] src) {
         return wrap(src, 0, src.length);
     }
 
+    @SuppressWarnings("deprecation")  // Buffer#wrap(byte[], int, int) is deprecated.
     public static Buffer wrap(byte[] src, int offset, int size) {
-        return new Buffer(src, offset, size).limit(size);
+        return new BufferImpl(src, offset, size).limit(size);
     }
 
     // http://findbugs.sourceforge.net/bugDescriptions.html#EI_EXPOSE_REP
+    @Deprecated
+    @Override
     public byte[] array() {
         return array;
     }
 
+    @Override
     public int offset() {
         return offset;
     }
 
+    @Override
     public Buffer offset(int offset) {
         this.offset = offset;
         return this;
     }
 
+    @Override
     public int limit() {
         return filled - offset;
     }
 
+    @Override
     public Buffer limit(int limit) {
         if (capacity < limit) {
             // TODO
@@ -68,34 +79,42 @@ public class Buffer {
         return this;
     }
 
+    @Override
     public int capacity() {
         return capacity;
     }
 
+    @Override
     public void setBytes(int index, byte[] source, int sourceIndex, int length) {
         System.arraycopy(source, sourceIndex, array, offset + index, length);
     }
 
+    @SuppressWarnings("deprecation")  // Calling Buffer#array().
+    @Override
     public void setBytes(int index, Buffer source, int sourceIndex, int length) {
         setBytes(index, source.array(), source.offset() + sourceIndex, length);
     }
 
+    @Override
     public void getBytes(int index, byte[] dest, int destIndex, int length) {
         System.arraycopy(array, offset + index, dest, destIndex, length);
     }
 
+    @SuppressWarnings("deprecation")  // Calling Buffer#array().
+    @Override
     public void getBytes(int index, Buffer dest, int destIndex, int length) {
         getBytes(index, dest.array(), dest.offset() + destIndex, length);
     }
 
+    @Override
     public void release() {}
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof Buffer)) {
+        if (!(other instanceof BufferImpl)) {
             return false;
         }
-        Buffer o = (Buffer) other;
+        BufferImpl o = (BufferImpl) other;
 
         // TODO optimize
         if (limit() != o.limit()) {

--- a/embulk-core/src/main/java/org/embulk/spi/Page.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Page.java
@@ -29,7 +29,7 @@ public class Page {
     }
 
     public static Page allocate(int length) {
-        return new Page(Buffer.allocate(length));
+        return new Page(BufferImpl.allocate(length));
     }
 
     public static Page wrap(Buffer buffer) {

--- a/embulk-core/src/main/java/org/embulk/spi/PageReader.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageReader.java
@@ -16,7 +16,7 @@ public class PageReader implements AutoCloseable {
     private int position;
     private final byte[] nullBitSet;
 
-    private static final Page SENTINEL = Page.wrap(Buffer.wrap(new byte[4]));  // buffer().release() does nothing
+    private static final Page SENTINEL = Page.wrap(BufferImpl.wrap(new byte[4]));  // buffer().release() does nothing
 
     public PageReader(Schema schema) {
         this.schema = schema;

--- a/embulk-core/src/main/java/org/embulk/spi/util/FileInputInputStream.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/FileInputInputStream.java
@@ -2,12 +2,13 @@ package org.embulk.spi.util;
 
 import java.io.InputStream;
 import org.embulk.spi.Buffer;
+import org.embulk.spi.BufferImpl;
 import org.embulk.spi.FileInput;
 
 public class FileInputInputStream extends InputStream {
     private final FileInput in;
     private int pos;
-    private Buffer buffer = Buffer.EMPTY;
+    private Buffer buffer = BufferImpl.EMPTY;
 
     public FileInputInputStream(FileInput in) {
         this.in = in;
@@ -27,6 +28,7 @@ public class FileInputInputStream extends InputStream {
         return buffer.limit() - pos;
     }
 
+    @SuppressWarnings("deprecation")  // Calling Buffer#array().
     @Override
     public int read() {
         while (pos >= buffer.limit()) {
@@ -87,7 +89,7 @@ public class FileInputInputStream extends InputStream {
 
     private void releaseBuffer() {
         buffer.release();
-        buffer = Buffer.EMPTY;
+        buffer = BufferImpl.EMPTY;
         pos = 0;
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/util/FileOutputOutputStream.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/FileOutputOutputStream.java
@@ -3,6 +3,7 @@ package org.embulk.spi.util;
 import java.io.OutputStream;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.BufferAllocator;
+import org.embulk.spi.BufferImpl;
 import org.embulk.spi.FileOutput;
 
 public class FileOutputOutputStream extends OutputStream {
@@ -35,6 +36,7 @@ public class FileOutputOutputStream extends OutputStream {
         out.finish();
     }
 
+    @SuppressWarnings("deprecation")  // Calling Buffer#array().
     @Override
     public void write(int b) {
         buffer.array()[buffer.offset() + pos] = (byte) b;
@@ -69,7 +71,7 @@ public class FileOutputOutputStream extends OutputStream {
         if (pos > 0) {
             buffer.limit(pos);
             out.add(buffer);
-            buffer = Buffer.EMPTY;
+            buffer = BufferImpl.EMPTY;
             pos = 0;
             return true;
         }
@@ -104,7 +106,7 @@ public class FileOutputOutputStream extends OutputStream {
             default:  // Never default as all enums are listed.
         }
         buffer.release();
-        buffer = Buffer.EMPTY;
+        buffer = BufferImpl.EMPTY;
         pos = 0;
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/InputStreamFileInput.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/InputStreamFileInput.java
@@ -142,6 +142,7 @@ public class InputStreamFileInput implements FileInput {
         this(allocator, new InputStreamProvider(openedStream));
     }
 
+    @SuppressWarnings("deprecation")  // Calling Buffer#array().
     public Buffer poll() {
         if (current == null || current.getInputStream() == null) {
             throw new IllegalStateException("nextFile() must be called before poll()");

--- a/embulk-core/src/main/java/org/embulk/spi/util/OutputStreamFileOutput.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/OutputStreamFileOutput.java
@@ -32,6 +32,7 @@ public class OutputStreamFileOutput implements FileOutput {
         }
     }
 
+    @SuppressWarnings("deprecation")  // Calling Buffer#array().
     public void add(Buffer buffer) {
         if (current == null) {
             throw new IllegalStateException("nextFile() must be called before poll()");

--- a/embulk-core/src/main/ruby/embulk/buffer.rb
+++ b/embulk-core/src/main/ruby/embulk/buffer.rb
@@ -1,4 +1,3 @@
-
 module Embulk
   class Buffer < String
     def self.from_java(java_buffer)
@@ -14,7 +13,7 @@ module Embulk
     end
 
     def to_java
-      Java::Buffer.wrap(to_java_bytes)
+      Java::org.embulk.spi.BufferImpl.wrap(to_java_bytes)
     end
   end
 end

--- a/embulk-core/src/test/java/org/embulk/spi/TestBufferImpl.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestBufferImpl.java
@@ -5,13 +5,13 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-public class TestBuffer {
+public class TestBufferImpl {
     @Test
     public void testEquals() throws Exception {
         byte[] bytes = new byte[] { 1, 2, 3, 2, 3 };
-        Buffer b1 = Buffer.wrap(bytes, 0, 2);  // [1, 2]
-        Buffer b2 = Buffer.wrap(bytes, 1, 2);  // [2, 3]
-        Buffer b3 = Buffer.wrap(bytes, 3, 2);  // [2, 3]
+        Buffer b1 = BufferImpl.wrap(bytes, 0, 2);  // [1, 2]
+        Buffer b2 = BufferImpl.wrap(bytes, 1, 2);  // [2, 3]
+        Buffer b3 = BufferImpl.wrap(bytes, 3, 2);  // [2, 3]
 
         assertFalse(b1.equals(b2));
         assertTrue(b2.equals(b3));

--- a/embulk-core/src/test/java/org/embulk/spi/TestPageBuilderReader.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestPageBuilderReader.java
@@ -252,12 +252,12 @@ public class TestPageBuilderReader {
         this.bufferAllocator = new BufferAllocator() {
             @Override
             public Buffer allocate() {
-                return Buffer.allocate(1);
+                return BufferImpl.allocate(1);
             }
 
             @Override
             public Buffer allocate(int minimumCapacity) {
-                return Buffer.allocate(minimumCapacity);
+                return BufferImpl.allocate(minimumCapacity);
             }
         };
         assertEquals(
@@ -271,12 +271,12 @@ public class TestPageBuilderReader {
         this.bufferAllocator = new BufferAllocator() {
             @Override
             public Buffer allocate() {
-                return Buffer.allocate(1);
+                return BufferImpl.allocate(1);
             }
 
             @Override
             public Buffer allocate(int minimumCapacity) {
-                return Buffer.allocate(minimumCapacity);
+                return BufferImpl.allocate(minimumCapacity);
             }
         };
         assertEquals(

--- a/embulk-core/src/test/java/org/embulk/spi/util/TestLineDecoder.java
+++ b/embulk-core/src/test/java/org/embulk/spi/util/TestLineDecoder.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.Buffer;
+import org.embulk.spi.BufferImpl;
 import org.embulk.spi.Exec;
 import org.junit.Rule;
 import org.junit.Test;
@@ -81,7 +82,7 @@ public class TestLineDecoder {
         List<Buffer> buffers = new ArrayList<Buffer>();
         for (String source : sources) {
             ByteBuffer buffer = charset.encode(source);
-            buffers.add(Buffer.wrap(buffer.array(), 0, buffer.limit()));
+            buffers.add(BufferImpl.wrap(buffer.array(), 0, buffer.limit()));
         }
 
         return buffers;

--- a/embulk-core/src/test/java/org/embulk/spi/util/TestLineEncoder.java
+++ b/embulk-core/src/test/java/org/embulk/spi/util/TestLineEncoder.java
@@ -99,6 +99,7 @@ public class TestLineEncoder {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private String bufferToString(Buffer buffer, String charset)
             throws UnsupportedEncodingException {
         return new String(buffer.array(), buffer.offset(), buffer.limit(), charset);

--- a/embulk-deps/buffer/build.gradle
+++ b/embulk-deps/buffer/build.gradle
@@ -13,10 +13,12 @@ configurations {
 }
 
 dependencies {
+    compileOnly project(":embulk-api")
     compileOnly project(":embulk-core")
     implementation "io.netty:netty-buffer:4.0.44.Final"
     implementation "io.airlift:slice:0.9"
 
+    testImplementation project(":embulk-api")
     testImplementation project(":embulk-core")
     testImplementation "junit:junit:4.12"
 }

--- a/embulk-deps/buffer/src/main/java/org/embulk/deps/buffer/PooledBufferAllocatorImpl.java
+++ b/embulk-deps/buffer/src/main/java/org/embulk/deps/buffer/PooledBufferAllocatorImpl.java
@@ -3,6 +3,7 @@ package org.embulk.deps.buffer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import org.embulk.spi.Buffer;
+import org.embulk.spi.BufferImpl;
 
 public class PooledBufferAllocatorImpl extends org.embulk.deps.buffer.PooledBufferAllocator {
     public PooledBufferAllocatorImpl(final int pageSize) {
@@ -26,7 +27,7 @@ public class PooledBufferAllocatorImpl extends org.embulk.deps.buffer.PooledBuff
         return new BufferBasedOnNettyByteBuf(nettyByteBufAllocator.buffer(size));
     }
 
-    private static class BufferBasedOnNettyByteBuf extends Buffer {
+    private static class BufferBasedOnNettyByteBuf extends BufferImpl {
         private BufferBasedOnNettyByteBuf(final ByteBuf internalNettyByteBuf) {
             super(internalNettyByteBuf.array(), internalNettyByteBuf.arrayOffset(), internalNettyByteBuf.capacity());
 

--- a/embulk-standards/build.gradle
+++ b/embulk-standards/build.gradle
@@ -20,6 +20,7 @@ configurations {
 }
 
 dependencies {
+    compileOnly project(":embulk-api")
     compileOnly project(":embulk-core")
     compileOnly "com.google.guava:guava:18.0"
     compileOnly "com.google.inject:guice:4.0"
@@ -34,6 +35,7 @@ dependencies {
 
     testImplementation "junit:junit:4.12"
     testImplementation "org.hamcrest:hamcrest-library:1.3"
+    testImplementation project(":embulk-api")
     testImplementation project(":embulk-core")
     testImplementation project(":embulk-core").sourceSets.test.output
     testImplementation project(":embulk-junit4")
@@ -51,6 +53,7 @@ dependencies {
     testImplementation project(":embulk-deps-guess")
 
     jruby "org.jruby:jruby-complete:" + rootProject.jrubyVersion
+    rubyTestRuntime project(":embulk-api")
     rubyTestRuntime project(":embulk-core")
 }
 

--- a/embulk-standards/src/main/java/org/embulk/standards/LocalFileOutputPlugin.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/LocalFileOutputPlugin.java
@@ -100,6 +100,7 @@ public class LocalFileOutputPlugin implements FileOutputPlugin {
                 }
             }
 
+            @SuppressWarnings("deprecation")  // Calling Buffer#array().
             public void add(Buffer buffer) {
                 try {
                     output.write(buffer.array(), buffer.offset(), buffer.limit());

--- a/embulk-standards/src/test/java/org/embulk/standards/TestCsvTokenizer.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/TestCsvTokenizer.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.Buffer;
+import org.embulk.spi.BufferImpl;
 import org.embulk.spi.Column;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FileInput;
@@ -50,7 +51,7 @@ public class TestCsvTokenizer {
         List<Buffer> buffers = new ArrayList<>();
         for (String line : lines) {
             byte[] buffer = (line + task.getNewline().getString()).getBytes(task.getCharset());
-            buffers.add(Buffer.wrap(buffer));
+            buffers.add(BufferImpl.wrap(buffer));
         }
         return new ListFileInput(ImmutableList.of(buffers));
     }
@@ -58,7 +59,7 @@ public class TestCsvTokenizer {
     private static FileInput newFileInputFromText(CsvParserPlugin.PluginTask task, String text) {
         return new ListFileInput(
                 ImmutableList.of(ImmutableList.of(
-                        Buffer.wrap(text.getBytes(task.getCharset())))));
+                        BufferImpl.wrap(text.getBytes(task.getCharset())))));
     }
 
     private static List<List<String>> parse(CsvParserPlugin.PluginTask task, String... lines) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'embulk'
 
+include 'embulk-api'
 include 'embulk-core'
 include 'embulk-deps-buffer'
 project(':embulk-deps-buffer').projectDir = file('embulk-deps/buffer')


### PR DESCRIPTION
As described in `docs/design/api_and_spi.md`, going to split some classes into different artifacts `embulk-api` and `embulk-spi` so that Embulk plugins will need to depend only on them, not depending on `embulk-core`.

`Buffer` is the first step because it does not depend on other classes, and used from other classes. `Buffer` in `embulk-api` is an abstract class. The implementation is `BufferImpl` in `embulk-core`.

`embulk-api` and `embulk-spi` would be released to Maven Central, not Bintray nor JCenter. Common build tools often refer Maven Central by default. Other Maven repositories like JCenter usually inherit Maven Central.

The `embulk-api` artifact is to have the `LICENSE` file from :
https://www.apache.org/licenses/LICENSE-2.0
