### PR TITLE
Stop using org.jruby.util.RubyDateFormat, and replace with embulk-util-rubytime under a sub ClassLoader (Fix #830)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ def subprojectNamesReleasedInBintray = [
     "embulk-deps-guess",
     "embulk-deps-config",
     "embulk-deps-maven",
+    "embulk-deps-timestamp",
     "embulk-standards",
     "embulk-junit4",
 ]
@@ -302,6 +303,8 @@ dependencies {
     }
 
     embed project(':embulk-deps-cli')
+
+    embed project(':embulk-deps-timestamp')
 }
 
 def listEmbedDependencies = { rootModuleName, prefix ->
@@ -347,6 +350,7 @@ jar {
                    'Embulk-Resource-Class-Path-Guess': listEmbedDependencies('embulk-deps-guess', '/lib/'),
                    'Embulk-Resource-Class-Path-Maven': listEmbedDependencies('embulk-deps-maven', '/lib/'),
                    'Embulk-Resource-Class-Path-Cli': listEmbedDependencies('embulk-deps-cli', '/lib/'),
+                   'Embulk-Resource-Class-Path-Timestamp': listEmbedDependencies('embulk-deps-timestamp', '/lib/'),
                    'Main-Class': 'org.embulk.cli.Main'
     }
 }

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testImplementation project(":embulk-deps-buffer")
     testImplementation project(":embulk-deps-config")
     testImplementation project(":embulk-deps-guess")
+    testImplementation project(":embulk-deps-timestamp")
 }
 
 task rubyTestVanilla(type: JavaExec, dependsOn: [
@@ -65,6 +66,7 @@ task rubyTestVanilla(type: JavaExec, dependsOn: [
         ":embulk-deps-buffer:prepareDependencyJars",
         ":embulk-deps-config:prepareDependencyJars",
         ":embulk-deps-guess:prepareDependencyJars",
+        ":embulk-deps-timestamp:prepareDependencyJars",
         ]) {
     workingDir = file("${projectDir}");
     classpath = sourceSets.main.runtimeClasspath  // Not "configurations.runtimeClasspath" to use compiled embulk-core

--- a/embulk-core/src/main/java/org/embulk/deps/DependencyCategory.java
+++ b/embulk-core/src/main/java/org/embulk/deps/DependencyCategory.java
@@ -6,6 +6,7 @@ public enum DependencyCategory {
     GUESS("Guess", "Embulk-Resource-Class-Path-Guess"),
     CLI("CLI", "Embulk-Resource-Class-Path-Cli"),
     MAVEN("Maven", "Embulk-Resource-Class-Path-Maven"),
+    TIMESTAMP("Timestamp", "Embulk-Resource-Class-Path-Timestamp"),
     ;
 
     private DependencyCategory(final String name, final String manifestAttributeName) {

--- a/embulk-core/src/main/java/org/embulk/deps/timestamp/RubyDateTimeFormatter.java
+++ b/embulk-core/src/main/java/org/embulk/deps/timestamp/RubyDateTimeFormatter.java
@@ -1,0 +1,51 @@
+package org.embulk.deps.timestamp;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.time.temporal.TemporalAccessor;
+import org.embulk.deps.DependencyCategory;
+import org.embulk.deps.EmbulkDependencyClassLoaders;
+
+public abstract class RubyDateTimeFormatter {
+    public static RubyDateTimeFormatter create(final String pattern) {
+        try {
+            return CONSTRUCTOR.newInstance(pattern);
+        } catch (final IllegalAccessException | IllegalArgumentException | InstantiationException ex) {
+            throw new LinkageError("Dependencies for Timestamp are not loaded correctly: " + CLASS_NAME, ex);
+        } catch (final InvocationTargetException ex) {
+            final Throwable targetException = ex.getTargetException();
+            if (targetException instanceof RuntimeException) {
+                throw (RuntimeException) targetException;
+            } else if (targetException instanceof Error) {
+                throw (Error) targetException;
+            } else {
+                throw new RuntimeException("Unexpected Exception in creating: " + CLASS_NAME, ex);
+            }
+        }
+    }
+
+    public abstract String format(final TemporalAccessor temporal);
+
+    @SuppressWarnings("unchecked")
+    private static Class<RubyDateTimeFormatter> loadImplClass() {
+        try {
+            return (Class<RubyDateTimeFormatter>) CLASS_LOADER.loadClass(CLASS_NAME);
+        } catch (final ClassNotFoundException ex) {
+            throw new LinkageError("Dependencies for Timestamp are not loaded correctly: " + CLASS_NAME, ex);
+        }
+    }
+
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.of(DependencyCategory.TIMESTAMP);
+    private static final String CLASS_NAME = "org.embulk.deps.timestamp.RubyDateTimeFormatterImpl";
+
+    static {
+        final Class<RubyDateTimeFormatter> clazz = loadImplClass();
+        try {
+            CONSTRUCTOR = clazz.getConstructor(String.class);
+        } catch (final NoSuchMethodException ex) {
+            throw new LinkageError("Dependencies for Timestamp are not loaded correctly: " + CLASS_NAME, ex);
+        }
+    }
+
+    private static final Constructor<RubyDateTimeFormatter> CONSTRUCTOR;
+}

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
@@ -1,6 +1,7 @@
 package org.embulk.spi.time;
 
 import com.google.common.base.Optional;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -25,16 +26,16 @@ public class TimestampFormatter {
                      columnOption.isPresent()
                              ? columnOption.get().getFormat().or(task.getDefaultTimestampFormat())
                              : task.getDefaultTimestampFormat(),
-                     columnOption.isPresent()
-                             ? columnOption.get().getTimeZone().or(task.getDefaultTimeZone())
-                             : task.getDefaultTimeZone()));
+                     ZoneId.of(columnOption.isPresent()
+                             ? columnOption.get().getTimeZoneId().or(task.getDefaultTimeZoneId())
+                             : task.getDefaultTimeZoneId())));
     }
 
     // Using Joda-Time is deprecated, but the constructor receives org.joda.time.DateTimeZone for plugin compatibility.
     // It won't be removed very soon at least until Embulk v0.10.
     @Deprecated
     public TimestampFormatter(final String format, final org.joda.time.DateTimeZone timeZone) {
-        this(TimestampFormatterRuby.ofLegacy(format, timeZone));
+        this(TimestampFormatterRuby.ofLegacy(format, timeZone.toTimeZone().toZoneId()));
     }
 
     public static TimestampFormatter of(final String pattern, final String zoneIdString) {
@@ -55,7 +56,7 @@ public class TimestampFormatter {
             }
             return TimestampFormatterRuby.of(pattern.substring(5), zoneOffset);
         } else {
-            return TimestampFormatterRuby.ofLegacy(pattern, TimeZoneIds.parseJodaDateTimeZone(zoneIdString));
+            return TimestampFormatterRuby.ofLegacy(pattern, ZoneId.of(zoneIdString));
         }
     }
 
