### PR TITLE
Use "api" in "java-library" to build embulk-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id "java-library"
     id "maven-publish"
     id "jacoco"
     id "com.jfrog.bintray" version "1.8.4" apply false
@@ -61,6 +62,7 @@ def subprojectNamesReleasedInBintray = [
 def subprojectNamesReleased = subprojectNamesReleasedInMavenCentral + subprojectNamesReleasedInBintray
 
 configure(subprojects.findAll { subprojectNamesReleased.contains(it.name) }) {
+    apply plugin: "java-library"
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'maven-publish'

--- a/embulk-api/build.gradle
+++ b/embulk-api/build.gradle
@@ -10,4 +10,5 @@ configurations {
 }
 
 dependencies {
+    // Its dependencies would be declared with "api", not "implementation".
 }

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -11,8 +11,8 @@ processResources.from("${buildDir}/embulk_gem_as_resources", "${buildDir}/depend
 configurations {
     // com.google.inject:guice depends on asm and cglib but version of the libraries conflict
     // with ones bundled in jruby-complete and cause bytecode compatibility error
-    implementation.exclude group: "asm", module: "asm"
-    implementation.exclude group: "org.sonatype.sisu.inject", module: "cglib"
+    api.exclude group: "asm", module: "asm"
+    api.exclude group: "org.sonatype.sisu.inject", module: "cglib"
     compileClasspath.resolutionStrategy.activateDependencyLocking()
     runtimeClasspath.resolutionStrategy.activateDependencyLocking()
 }
@@ -23,30 +23,32 @@ repositories {
 
 // determine which dependencies have updates: $ gradle dependencyUpdates
 dependencies {
-    implementation project(":embulk-api")
-
-    implementation "com.google.guava:guava:18.0"
-    implementation "com.google.inject:guice:4.0"
-    implementation "com.google.inject.extensions:guice-multibindings:4.0"
-    implementation "javax.inject:javax.inject:1"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.6.7"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7"
-    implementation "com.fasterxml.jackson.module:jackson-module-guice:2.6.7"
-    implementation "org.slf4j:slf4j-api:1.7.12"
-    implementation "org.jruby:jruby-complete:" + rootProject.jrubyVersion
-    implementation "javax.validation:validation-api:1.1.0.Final"
-    implementation "org.apache.bval:bval-jsr303:0.5"
-    implementation "joda-time:joda-time:2.9.2"
-    implementation "org.msgpack:msgpack-core:0.8.11"
+    // Embulk plugins have expected that embulk-core's dependencies are declared as "compile" in pom.xml.
+    // Although those dependencies would be finally removed from embulk-core's direct dependencies,
+    // those "compile" declaration would be kept so that plugin developers won't be confused unnecessarily.
+    api project(":embulk-api")
+    api "com.google.guava:guava:18.0"
+    api "com.google.inject:guice:4.0"
+    api "com.google.inject.extensions:guice-multibindings:4.0"
+    api "javax.inject:javax.inject:1"
+    api "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
+    api "com.fasterxml.jackson.core:jackson-core:2.6.7"
+    api "com.fasterxml.jackson.core:jackson-databind:2.6.7"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7"
+    api "com.fasterxml.jackson.module:jackson-module-guice:2.6.7"
+    api "org.slf4j:slf4j-api:1.7.12"
+    api "org.jruby:jruby-complete:" + rootProject.jrubyVersion
+    api "javax.validation:validation-api:1.1.0.Final"
+    api "org.apache.bval:bval-jsr303:0.5"
+    api "joda-time:joda-time:2.9.2"
+    api "org.msgpack:msgpack-core:0.8.11"
 
     // bval-jsr303:0.5 depends on commons-lang3:3.1,
     // but it was upgraded to 3.4 when maven-aether-provider:3.3.9 was introduced.
     // Maven-related dependencies are moved to embulk-deps-maven.
-    implementation "org.apache.commons:commons-lang3:3.4"
+    api "org.apache.commons:commons-lang3:3.4"
 
     testImplementation "junit:junit:4.12"
     testImplementation "ch.qos.logback:logback-classic:1.1.3"

--- a/embulk-deps/buffer/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/buffer/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
+com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
+com.google.inject:guice:4.0
+commons-beanutils:commons-beanutils-core:1.8.3
 io.airlift:slice:0.9
 io.netty:netty-buffer:4.0.44.Final
 io.netty:netty-common:4.0.44.Final
+javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
+org.apache.commons:commons-lang3:3.4
+org.jruby:jruby-complete:9.1.15.0
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12

--- a/embulk-deps/cli/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/cli/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,28 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
+com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
+com.google.inject:guice:4.0
+commons-beanutils:commons-beanutils-core:1.8.3
 commons-cli:commons-cli:1.3.1
 commons-collections:commons-collections:3.2.1
 commons-lang:commons-lang:2.4
+javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
+org.apache.commons:commons-lang3:3.4
 org.apache.velocity:velocity:1.7
+org.jruby:jruby-complete:9.1.15.0
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12

--- a/embulk-deps/config/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/config/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,4 +1,25 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
+com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
+com.google.inject:guice:4.0
+commons-beanutils:commons-beanutils-core:1.8.3
+javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
+org.apache.commons:commons-lang3:3.4
+org.jruby:jruby-complete:9.1.15.0
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12
 org.yaml:snakeyaml:1.18

--- a/embulk-deps/guess/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/guess/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,4 +1,25 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
+com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
+com.google.inject:guice:4.0
 com.ibm.icu:icu4j:54.1.1
+commons-beanutils:commons-beanutils-core:1.8.3
+javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
+org.apache.commons:commons-lang3:3.4
+org.jruby:jruby-complete:9.1.15.0
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12

--- a/embulk-deps/maven/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/maven/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,23 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
+com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
+com.google.inject:guice:4.0
+commons-beanutils:commons-beanutils-core:1.8.3
+javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
 org.apache.commons:commons-lang3:3.8.1
 org.apache.maven.resolver:maven-resolver-api:1.3.3
 org.apache.maven.resolver:maven-resolver-impl:1.3.3
@@ -15,3 +32,6 @@ org.apache.maven:maven-resolver-provider:3.6.1
 org.codehaus.plexus:plexus-component-annotations:1.7.1
 org.codehaus.plexus:plexus-interpolation:1.25
 org.codehaus.plexus:plexus-utils:3.2.0
+org.jruby:jruby-complete:9.1.15.0
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12

--- a/embulk-deps/timestamp/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/timestamp/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,4 +1,25 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
+com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
+com.google.inject:guice:4.0
+commons-beanutils:commons-beanutils-core:1.8.3
+javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
+org.apache.commons:commons-lang3:3.4
 org.embulk:embulk-util-rubytime:0.3.2
+org.jruby:jruby-complete:9.1.15.0
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12

--- a/embulk-junit4/build.gradle
+++ b/embulk-junit4/build.gradle
@@ -10,11 +10,11 @@ configurations {
 }
 
 dependencies {
-    implementation "junit:junit:4.13"
-    implementation "org.hamcrest:hamcrest-library:1.3"
+    api "junit:junit:4.13"
+    api "org.hamcrest:hamcrest-library:1.3"
 
-    implementation project(":embulk-api")
-    implementation project(":embulk-core")
+    api project(":embulk-api")
+    api project(":embulk-core")
     compileOnly "org.slf4j:slf4j-api:1.7.12"
     compileOnly "com.google.guava:guava:18.0"
     compileOnly "com.google.inject:guice:4.0"

--- a/embulk-junit4/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-junit4/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,10 +2,26 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 aopalliance:aopalliance:1.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
 com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
 com.google.inject:guice:4.0
+commons-beanutils:commons-beanutils-core:1.8.3
 javax.inject:javax.inject:1
+javax.validation:validation-api:1.1.0.Final
+joda-time:joda-time:2.9.2
 junit:junit:4.13
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
+org.apache.commons:commons-lang3:3.4
 org.hamcrest:hamcrest-core:1.3
 org.hamcrest:hamcrest-library:1.3
+org.jruby:jruby-complete:9.1.15.0
+org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.12

--- a/embulk-standards/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-standards/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,14 +2,24 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 aopalliance:aopalliance:1.0
-com.fasterxml.jackson.core:jackson-annotations:2.6.0
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
+com.fasterxml.jackson.module:jackson-module-guice:2.6.7
 com.google.guava:guava:18.0
+com.google.inject.extensions:guice-multibindings:4.0
 com.google.inject:guice:4.0
+commons-beanutils:commons-beanutils-core:1.8.3
 javax.inject:javax.inject:1
 javax.validation:validation-api:1.1.0.Final
 joda-time:joda-time:2.9.2
+org.apache.bval:bval-core:0.5
+org.apache.bval:bval-jsr303:0.5
 org.apache.commons:commons-compress:1.10
+org.apache.commons:commons-lang3:3.4
+org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.12


### PR DESCRIPTION
Since v0.10.0 after Embulk started using "implementation" to declare dependencies instead of "compile", embulk-core's dependencies are defined as "runtime" instead of "compile" in their pom.xml.

https://bintray.com/embulk/maven/embulk/0.9.23#files/org%2Fembulk%2Fembulk-core%2F0.9.23
https://bintray.com/embulk/maven/embulk/0.10.0#files/org%2Fembulk%2Fembulk-core%2F0.10.0

Embulk plugins have expected that embulk-core's dependencies are declared as "compile" in pom.xml. So, plugins didn't declare such dependencies of embulk-core as their own dependencies.

As of now, keeping them as "compile" would be better because:
* This change was unexpected.
* We plan to remove many finally from direct dependencies of embulk-core.
  Plugins are expected to follow when the removal happens, not by this unexpected change.
  Impacting plugins multiple times is not very good.