### PR TITLE
Add a new `toJson` method in `org.embulk.config.DataSource`

### DIFF
--- a/embulk-api/src/main/java/org/embulk/config/ConfigSource.java
+++ b/embulk-api/src/main/java/org/embulk/config/ConfigSource.java
@@ -31,11 +31,17 @@ public interface ConfigSource extends DataSource {
     /**
      * Loads this configuration as a task class like {@code PluginTask}.
      *
+     * <p>This method will be deprecated. Loading configs will be replaced by another library
+     * {@code embulk-util-config} on plugin's side.
+     *
      * @param <T>   the task class to load this configuration as
      * @param taskType  the task class to load this configuration as
      * @return a task class instance loaded
      */
-    <T> T loadConfig(Class<T> taskType);
+    default <T> T loadConfig(Class<T> taskType) {
+        throw new UnsupportedOperationException(
+                "ConfigSource#loadConfig does not work with: " + this.getClass().getCanonicalName());
+    }
 
     /**
      * Returns a nested value under {@code attrName}.

--- a/embulk-api/src/main/java/org/embulk/config/DataSource.java
+++ b/embulk-api/src/main/java/org/embulk/config/DataSource.java
@@ -145,4 +145,11 @@ public interface DataSource {
      * @return itself after the other {@link org.embulk.config.DataSource} is merged
      */
     DataSource merge(DataSource other);
+
+    /**
+     * Returns a JSON representation of itself.
+     *
+     * @return its JSON representation in {@link java.lang.String}
+     */
+    String toJson();
 }

