### PR TITLE
Replace Jackson annotations in Type to Jackson Module

### DIFF
--- a/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
@@ -47,6 +47,7 @@ public abstract class PreviewPrinter implements Closeable {
         this.objectMapper.registerModule(new LocalFileJacksonModule());
         this.objectMapper.registerModule(new ToStringJacksonModule());
         this.objectMapper.registerModule(new ToStringMapJacksonModule());
+        // PreviewPrinter would not need TypeJacksonModule.
         this.objectMapper.registerModule(new GuavaModule());
         this.objectMapper.registerModule(new Jdk8Module());
         this.objectMapper.registerModule(new JodaModule());

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -22,6 +22,7 @@ import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.TempFileSpaceAllocator;
 import org.embulk.spi.time.DateTimeZoneJacksonModule;
 import org.embulk.spi.time.TimestampJacksonModule;
+import org.embulk.spi.type.TypeJacksonModule;
 import org.embulk.spi.unit.LocalFileJacksonModule;
 import org.embulk.spi.unit.ToStringJacksonModule;
 import org.embulk.spi.unit.ToStringMapJacksonModule;
@@ -64,6 +65,7 @@ public class ExecModule implements Module {
         mapper.registerModule(new LocalFileJacksonModule());
         mapper.registerModule(new ToStringJacksonModule());
         mapper.registerModule(new ToStringMapJacksonModule());
+        mapper.registerModule(new TypeJacksonModule());
         mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
         mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
         mapper.registerModule(new JodaModule());  // jackson-datatype-joda

--- a/embulk-core/src/main/java/org/embulk/spi/type/Type.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/Type.java
@@ -1,11 +1,6 @@
 package org.embulk.spi.type;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-
-@JsonDeserialize(using = TypeDeserializer.class)
 public interface Type {
-    @JsonValue
     String getName();
 
     Class<?> getJavaType();

--- a/embulk-core/src/main/java/org/embulk/spi/type/TypeJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/spi/type/TypeJacksonModule.java
@@ -1,0 +1,25 @@
+package org.embulk.spi.type;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+
+public final class TypeJacksonModule extends SimpleModule {
+    public TypeJacksonModule() {
+        this.addSerializer(Type.class, new TypeSerializer());
+        this.addDeserializer(Type.class, new TypeDeserializer());
+    }
+
+    private static class TypeSerializer extends JsonSerializer<Type> {
+        @Override
+        public void serialize(
+                final Type value,
+                final JsonGenerator jsonGenerator,
+                final SerializerProvider provider)
+                throws IOException {
+            jsonGenerator.writeString(value.getName());
+        }
+    }
+}

--- a/embulk-core/src/test/java/org/embulk/spi/type/TestTypeSerDe.java
+++ b/embulk-core/src/test/java/org/embulk/spi/type/TestTypeSerDe.java
@@ -4,13 +4,12 @@ import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.embulk.EmbulkTestRuntime;
-import org.junit.Rule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import java.io.IOException;
 import org.junit.Test;
 
 public class TestTypeSerDe {
-    @Rule
-    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
     private static class HasType {
         private Type type;
@@ -29,10 +28,18 @@ public class TestTypeSerDe {
     }
 
     @Test
-    public void testGetType() {
+    public void testGetType() throws IOException {
         HasType type = new HasType(StringType.STRING);
-        String json = runtime.getModelManager().writeObject(type);
-        HasType decoded = runtime.getModelManager().readObject(HasType.class, json);
+        String json = MAPPER.writeValueAsString(type);
+        HasType decoded = MAPPER.readValue(json, HasType.class);
         assertTrue(StringType.STRING == decoded.getType());
+    }
+
+    private static final ObjectMapper MAPPER;
+
+    static {
+        MAPPER = new ObjectMapper();
+        MAPPER.registerModule(new Jdk8Module());
+        MAPPER.registerModule(new TypeJacksonModule());
     }
 }


### PR DESCRIPTION
Replacing Jackson annotation on `org.embulk.spi.type.Type` to Jackson `Module`-based SerDe implementation.

This is needed to move `Type` to `embulk-api` that is Jackson-independent. As its side effect, `Type` will not be able to get converted out of `org.embulk.config.*` (including `ModelManager`), but we accept it.

We'll need another update for `embulk-util-config` once the new `embulk-api` including `Type` is released.
