### PR TITLE
Call LoggerFactory.getLogger more directly to prepare for removing logger binding from Guice

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -39,7 +39,9 @@ public class ExecModule implements Module {
 
         binder.bind(BulkLoader.class);
 
+        // TODO: Remove this ILoggerFactory binding.
         binder.bind(ILoggerFactory.class).toProvider(LoggerProvider.class).in(Scopes.SINGLETON);
+
         binder.bind(ModelManager.class).in(Scopes.SINGLETON);
         binder.bind(BufferAllocator.class).toInstance(this.createBufferAllocatorFromSystemConfig());
         binder.bind(TempFileSpaceAllocator.class).toInstance(new SimpleTempFileSpaceAllocator());

--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyInitializer.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyInitializer.java
@@ -10,8 +10,8 @@ import java.util.Collections;
 import java.util.List;
 import org.embulk.config.ModelManager;
 import org.embulk.spi.BufferAllocator;
-import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class JRubyInitializer {
     private JRubyInitializer(
@@ -141,7 +141,7 @@ public final class JRubyInitializer {
         jruby.callMethod(jruby.runScriptlet("Embulk"), "logger=", jruby.callMethod(
                              jruby.runScriptlet("Embulk::Logger"),
                              "new",
-                             injector.getInstance(ILoggerFactory.class).getLogger("ruby")));
+                             LoggerFactory.getLogger("ruby")));
     }
 
     // TODO: Remove these probing methods, and test through mocked ScriptingContainerDelegate.

--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.ModelManager;
 import org.embulk.spi.BufferAllocator;
-import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
 
 public class JRubyScriptingModule implements Module {
     @Override
@@ -33,7 +33,7 @@ public class JRubyScriptingModule implements Module {
 
             this.initializer = JRubyInitializer.of(
                     injector,
-                    injector.getInstance(ILoggerFactory.class).getLogger("init"),
+                    LoggerFactory.getLogger("init"),
 
                     embulkSystemProperties.getProperty("gem_home", null),
                     embulkSystemProperties.getProperty("gem_path", null),


### PR DESCRIPTION
`Exec.getLogger` is going to be replaced with SLF4J's direct `LoggerFactory.getLogger`, and its background `ILoggerFactory` Guice binding would be removed.

This is the last step of the replacement inside `embulk-core`.