--- a/embulk-api/src/main/java/org/embulk/config/TaskSource.java
+++ b/embulk-api/src/main/java/org/embulk/config/TaskSource.java
@@ -31,11 +31,17 @@ public interface TaskSource extends DataSource {
     /**
      * Loads this configuration as a task class like {@code PluginTask}.
      *
+     * <p>This method will be deprecated. Loading tasks will be replaced by another library
+     * {@code embulk-util-config} on plugin's side.
+     *
      * @param <T>   the task class to load this configuration as
      * @param taskType  the task class to load this configuration as
      * @return a task class instance loaded
      */
-    <T> T loadTask(Class<T> taskType);
+    default <T> T loadTask(Class<T> taskType) {
+        throw new UnsupportedOperationException(
+                "TaskSource#loadTask does not work with: " + this.getClass().getCanonicalName());
+    }
 
     /**
      * Returns a nested value under {@code attrName}.

--- a/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
+++ b/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
@@ -177,6 +177,11 @@ public class DataSourceImpl
         return this;
     }
 
+    @Override
+    public String toJson() {
+        return this.model.writeObject(this.data);
+    }
+
     private static void mergeJsonObject(ObjectNode src, ObjectNode other) {
         Iterator<Map.Entry<String, JsonNode>> ite = other.fields();
         while (ite.hasNext()) {

--- a/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
+++ b/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
@@ -128,28 +128,40 @@ public class DataSourceImpl
         return this;
     }
 
-    @SuppressWarnings("deprecation")  // Calling getObjectNode().
     @Override
     public DataSourceImpl setNested(String attrName, DataSource v) {
-        if (v instanceof DataSourceImpl) {
-            final DataSourceImpl vImpl = (DataSourceImpl) v;
-            data.set(attrName, vImpl.getObjectNode());
+        if (v == null) {
+            this.data.set(attrName, null);
         } else {
-            throw new IllegalArgumentException("DataSourceImpl#setNested aceepts only DataSourceImpl.");
+            final String vJsonStringified = v.toJson();
+            if (vJsonStringified == null) {
+                throw new ConfigException(new NullPointerException("DataSource#setNested accepts only valid DataSource"));
+            }
+            final JsonNode vJsonNode = this.model.readObject(JsonNode.class, vJsonStringified);
+            if (!vJsonNode.isObject()) {
+                throw new ConfigException(new ClassCastException("DataSource#setNested accepts only valid JSON object"));
+            }
+            this.data.set(attrName, (ObjectNode) vJsonNode);
         }
         return this;
     }
 
-    @SuppressWarnings("deprecation")  // Calling getAttributes().
     @Override
     public DataSourceImpl setAll(DataSource other) {
-        if (other instanceof DataSourceImpl) {
-            final DataSourceImpl otherImpl = (DataSourceImpl) other;
-            for (Map.Entry<String, JsonNode> field : otherImpl.getAttributes()) {
-                data.set(field.getKey(), field.getValue());
-            }
-        } else {
-            throw new IllegalArgumentException("DataSourceImpl#setAll aceepts only DataSourceImpl.");
+        if (other == null) {
+            throw new ConfigException(new NullPointerException("DataSource#setAll accepts only non-null value"));
+        }
+        final String otherJsonStringified = other.toJson();
+        if (otherJsonStringified == null) {
+            throw new ConfigException(new NullPointerException("DataSource#setAll accepts only valid DataSource"));
+        }
+        final JsonNode otherJsonNode = this.model.readObject(JsonNode.class, otherJsonStringified);
+        if (!otherJsonNode.isObject()) {
+            throw new ConfigException(new ClassCastException("DataSource#setAll accepts only valid JSON object"));
+        }
+        final ObjectNode otherObjectNode = (ObjectNode) otherJsonNode;
+        for (Map.Entry<String, JsonNode> field : (Iterable<Map.Entry<String, JsonNode>>) () -> otherObjectNode.fields()) {
+            this.data.set(field.getKey(), field.getValue());
         }
         return this;
     }
@@ -165,15 +177,20 @@ public class DataSourceImpl
         return newInstance(model, data.deepCopy());
     }
 
-    @SuppressWarnings("deprecation")  // Calling getObjectNode().
     @Override
     public DataSourceImpl merge(DataSource other) {
-        if (other instanceof DataSourceImpl) {
-            final DataSourceImpl otherImpl = (DataSourceImpl) other;
-            mergeJsonObject(data, otherImpl.deepCopy().getObjectNode());
-        } else {
-            throw new IllegalArgumentException("DataSourceImpl#merge aceepts only DataSourceImpl.");
+        if (other == null) {
+            throw new ConfigException(new NullPointerException("DataSource#merge accepts only non-null value"));
         }
+        final String otherJsonStringified = other.toJson();
+        if (otherJsonStringified == null) {
+            throw new ConfigException(new NullPointerException("DataSource#merge accepts only valid DataSource"));
+        }
+        final JsonNode otherJsonNode = this.model.readObject(JsonNode.class, otherJsonStringified);
+        if (!otherJsonNode.isObject()) {
+            throw new ConfigException(new ClassCastException("DataSource#setAll accepts only valid JSON object"));
+        }
+        mergeJsonObject(data, (ObjectNode) otherJsonNode);
         return this;
     }
 
@@ -232,10 +249,22 @@ public class DataSourceImpl
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof DataSourceImpl)) {
+        if (other == null) {
             return false;
         }
-        return data.equals(((DataSourceImpl) other).getObjectNode());
+        if (!(other instanceof DataSource)) {
+            return false;
+        }
+        final DataSource otherDataSource = (DataSource) other;
+        final String otherJsonStringified = otherDataSource.toJson();
+        if (otherJsonStringified == null) {
+            return false;
+        }
+        final JsonNode otherJsonNode = this.model.readObject(JsonNode.class, otherJsonStringified);
+        if (!otherJsonNode.isObject()) {
+            return false;
+        }
+        return data.equals((ObjectNode) otherJsonNode);
     }
 
     @Override

--- a/embulk-core/src/test/java/org/embulk/config/TestConfigSource.java
+++ b/embulk-core/src/test/java/org/embulk/config/TestConfigSource.java
@@ -4,6 +4,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.spi.Exec;
 import org.embulk.spi.time.TimestampParser;
@@ -74,7 +79,7 @@ public class TestConfigSource {
     }
 
     @Test
-    public void testSetGet() {
+    public void testSetGet() throws IOException {
         config.set("boolean", true);
         config.set("int", 3);
         config.set("double", 0.2);
@@ -86,6 +91,28 @@ public class TestConfigSource {
         assertEquals(0.2, (double) config.get(double.class, "double"), 0.001);
         assertEquals(Long.MAX_VALUE, (long) config.get(long.class, "long"));
         assertEquals("sf", config.get(String.class, "string"));
+
+        final JsonNode json = (new ObjectMapper()).readTree(config.toJson());
+        assertTrue(json.isObject());
+        final ArrayList<String> fieldNames = new ArrayList<>();
+        json.fieldNames().forEachRemaining(fieldNames::add);
+        Collections.sort(fieldNames);
+        assertEquals(5, fieldNames.size());
+        assertEquals("boolean", fieldNames.get(0));
+        assertTrue(json.get("boolean").isBoolean());
+        assertEquals(true, json.get("boolean").asBoolean());
+        assertEquals("double", fieldNames.get(1));
+        assertTrue(json.get("double").isDouble());
+        assertEquals(0.2, json.get("double").asDouble(), 0.001);
+        assertEquals("int", fieldNames.get(2));
+        assertTrue(json.get("int").isInt());
+        assertEquals(3, json.get("int").asInt());
+        assertEquals("long", fieldNames.get(3));
+        assertTrue(json.get("long").isLong());
+        assertEquals(Long.MAX_VALUE, json.get("long").asLong());
+        assertEquals("string", fieldNames.get(4));
+        assertTrue(json.get("string").isTextual());
+        assertEquals("sf", json.get("string").asText());
     }
 
     @Test


### PR DESCRIPTION
We're going to separate the config processing part (mapping `ConfigSource`/`TaskSource` into `(Plugin)Task` interface) into another utility artifact `embulk-util-config` to process configs on plugin's side.

To realize that, we have to have a method to retrieve `DataSource`'s internal structure without leaking Jackson instances, but as of now, we only have `getAttributes` and `getObjectNode` to return Jackson instances.

To retrieve `DataSource`'s internal structure, this PR is to add a new `toJson` method to stringify `DataSource`'s internal JSON structure so that `embulk-util-config` can rebuild its own JSON structure.