### PR TITLE
Bump up to v0.10.12-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {  // Applies all projects including the root project as well.
     }
 }
 
-version = "0.10.11-SNAPSHOT"
+version = "0.10.12-SNAPSHOT"
 
 description = 'Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control.'
 


### PR DESCRIPTION
Planning to release v0.10.11 with #1277, #1285, #1286, and #1287.

I already have #1289 and #1290 in the queue, but they can be impactful changes. So, I'm going to cut the version before them.