### PR TITLE
Replace some SerDe classes to independent Jackson Modules

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -20,7 +20,7 @@ import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.ExecutorPlugin;
 import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.TempFileSpaceAllocator;
-import org.embulk.spi.time.DateTimeZoneSerDe;
+import org.embulk.spi.time.DateTimeZoneJacksonModule;
 import org.embulk.spi.time.TimestampSerDe;
 import org.embulk.spi.unit.LocalFileSerDe;
 import org.embulk.spi.util.CharsetSerDe;
@@ -31,6 +31,7 @@ public class ExecModule implements Module {
         this.embulkSystemProperties = embulkSystemProperties;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void configure(final Binder binder) {
         if (binder == null) {
@@ -55,7 +56,7 @@ public class ExecModule implements Module {
 
         // SerDe
         final ObjectMapperModule mapper = new ObjectMapperModule();
-        DateTimeZoneSerDe.configure(mapper);
+        mapper.registerModule(new DateTimeZoneJacksonModule());  // Deprecated -- to be removed.
         TimestampSerDe.configure(mapper);
         CharsetSerDe.configure(mapper);
         LocalFileSerDe.configure(mapper);

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -22,7 +22,7 @@ import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.TempFileSpaceAllocator;
 import org.embulk.spi.time.DateTimeZoneJacksonModule;
 import org.embulk.spi.time.TimestampJacksonModule;
-import org.embulk.spi.unit.LocalFileSerDe;
+import org.embulk.spi.unit.LocalFileJacksonModule;
 import org.embulk.spi.util.CharsetJacksonModule;
 import org.slf4j.ILoggerFactory;
 
@@ -59,7 +59,7 @@ public class ExecModule implements Module {
         mapper.registerModule(new DateTimeZoneJacksonModule());  // Deprecated -- to be removed.
         mapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
         mapper.registerModule(new CharsetJacksonModule());
-        LocalFileSerDe.configure(mapper);
+        mapper.registerModule(new LocalFileJacksonModule());
         mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
         mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
         mapper.registerModule(new JodaModule());  // jackson-datatype-joda

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -23,7 +23,7 @@ import org.embulk.spi.TempFileSpaceAllocator;
 import org.embulk.spi.time.DateTimeZoneJacksonModule;
 import org.embulk.spi.time.TimestampJacksonModule;
 import org.embulk.spi.unit.LocalFileSerDe;
-import org.embulk.spi.util.CharsetSerDe;
+import org.embulk.spi.util.CharsetJacksonModule;
 import org.slf4j.ILoggerFactory;
 
 public class ExecModule implements Module {
@@ -58,7 +58,7 @@ public class ExecModule implements Module {
         final ObjectMapperModule mapper = new ObjectMapperModule();
         mapper.registerModule(new DateTimeZoneJacksonModule());  // Deprecated -- to be removed.
         mapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
-        CharsetSerDe.configure(mapper);
+        mapper.registerModule(new CharsetJacksonModule());
         LocalFileSerDe.configure(mapper);
         mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
         mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -21,7 +21,7 @@ import org.embulk.spi.ExecutorPlugin;
 import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.TempFileSpaceAllocator;
 import org.embulk.spi.time.DateTimeZoneJacksonModule;
-import org.embulk.spi.time.TimestampSerDe;
+import org.embulk.spi.time.TimestampJacksonModule;
 import org.embulk.spi.unit.LocalFileSerDe;
 import org.embulk.spi.util.CharsetSerDe;
 import org.slf4j.ILoggerFactory;
@@ -57,7 +57,7 @@ public class ExecModule implements Module {
         // SerDe
         final ObjectMapperModule mapper = new ObjectMapperModule();
         mapper.registerModule(new DateTimeZoneJacksonModule());  // Deprecated -- to be removed.
-        TimestampSerDe.configure(mapper);
+        mapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
         CharsetSerDe.configure(mapper);
         LocalFileSerDe.configure(mapper);
         mapper.registerModule(new GuavaModule());  // jackson-datatype-guava

--- a/embulk-core/src/main/java/org/embulk/spi/time/DateTimeZoneJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/DateTimeZoneJacksonModule.java
@@ -7,18 +7,16 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.module.guice.ObjectMapperModule;
 import java.io.IOException;
 
-public class DateTimeZoneSerDe {
-    public static void configure(ObjectMapperModule mapper) {
-        SimpleModule module = new SimpleModule();
-        module.addSerializer(org.joda.time.DateTimeZone.class, new DateTimeZoneSerializer());
-        module.addDeserializer(org.joda.time.DateTimeZone.class, new DateTimeZoneDeserializer());
-        mapper.registerModule(module);
+@Deprecated
+public final class DateTimeZoneJacksonModule extends SimpleModule {
+    public DateTimeZoneJacksonModule() {
+        this.addSerializer(org.joda.time.DateTimeZone.class, new DateTimeZoneSerializer());
+        this.addDeserializer(org.joda.time.DateTimeZone.class, new DateTimeZoneDeserializer());
     }
 
-    public static class DateTimeZoneSerializer extends JsonSerializer<org.joda.time.DateTimeZone> {
+    private static class DateTimeZoneSerializer extends JsonSerializer<org.joda.time.DateTimeZone> {
         @Override
         public void serialize(org.joda.time.DateTimeZone value, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException {
@@ -26,8 +24,7 @@ public class DateTimeZoneSerDe {
         }
     }
 
-    public static class DateTimeZoneDeserializer
-            extends FromStringDeserializer<org.joda.time.DateTimeZone> {
+    private static class DateTimeZoneDeserializer extends FromStringDeserializer<org.joda.time.DateTimeZone> {
         public DateTimeZoneDeserializer() {
             super(org.joda.time.DateTimeZone.class);
         }

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampJacksonModule.java
@@ -7,18 +7,16 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.module.guice.ObjectMapperModule;
 import java.io.IOException;
 
-public class TimestampSerDe {
-    public static void configure(ObjectMapperModule mapper) {
-        SimpleModule module = new SimpleModule();
-        module.addSerializer(Timestamp.class, new TimestampSerializer());
-        module.addDeserializer(Timestamp.class, new TimestampDeserializer());
-        mapper.registerModule(module);
+@Deprecated
+public final class TimestampJacksonModule extends SimpleModule {
+    public TimestampJacksonModule() {
+        this.addSerializer(Timestamp.class, new TimestampSerializer());
+        this.addDeserializer(Timestamp.class, new TimestampDeserializer());
     }
 
-    public static class TimestampSerializer extends JsonSerializer<Timestamp> {
+    private static class TimestampSerializer extends JsonSerializer<Timestamp> {
         @Override
         public void serialize(Timestamp value, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException {
@@ -26,7 +24,7 @@ public class TimestampSerDe {
         }
     }
 
-    public static class TimestampDeserializer extends FromStringDeserializer<Timestamp> {
+    private static class TimestampDeserializer extends FromStringDeserializer<Timestamp> {
         public TimestampDeserializer() {
             super(Timestamp.class);
         }

--- a/embulk-core/src/main/java/org/embulk/spi/unit/LocalFileJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/spi/unit/LocalFileJacksonModule.java
@@ -8,16 +8,13 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.module.guice.ObjectMapperModule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-public class LocalFileSerDe {
-    public static void configure(ObjectMapperModule mapper) {
-        SimpleModule module = new SimpleModule();
-        module.addSerializer(LocalFile.class, new LocalFileSerializer());
-        module.addDeserializer(LocalFile.class, new LocalFileDeserializer());
-        mapper.registerModule(module);
+public final class LocalFileJacksonModule extends SimpleModule {
+    public LocalFileJacksonModule() {
+        this.addSerializer(LocalFile.class, new LocalFileSerializer());
+        this.addDeserializer(LocalFile.class, new LocalFileDeserializer());
     }
 
     private static class LocalFileSerializer extends JsonSerializer<LocalFile> {

--- a/embulk-core/src/main/java/org/embulk/spi/util/CharsetJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/CharsetJacksonModule.java
@@ -7,19 +7,16 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.module.guice.ObjectMapperModule;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-public class CharsetSerDe {
-    public static void configure(ObjectMapperModule mapper) {
-        SimpleModule module = new SimpleModule();
-        module.addSerializer(Charset.class, new CharsetSerializer());
-        module.addDeserializer(Charset.class, new CharsetDeserializer());
-        mapper.registerModule(module);
+public final class CharsetJacksonModule extends SimpleModule {
+    public CharsetJacksonModule() {
+        this.addSerializer(Charset.class, new CharsetSerializer());
+        this.addDeserializer(Charset.class, new CharsetDeserializer());
     }
 
-    public static class CharsetSerializer extends JsonSerializer<Charset> {
+    private static class CharsetSerializer extends JsonSerializer<Charset> {
         @Override
         public void serialize(Charset value, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException {
@@ -27,7 +24,7 @@ public class CharsetSerDe {
         }
     }
 
-    public static class CharsetDeserializer extends FromStringDeserializer<Charset> {
+    private static class CharsetDeserializer extends FromStringDeserializer<Charset> {
         public CharsetDeserializer() {
             super(Charset.class);
         }


### PR DESCRIPTION
For unknown reasons, some Jackson Serializers and Deserializers (`*SerDe`) have been implemented to register only into `ObjectMapperModule` (Guice `Module`) only for `ModelManager`, not as common Jackson `Module`s. (Note that: Guice `Module` and Jackson `Module` are totally different concepts.)

But, they can be implemented as Jackson `Module`s, and that would be more general-purpose. As we want to use them for general `ObjectMapper` (in next #1263), they would be implemented as Jackson `Module`s.