### PR TITLE
Stop using ModelManager in PreviewPrinter

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
@@ -212,15 +212,14 @@ public class EmbulkRunner {
 
     private void previewInternal(final ConfigSource configSource, final String format) throws IOException {
         final PreviewResult previewResult = this.embed.preview(configSource);
-        final ModelManager modelManager = this.embed.getModelManager();
 
         final PreviewPrinter printer;
         switch (format != null ? format : "table") {
             case "table":
-                printer = new TablePreviewPrinter(System.out, modelManager, previewResult.getSchema());
+                printer = new TablePreviewPrinter(System.out, previewResult.getSchema());
                 break;
             case "vertical":
-                printer = new VerticalPreviewPrinter(System.out, modelManager, previewResult.getSchema());
+                printer = new VerticalPreviewPrinter(System.out, previewResult.getSchema());
                 break;
             default:
                 throw new IllegalArgumentException(

--- a/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
@@ -1,15 +1,23 @@
 package org.embulk.command;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.text.NumberFormat;
 import java.util.List;
 import java.util.Locale;
-import org.embulk.config.ModelManager;
 import org.embulk.spi.Page;
 import org.embulk.spi.Schema;
+import org.embulk.spi.time.DateTimeZoneJacksonModule;
 import org.embulk.spi.time.Timestamp;
+import org.embulk.spi.time.TimestampJacksonModule;
+import org.embulk.spi.unit.LocalFileJacksonModule;
+import org.embulk.spi.util.CharsetJacksonModule;
 import org.embulk.spi.util.Pages;
 import org.msgpack.value.Value;
 
@@ -17,16 +25,27 @@ public abstract class PreviewPrinter implements Closeable {
     protected final PrintStream out;
     protected final Schema schema;
 
-    private final ModelManager modelManager;
+    private final ObjectMapper objectMapper;
     private final String[] stringValues;
     private final NumberFormat numberFormat;
 
-    public PreviewPrinter(PrintStream out, ModelManager modelManager, Schema schema) {
+    @SuppressWarnings("deprecation")
+    public PreviewPrinter(final PrintStream out, final Schema schema) {
         this.out = out;
-        this.modelManager = modelManager;
         this.schema = schema;
         this.stringValues = new String[schema.getColumnCount()];
         this.numberFormat = NumberFormat.getNumberInstance(Locale.ENGLISH);
+
+        this.objectMapper = new ObjectMapper();
+
+        // Those Jackson modules are registered for a while, but unnecessary ones will be swiped out.
+        this.objectMapper.registerModule(new DateTimeZoneJacksonModule());  // Deprecated -- to be removed.
+        this.objectMapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
+        this.objectMapper.registerModule(new CharsetJacksonModule());
+        this.objectMapper.registerModule(new LocalFileJacksonModule());
+        this.objectMapper.registerModule(new GuavaModule());
+        this.objectMapper.registerModule(new Jdk8Module());
+        this.objectMapper.registerModule(new JodaModule());
     }
 
     public final void printAllPages(List<Page> pages) throws IOException {
@@ -74,7 +93,11 @@ public abstract class PreviewPrinter implements Closeable {
         } else if (obj instanceof Value) {
             return obj.toString();
         } else {
-            return modelManager.writeObject(obj);
+            try {
+                return this.objectMapper.writeValueAsString(obj);
+            } catch (final JsonProcessingException ex) {
+                throw new RuntimeException(ex);
+            }
         }
     }
 }

--- a/embulk-core/src/main/java/org/embulk/command/TablePreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/TablePreviewPrinter.java
@@ -13,12 +13,14 @@ public class TablePreviewPrinter extends PreviewPrinter {
 
     private List<String[]> samples;
     private int sampleSize;
-    private String format = null;
-    private String border = null;
+    private String format;
+    private String border;
 
     public TablePreviewPrinter(PrintStream out, ModelManager modelManager, Schema schema) {
         super(out, modelManager, schema);
         this.samples = new ArrayList<String[]>();
+        this.format = null;
+        this.border = null;
         String[] header = new String[schema.getColumnCount()];
         for (int i = 0; i < header.length; i++) {
             header[i] = schema.getColumnName(i) + ":" + schema.getColumnType(i);

--- a/embulk-core/src/main/java/org/embulk/command/TablePreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/TablePreviewPrinter.java
@@ -5,7 +5,6 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.embulk.config.ModelManager;
 import org.embulk.spi.Schema;
 
 public class TablePreviewPrinter extends PreviewPrinter {
@@ -16,8 +15,8 @@ public class TablePreviewPrinter extends PreviewPrinter {
     private String format;
     private String border;
 
-    public TablePreviewPrinter(PrintStream out, ModelManager modelManager, Schema schema) {
-        super(out, modelManager, schema);
+    public TablePreviewPrinter(final PrintStream out, final Schema schema) {
+        super(out, schema);
         this.samples = new ArrayList<String[]>();
         this.format = null;
         this.border = null;

--- a/embulk-core/src/main/java/org/embulk/command/VerticalPreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/VerticalPreviewPrinter.java
@@ -2,15 +2,14 @@ package org.embulk.command;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import org.embulk.config.ModelManager;
 import org.embulk.spi.Schema;
 
 public class VerticalPreviewPrinter extends PreviewPrinter {
     private final String format;
     private int count;
 
-    public VerticalPreviewPrinter(PrintStream out, ModelManager modelManager, Schema schema) {
-        super(out, modelManager, schema);
+    public VerticalPreviewPrinter(final PrintStream out, final Schema schema) {
+        super(out, schema);
         this.format = "%" + maxColumnNameLength(schema) + "s (%" + maxColumnTypeNameLength(schema) + "s) : %s%n";
         this.count = 0;
     }

--- a/embulk-core/src/main/java/org/embulk/command/VerticalPreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/VerticalPreviewPrinter.java
@@ -7,11 +7,21 @@ import org.embulk.spi.Schema;
 
 public class VerticalPreviewPrinter extends PreviewPrinter {
     private final String format;
-    private int count = 0;
+    private int count;
 
     public VerticalPreviewPrinter(PrintStream out, ModelManager modelManager, Schema schema) {
         super(out, modelManager, schema);
         this.format = "%" + maxColumnNameLength(schema) + "s (%" + maxColumnTypeNameLength(schema) + "s) : %s%n";
+        this.count = 0;
+    }
+
+    @Override
+    protected void printRecord(String[] values) throws IOException {
+        count++;
+        out.format("*************************** %d ***************************%n", count);
+        for (int i = 0; i < schema.getColumnCount(); i++) {
+            out.format(format, schema.getColumnName(i), schema.getColumnType(i), values[i]);
+        }
     }
 
     private static int maxColumnNameLength(Schema schema) {
@@ -28,14 +38,5 @@ public class VerticalPreviewPrinter extends PreviewPrinter {
             max = Math.max(max, schema.getColumnType(i).toString().length());
         }
         return max;
-    }
-
-    @Override
-    protected void printRecord(String[] values) throws IOException {
-        count++;
-        out.format("*************************** %d ***************************%n", count);
-        for (int i = 0; i < schema.getColumnCount(); i++) {
-            out.format(format, schema.getColumnName(i), schema.getColumnType(i), values[i]);
-        }
     }
 }


### PR DESCRIPTION
To reduce dependency onto `ModelManager`, stopping to use `ModelManager` in `PreviewPrinter`.

`PreviewPrinter` is used only in the `embulk preview` command -- especially only when called via CLI. Not used from an embedded program using `EmbulkEmbed`.