### PR TITLE
Get the constructor of org.embulk.spi.Buffer protected

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/Buffer.java
+++ b/embulk-api/src/main/java/org/embulk/spi/Buffer.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
  * <p>At the same time, a constant {@code Buffer.EMPTY} has already been removed. Plugins cannot use it anymore.
  */
 public abstract class Buffer {
-    Buffer() {
+    protected Buffer() {
     }
 
     /**


### PR DESCRIPTION
The package-private constructor of `abstract org.embulk.spi.Buffer` was implemented in #1232 when it was moved to `embulk-api`, but I don't remember why I made it package-private... It blocked me from implementing another implementation of `Buffer` out of `org.embulk.spi`.

I don't think it needs to be package-private. Let me know if you see any concern.

(I thought removing the explicitly-defined constructor was another option to have just an implicit default constructor. I thought it should be okay, but kept it declared just because I didn't remember the original reason to have an explicit constructor, and I saw no practical difference there as it's an `abstract` class.)