### PR TITLE
Explicitly show the dump of an Exception for JEP 320 is a dummy Exception

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
@@ -281,7 +281,7 @@ public class PluginClassLoader extends URLClassLoader {
                     logger.info(
                             "Class " + className + " is loaded by the parent ClassLoader, which is removed by JEP 320. "
                             + "The plugin needs to include it on the plugin side. "
-                            + "See https://github.com/embulk/embulk/issues/1270 for more details.", new Exception());
+                            + "See https://github.com/embulk/embulk/issues/1270 for more details.", new DummyStackTraceDump());
                     this.hasJep320LoggedWithStackTrace = true;
                 } else {
                     logger.info("Class " + className + " is loaded by the parent ClassLoader, which is removed by JEP 320.");
@@ -301,6 +301,12 @@ public class PluginClassLoader extends URLClassLoader {
                         + "See https://github.com/embulk/embulk/issues/1270 for more details.",
                         ex);
             }
+        }
+    }
+
+    private static class DummyStackTraceDump extends Exception {
+        DummyStackTraceDump() {
+            super("[DUMMY] It is not an Exception. Just showing where classes which will be removed in JEP 320 are loaded.");
         }
     }
 


### PR DESCRIPTION
The log message introduced in #1271 is shown like:

```
2020-08-13 08:22:41.828 +0000 [INFO] (0001:transaction): Class javax.annotation.PostConstruct is loaded by the parent ClassLoader, which is removed by JEP 320. The plugin needs to include it on the plugin side. See https://github.com/embulk/embulk/issues/1270 for more details.
java.lang.Exception: null
	at org.embulk.plugin.PluginClassLoader.logInfoIfJep320Class(PluginClassLoader.java:281) [embulk-core-0.10.8.jar:0.10.8]
```

`java.lang.Exception: null` is much confusing. We'll want the stack trace to be shown as `DUMMY` explicitly.
