### PR TITLE
Remove direct injection of org.jruby.embed.ScriptingContainer (Fix #1007)

### DIFF
--- a/embulk-core/src/main/java/org/embulk/jruby/LazyScriptingContainerDelegate.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/LazyScriptingContainerDelegate.java
@@ -211,13 +211,6 @@ public final class LazyScriptingContainerDelegate extends ScriptingContainerDele
         return getInitialized().getRuntime();
     }
 
-    // TODO: Remove this method finally. https://github.com/embulk/embulk/issues/1007
-    // It is intentionally package-private. It should return ScriptingContainer while it is Object in the signature.
-    @Override
-    Object getScriptingContainer() throws JRubyNotLoadedException {
-        return getInitialized().getScriptingContainer();
-    }
-
     synchronized ScriptingContainerDelegateImpl getInitialized() {
         if (this.impl == null) {
             this.impl = ScriptingContainerDelegateImpl.create(

--- a/embulk-core/src/main/java/org/embulk/jruby/ScriptingContainerDelegate.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/ScriptingContainerDelegate.java
@@ -149,7 +149,4 @@ public abstract class ScriptingContainerDelegate {
 
     // It is intentionally private. It should return Runtime while it is Object in the signature.
     abstract Object getRuntime() throws JRubyNotLoadedException;
-
-    // TODO: Remove this method finally. https://github.com/embulk/embulk/issues/1007
-    abstract Object getScriptingContainer() throws JRubyNotLoadedException;
 }

--- a/embulk-core/src/main/java/org/embulk/jruby/ScriptingContainerDelegateImpl.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/ScriptingContainerDelegateImpl.java
@@ -881,16 +881,6 @@ public final class ScriptingContainerDelegateImpl extends ScriptingContainerDele
         }
     }
 
-    // TODO: Remove this method finally. https://github.com/embulk/embulk/issues/1007
-    // It is intentionally package-private. It should return ScriptingContainer while it is Object in the signature.
-    @Override
-    Object getScriptingContainer() throws JRubyNotLoadedException {
-        if (this.scriptingContainer == null) {
-            throw new JRubyNotLoadedException();
-        }
-        return this.scriptingContainer;
-    }
-
     /** Instance of org.jruby.embed.ScriptingContainer. It may be created lazily. */
     private final Object scriptingContainer;
 


### PR DESCRIPTION
`org.jruby.embed.ScriptingContainer` has still been injected for some plugins still getting `ScriptingContainer`, but we are going to unsupport it in v0.10. The JRuby runtime will be loaded just optionally at all, under a sub ClassLoader.
