### PR TITLE
Replace Jackson annotations in Column to Jackson Module

### DIFF
--- a/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
@@ -47,7 +47,7 @@ public abstract class PreviewPrinter implements Closeable {
         this.objectMapper.registerModule(new LocalFileJacksonModule());
         this.objectMapper.registerModule(new ToStringJacksonModule());
         this.objectMapper.registerModule(new ToStringMapJacksonModule());
-        // PreviewPrinter would not need TypeJacksonModule.
+        // PreviewPrinter would not need TypeJacksonModule, and ColumnJacksonModule.
         this.objectMapper.registerModule(new GuavaModule());
         this.objectMapper.registerModule(new Jdk8Module());
         this.objectMapper.registerModule(new JodaModule());

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -17,6 +17,7 @@ import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.ModelManager;
 import org.embulk.deps.buffer.PooledBufferAllocator;
 import org.embulk.spi.BufferAllocator;
+import org.embulk.spi.ColumnJacksonModule;
 import org.embulk.spi.ExecutorPlugin;
 import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.TempFileSpaceAllocator;
@@ -66,6 +67,7 @@ public class ExecModule implements Module {
         mapper.registerModule(new ToStringJacksonModule());
         mapper.registerModule(new ToStringMapJacksonModule());
         mapper.registerModule(new TypeJacksonModule());
+        mapper.registerModule(new ColumnJacksonModule());
         mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
         mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
         mapper.registerModule(new JodaModule());  // jackson-datatype-joda

--- a/embulk-core/src/main/java/org/embulk/spi/Column.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Column.java
@@ -1,7 +1,5 @@
 package org.embulk.spi;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import org.embulk.spi.type.BooleanType;
 import org.embulk.spi.type.DoubleType;
@@ -16,27 +14,20 @@ public class Column {
     private final String name;
     private final Type type;
 
-    @JsonCreator
-    public Column(
-            @JsonProperty("index") int index,
-            @JsonProperty("name") String name,
-            @JsonProperty("type") Type type) {
+    public Column(final int index, final String name, final Type type) {
         this.index = index;
         this.name = name;
         this.type = type;
     }
 
-    @JsonProperty("index")
     public int getIndex() {
         return index;
     }
 
-    @JsonProperty("name")
     public String getName() {
         return name;
     }
 
-    @JsonProperty("type")
     public Type getType() {
         return type;
     }

--- a/embulk-core/src/main/java/org/embulk/spi/ColumnJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ColumnJacksonModule.java
@@ -1,0 +1,98 @@
+package org.embulk.spi;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdNodeBasedDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.embulk.spi.type.Type;
+import org.embulk.spi.type.Types;
+
+public final class ColumnJacksonModule extends SimpleModule {
+    public ColumnJacksonModule() {
+        this.addSerializer(Column.class, new ColumnSerializer());
+        this.addDeserializer(Column.class, new ColumnDeserializer());
+    }
+
+    private static class ColumnSerializer extends JsonSerializer<Column> {
+        @Override
+        public void serialize(
+                final Column value,
+                final JsonGenerator jsonGenerator,
+                final SerializerProvider provider)
+                throws IOException {
+            final ObjectNode object = OBJECT_MAPPER.createObjectNode();
+            object.put("index", value.getIndex());
+            object.put("name", value.getName());
+            object.put("type", value.getType().getName());
+            jsonGenerator.writeTree(object);
+        }
+    }
+
+    private static class ColumnDeserializer extends StdNodeBasedDeserializer<Column> {
+        protected ColumnDeserializer() {
+            super(Column.class);
+        }
+
+        @Override
+        public Column convert(
+                final JsonNode root,
+                final DeserializationContext context)
+                throws JsonProcessingException {
+            if (root == null || !root.isObject()) {
+                throw JsonMappingException.from(context.getParser(), "Column expects a JSON Object node.");
+            }
+            final ObjectNode object = (ObjectNode) root;
+
+            final JsonNode indexNode = object.get("index");
+            if (indexNode == null) {
+                throw JsonMappingException.from(context.getParser(), "index is null.");
+            }
+            final int index = OBJECT_MAPPER.treeToValue(indexNode, int.class);
+
+            final JsonNode nameNode = object.get("name");
+            if (nameNode == null) {
+                throw JsonMappingException.from(context.getParser(), "name is null.");
+            }
+            final String name = OBJECT_MAPPER.treeToValue(nameNode, String.class);
+
+            final JsonNode typeNode = object.get("type");
+            if (typeNode == null) {
+                throw JsonMappingException.from(context.getParser(), "type is null.");
+            }
+            final String typeString = OBJECT_MAPPER.treeToValue(typeNode, String.class);
+
+            if (!STRING_TO_TYPE.containsKey(typeString)) {
+                throw JsonMappingException.from(context.getParser(), "Unexpected type: " + typeString);
+            }
+            final Type type = STRING_TO_TYPE.get(typeString);
+
+            return new Column(index, name, type);
+        }
+    }
+
+    static {
+        final HashMap<String, Type> builder = new HashMap<>();
+        builder.put(Types.BOOLEAN.getName(), Types.BOOLEAN);
+        builder.put(Types.LONG.getName(), Types.LONG);
+        builder.put(Types.DOUBLE.getName(), Types.DOUBLE);
+        builder.put(Types.STRING.getName(), Types.STRING);
+        builder.put(Types.TIMESTAMP.getName(), Types.TIMESTAMP);
+        builder.put(Types.JSON.getName(), Types.JSON);
+        STRING_TO_TYPE = Collections.unmodifiableMap(builder);
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final Map<String, Type> STRING_TO_TYPE;
+}

--- a/embulk-core/src/test/java/org/embulk/spi/TestColumnMapping.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestColumnMapping.java
@@ -1,0 +1,281 @@
+package org.embulk.spi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ModelManager;
+import org.embulk.spi.type.Type;
+import org.embulk.spi.type.Types;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestColumnMapping {
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    @Test
+    public void testSerialization() throws IOException {
+        final ModelManager modelManager = Exec.getModelManager();
+
+        final Column column = new Column(21, "bar", Types.DOUBLE);
+        final String stringified = modelManager.writeObject(column);
+        final JsonNode reparsed = (new ObjectMapper()).readTree(stringified);
+        assertTrue(reparsed.get("index").isInt());
+        assertEquals(21, reparsed.get("index").intValue());
+        assertTrue(reparsed.get("name").isTextual());
+        assertEquals("bar", reparsed.get("name").textValue());
+        assertTrue(reparsed.get("type").isTextual());
+        assertEquals("double", reparsed.get("type").textValue());
+    }
+
+    @Test
+    public void testNormal() {
+        assertColumn(12, "foo", Types.LONG, "12", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testStringIndex() {
+        assertColumn(9491, "foo", Types.LONG, "\"9491\"", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testDoubleIndex1() {
+        assertColumn(481, "foo", Types.LONG, "481.4", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testDoubleIndex2() {
+        assertColumn(481, "foo", Types.LONG, "481.6", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testDoubleStringIndex() {
+        assertMappingException("\"1938.45\"", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testNullIndex() {
+        assertMappingException("null", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testArrayIndex() {
+        assertMappingException("[\"bar\"]", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testObjectIndex() {
+        assertMappingException("{\"bar\":\"baz\"}", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testTrueIndex() {
+        assertMappingException("true", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testFalseIndex() {
+        assertMappingException("false", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testTrueStringIndex() {
+        assertMappingException("\"true\"", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testFalseStringIndex() {
+        assertMappingException("\"false\"", "\"foo\"", "\"long\"");
+    }
+
+    @Test
+    public void testZeroName() {
+        assertColumn(12, "0", Types.LONG, "12", "0", "\"long\"");
+    }
+
+    @Test
+    public void testIntegralName() {
+        assertColumn(12, "49814", Types.LONG, "12", "49814", "\"long\"");
+    }
+
+    @Test
+    public void testZeroLeadingIntegralName() {
+        assertException(JsonParseException.class, "12", "049814", "\"long\"");
+    }
+
+    @Test
+    public void testDoubleName() {
+        assertColumn(12, "49814.12034", Types.LONG, "12", "49814.12034", "\"long\"");
+    }
+
+    @Test
+    public void testTrueName() {
+        assertColumn(12, "true", Types.LONG, "12", "true", "\"long\"");
+    }
+
+    @Test
+    public void testFalseName() {
+        assertColumn(12, "false", Types.LONG, "12", "false", "\"long\"");
+    }
+
+    @Test
+    public void testNumericalName() {
+        assertColumn(12, "123", Types.LONG, "12", "\"123\"", "\"long\"");
+    }
+
+    @Test
+    public void testSymbolicName() {
+        assertColumn(12, "###", Types.LONG, "12", "\"###\"", "\"long\"");
+    }
+
+    @Test
+    public void testArrayName() {
+        assertMappingException("12", "[\"foo\"]", "\"long\"");
+    }
+
+    @Test
+    public void testObjectName() {
+        assertMappingException("12", "{\"foo\":\"bar\"}", "\"long\"");
+    }
+
+    @Test
+    public void testNullName() {
+        assertMappingException("12", "null", "\"long\"");
+    }
+
+    @Test
+    public void testDoubleType() {
+        assertColumn(12, "foo", Types.DOUBLE, "12", "\"foo\"", "\"double\"");
+    }
+
+    @Test
+    public void testBooleanType() {
+        assertColumn(12, "foo", Types.BOOLEAN, "12", "\"foo\"", "\"boolean\"");
+    }
+
+    @Test
+    public void testJsonType() {
+        assertColumn(12, "foo", Types.JSON, "12", "\"foo\"", "\"json\"");
+    }
+
+    @Test
+    public void testStringType() {
+        assertColumn(12, "foo", Types.STRING, "12", "\"foo\"", "\"string\"");
+    }
+
+    @Test
+    public void testTimestampType() {
+        assertColumn(12, "foo", Types.TIMESTAMP, "12", "\"foo\"", "\"timestamp\"");
+    }
+
+    @Test
+    public void testInvalidStringType() {
+        assertMappingException("12", "\"foo\"", "\"invalid\"");
+    }
+
+    @Test
+    public void testNumericType() {
+        assertMappingException("12", "\"foo\"", "931");
+    }
+
+    @Test
+    public void testNullType() {
+        assertMappingException("12", "\"foo\"", "null");
+    }
+
+    @Test
+    public void testArrayType() {
+        assertMappingException("12", "\"foo\"", "[\"baz\"]");
+    }
+
+    @Test
+    public void testObjectType() {
+        assertMappingException("12", "\"foo\"", "{\"baz\":\"bar\"}");
+    }
+
+    @Test
+    public void testNoIndex() {
+        assertMappingException("{\"name\":\"foo\",\"type\":\"long\"}");
+    }
+
+    @Test
+    public void testNoName() {
+        assertMappingException("{\"index\":12,\"type\":\"long\"}");
+    }
+
+    @Test
+    public void testNoType() {
+        assertMappingException("{\"index\":12,\"name\":\"foo\"}");
+    }
+
+    @Test
+    public void testArray() {
+        assertMappingException("[\"index\", 12, \"name\", \"foo\", \"type\", \"long\"]");
+    }
+
+    @Test
+    public void testDirectValue() {
+        assertMappingException("123");
+    }
+
+    @Test
+    public void testEmpty() {
+        assertMappingException("");
+    }
+
+    @Test
+    public void testNull() {
+        assertMappingException("null");
+    }
+
+    private static void assertColumn(
+            final int indexExpected, final String nameExpected, final Type typeExpected, final String json) {
+        final ModelManager modelManager = Exec.getModelManager();
+        final Column column = modelManager.readObject(Column.class, json);
+        assertEquals(indexExpected, column.getIndex());
+        assertEquals(nameExpected, column.getName());
+        assertEquals(typeExpected, column.getType());
+    }
+
+    private static void assertColumn(
+            final int indexExpected, final String nameExpected, final Type typeExpected,
+            final String indexValue, final String nameValue, final String typeValue) {
+        assertColumn(indexExpected, nameExpected, typeExpected,
+                     String.format("{\"index\":%s,\"name\":%s,\"type\":%s}", indexValue, nameValue, typeValue));
+    }
+
+    private static void assertException(final Class<? extends Exception> expectedException, final String json) {
+        final ModelManager modelManager = Exec.getModelManager();
+        try {
+            modelManager.readObject(Column.class, json);
+        } catch (final RuntimeException ex) {
+            final Throwable cause = ex.getCause();
+            if (!(expectedException.isInstance(cause))) {
+                cause.printStackTrace();
+                fail();
+            }
+        }
+    }
+
+    private static void assertException(
+            final Class<? extends Exception> expectedException,
+            final String indexValue, final String nameValue, final String typeValue) {
+        assertException(
+                expectedException, String.format("{\"index\":%s,\"name\":%s,\"type\":%s}", indexValue, nameValue, typeValue));
+    }
+
+    private static void assertMappingException(final String json) {
+        assertException(JsonMappingException.class, json);
+    }
+
+    private static void assertMappingException(final String indexValue, final String nameValue, final String typeValue) {
+        assertMappingException(String.format("{\"index\":%s,\"name\":%s,\"type\":%s}", indexValue, nameValue, typeValue));
+    }
+}


### PR DESCRIPTION
Replacing Jackson annotation on `org.embulk.spi.Column` to Jackson `Module`-based SerDe implementation.

This is needed to move `Column` to `embulk-api` that is Jackson-independent. As its side effect, `Column` will not be able to get converted out of `org.embulk.config.*` (including `ModelManager`), but we accept it.

We'll need another update for `embulk-util-config` once the new `embulk-api` including `Column` is released.

----

This PR consists of two commits:
* c16ffeb6ef8d65b8890faf05c4332dfa93de0073: Just add a test of mapping JSON to `Column`.
* 9470d2553891be2ae3b37f5cdf381af47e26d257: Actual replacement.

It is confirmed that c16ffeb6ef8d65b8890faf05c4332dfa93de0073 succeeds, and 9470d2553891be2ae3b37f5cdf381af47e26d257 still succeeds with the replacement.