### PR TITLE
Implement a default implementation for org.embulk.config.DataSource#toJson

### DIFF
--- a/embulk-api/src/main/java/org/embulk/config/DataSource.java
+++ b/embulk-api/src/main/java/org/embulk/config/DataSource.java
@@ -151,5 +151,8 @@ public interface DataSource {
      *
      * @return its JSON representation in {@link java.lang.String}
      */
-    String toJson();
+    default String toJson() {
+        throw new UnsupportedOperationException(
+                "ConfigSource#toJson is not implemented with: " + this.getClass().getCanonicalName());
+    }
 }


### PR DESCRIPTION
The `toJson` method is newly added in DataSource. Nice to have a default implementation
for it so that an unexpected combination of newer DataSource and older DataSourceImpl
won't cause ununderstandable errors.