@@ -91,8 +92,7 @@ public class TimestampFormatter {
             }
             return TimestampFormatterRuby.of(pattern.substring(5), zoneOffset);
         } else {
-            return TimestampFormatterRuby.ofLegacy(pattern,
-                                                   TimeZoneIds.parseJodaDateTimeZone(zoneIdString));
+            return TimestampFormatterRuby.ofLegacy(pattern, ZoneId.of(zoneIdString));
         }
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatterRuby.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatterRuby.java
@@ -1,36 +1,30 @@
 package org.embulk.spi.time;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.Locale;
+import java.time.ZonedDateTime;
+import java.util.TimeZone;
+import org.embulk.deps.timestamp.RubyDateTimeFormatter;
 
 public class TimestampFormatterRuby extends TimestampFormatter {
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/830
-    private TimestampFormatterRuby(final org.jruby.util.RubyDateFormat formatter,
-                                   final ZoneOffset zoneOffset,
-                                   final org.joda.time.DateTimeZone jodaDateTimeZone,
+    private TimestampFormatterRuby(final RubyDateTimeFormatter formatter,
+                                   final ZoneId zoneId,
                                    final String formatString) {
         this.formatter = formatter;
-        this.zoneOffset = zoneOffset;
-        this.jodaDateTimeZone = jodaDateTimeZone;
+        this.zoneId = zoneId;
         this.formatString = formatString;
     }
 
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/830
     static TimestampFormatterRuby of(final String formatString, final ZoneOffset zoneOffset) {
-        return new TimestampFormatterRuby(new org.jruby.util.RubyDateFormat(formatString, Locale.ENGLISH, true),
+        return new TimestampFormatterRuby(RubyDateTimeFormatter.create(formatString),
                                           zoneOffset,
-                                          TimeZoneIds.convertZoneOffsetToJodaDateTimeZone(zoneOffset),
                                           formatString);
     }
 
-    // Using Joda-Time is deprecated, but the getter returns org.joda.time.DateTimeZone for plugin compatibility.
-    // It won't be removed very soon at least until Embulk v0.10.
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/830
-    static TimestampFormatterRuby ofLegacy(final String formatString,
-                                           final org.joda.time.DateTimeZone jodaDateTimeZone) {
-        return new TimestampFormatterRuby(new org.jruby.util.RubyDateFormat(formatString, Locale.ENGLISH, true),
-                                          null,
-                                          jodaDateTimeZone,
+    static TimestampFormatterRuby ofLegacy(final String formatString, final ZoneId zoneId) {
+        return new TimestampFormatterRuby(RubyDateTimeFormatter.create(formatString),
+                                          zoneId,
                                           formatString);
     }
 
@@ -39,19 +33,22 @@ public class TimestampFormatterRuby extends TimestampFormatter {
     @Deprecated
     @Override
     public org.joda.time.DateTimeZone getTimeZone() {
-        return this.jodaDateTimeZone;
+        if (this.zoneId instanceof ZoneOffset) {
+            return TimeZoneIds.convertZoneOffsetToJodaDateTimeZone((ZoneOffset) this.zoneId);
+        } else {
+            return org.joda.time.DateTimeZone.forTimeZone(TimeZone.getTimeZone(this.zoneId));
+        }
     }
 
     public String format(final Timestamp value) {
-        // TODO: Optimize by using reused StringBuilder.
-        this.formatter.setDateTime(new org.joda.time.DateTime(value.getEpochSecond() * 1000, this.jodaDateTimeZone));
-        this.formatter.setNSec(value.getNano());
-        return this.formatter.format(null);
+        if (this.zoneId instanceof ZoneOffset) {
+            return this.formatter.format(OffsetDateTime.ofInstant(value.getInstant(), this.zoneId));
+        } else {
+            return this.formatter.format(ZonedDateTime.ofInstant(value.getInstant(), this.zoneId));
+        }
     }
 
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/830
-    private final org.jruby.util.RubyDateFormat formatter;
-    private final ZoneOffset zoneOffset;  // Nullable
-    private final org.joda.time.DateTimeZone jodaDateTimeZone;  // Not null
+    private final RubyDateTimeFormatter formatter;
+    private final ZoneId zoneId;  // Nullable
     private final String formatString;
 }

--- a/embulk-core/src/test/java/org/embulk/deps/TestDependencyCategory.java
+++ b/embulk-core/src/test/java/org/embulk/deps/TestDependencyCategory.java
@@ -14,7 +14,7 @@ public class TestDependencyCategory {
      */
     @Test
     public void testConstants() {
-        assertEquals(5, DependencyCategory.values().length);
+        assertEquals(6, DependencyCategory.values().length);
         assertEquals("CLI", DependencyCategory.CLI.getName());
         assertEquals("Embulk-Resource-Class-Path-Cli", DependencyCategory.CLI.getManifestAttributeName());
         assertEquals("Maven", DependencyCategory.MAVEN.getName());
@@ -25,5 +25,7 @@ public class TestDependencyCategory {
         assertEquals("Embulk-Resource-Class-Path-Config", DependencyCategory.CONFIG.getManifestAttributeName());
         assertEquals("Guess", DependencyCategory.GUESS.getName());
         assertEquals("Embulk-Resource-Class-Path-Guess", DependencyCategory.GUESS.getManifestAttributeName());
+        assertEquals("Timestamp", DependencyCategory.TIMESTAMP.getName());
+        assertEquals("Embulk-Resource-Class-Path-Timestamp", DependencyCategory.TIMESTAMP.getManifestAttributeName());
     }
 }

--- a/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatter.java
+++ b/embulk-core/src/test/java/org/embulk/spi/time/TestTimestampFormatter.java
@@ -30,6 +30,22 @@ public class TestTimestampFormatter {
                            "%Y-%m-%dT%H:%M:%S %Z",
                            "Asia/Tokyo",
                            "2017-02-28T11:00:45 JST");
+        testLegacyToFormat(OffsetDateTime.of(2017, 2, 28, 2, 0, 45, 0, ZoneOffset.UTC).toInstant(),
+                           "%Y-%m-%dT%H:%M:%S %Z",
+                           "America/Los_Angeles",
+                           "2017-02-27T18:00:45 PST");
+        testLegacyToFormat(OffsetDateTime.of(2017, 8, 28, 2, 0, 45, 0, ZoneOffset.UTC).toInstant(),
+                           "%Y-%m-%dT%H:%M:%S %#Z",
+                           "America/Los_Angeles",
+                           "2017-08-27T19:00:45 pdt");
+        testLegacyToFormat(OffsetDateTime.of(2017, 8, 28, 2, 0, 45, 0, ZoneOffset.UTC).toInstant(),
+                           "%Y-%m-%dT%H:%M:%S %Z",
+                           "UTC",
+                           "2017-08-28T02:00:45 UTC");
+        testLegacyToFormat(OffsetDateTime.of(2017, 8, 28, 2, 0, 45, 0, ZoneOffset.UTC).toInstant(),
+                           "%Y-%m-%dT%H:%M:%S %Z",
+                           "+09:00",
+                           "2017-08-28T11:00:45 +09:00");
     }
 
     private void testJavaToFormat(final Instant instant,

--- a/embulk-deps/timestamp/build.gradle
+++ b/embulk-deps/timestamp/build.gradle
@@ -1,0 +1,29 @@
+description = "Wrapper of Embulk's Timestamp-related dependency libraries"
+ext {
+    summary = "Embulk's dependency wrapper for Timestamp"
+}
+
+repositories {
+    mavenCentral()
+}
+
+configurations {
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
+
+dependencies {
+    compileOnly project(":embulk-core")
+
+    implementation "org.embulk:embulk-util-rubytime:0.3.2"
+}
+
+task prepareDependencyJars(type: Copy, dependsOn: "jar") {
+    doFirst {
+        delete file("${buildDir}/dependency_jars")
+        mkdir file("${buildDir}/dependency_jars")
+    }
+    into "${buildDir}/dependency_jars"
+    from configurations.runtimeClasspath
+    from jar.outputs.files
+}

--- a/embulk-deps/timestamp/config/checkstyle/suppressions.xml
+++ b/embulk-deps/timestamp/config/checkstyle/suppressions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.2//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress checks="JavadocMethod" files=".*"/>
+  <suppress checks="JavadocParagraph" files=".*"/>
+  <suppress checks="JavadocTagContinuationIndentation" files=".*"/>
+  <suppress checks="SingleLineJavadoc" files=".*"/>
+  <suppress checks="SummaryJavadoc" files=".*"/>
+</suppressions>

--- a/embulk-deps/timestamp/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/timestamp/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.2

--- a/embulk-deps/timestamp/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-deps/timestamp/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.2

--- a/embulk-deps/timestamp/src/main/java/org/embulk/deps/timestamp/RubyDateTimeFormatterImpl.java
+++ b/embulk-deps/timestamp/src/main/java/org/embulk/deps/timestamp/RubyDateTimeFormatterImpl.java
@@ -1,0 +1,17 @@
+package org.embulk.deps.timestamp;
+
+import java.time.temporal.TemporalAccessor;
+import org.embulk.util.rubytime.RubyDateTimeFormatter;
+
+public final class RubyDateTimeFormatterImpl extends org.embulk.deps.timestamp.RubyDateTimeFormatter {
+    public RubyDateTimeFormatterImpl(final String pattern) {
+        this.formatter = RubyDateTimeFormatter.ofPattern(pattern);
+    }
+
+    @Override
+    public String format(final TemporalAccessor temporal) {
+        return this.formatter.formatWithZoneNameStyle(temporal, RubyDateTimeFormatter.ZoneNameStyle.SHORT);
+    }
+
+    private final RubyDateTimeFormatter formatter;
+}

--- a/embulk-standards/build.gradle
+++ b/embulk-standards/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     testImplementation project(":embulk-deps-buffer")
     testImplementation project(":embulk-deps-config")
     testImplementation project(":embulk-deps-guess")
+    testImplementation project(":embulk-deps-timestamp")
 
     jruby "org.jruby:jruby-complete:" + rootProject.jrubyVersion
     rubyTestRuntime project(":embulk-api")
@@ -64,6 +65,7 @@ task rubyTestVanilla(type: JavaExec, dependsOn: [
         ":embulk-deps-buffer:prepareDependencyJars",
         ":embulk-deps-config:prepareDependencyJars",
         ":embulk-deps-guess:prepareDependencyJars",
+        ":embulk-deps-timestamp:prepareDependencyJars",
         ]) {
     workingDir = file("${project.projectDir}");
     classpath = configurations.rubyTestRuntime

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,8 @@ include 'embulk-deps-guess'
 project(':embulk-deps-guess').projectDir = file('embulk-deps/guess')
 include 'embulk-deps-maven'
 project(':embulk-deps-maven').projectDir = file('embulk-deps/maven')
+include 'embulk-deps-timestamp'
+project(':embulk-deps-timestamp').projectDir = file('embulk-deps/timestamp')
 include 'embulk-standards'
 include 'embulk-junit4'
 include 'embulk-docs'


### PR DESCRIPTION
See #830 for the details. In short, this use of `org.jruby.util.RubyDataFormat` is the blocker to make JRuby optional.