### PR TITLE
Replace Jackson annotations in Schema to Jackson Module

### DIFF
--- a/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
@@ -47,7 +47,7 @@ public abstract class PreviewPrinter implements Closeable {
         this.objectMapper.registerModule(new LocalFileJacksonModule());
         this.objectMapper.registerModule(new ToStringJacksonModule());
         this.objectMapper.registerModule(new ToStringMapJacksonModule());
-        // PreviewPrinter would not need TypeJacksonModule, and ColumnJacksonModule.
+        // PreviewPrinter would not need TypeJacksonModule, ColumnJacksonModule, and SchemaJacksonModule.
         this.objectMapper.registerModule(new GuavaModule());
         this.objectMapper.registerModule(new Jdk8Module());
         this.objectMapper.registerModule(new JodaModule());

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -20,6 +20,7 @@ import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.ColumnJacksonModule;
 import org.embulk.spi.ExecutorPlugin;
 import org.embulk.spi.ParserPlugin;
+import org.embulk.spi.SchemaJacksonModule;
 import org.embulk.spi.TempFileSpaceAllocator;
 import org.embulk.spi.time.DateTimeZoneJacksonModule;
 import org.embulk.spi.time.TimestampJacksonModule;
@@ -68,6 +69,7 @@ public class ExecModule implements Module {
         mapper.registerModule(new ToStringMapJacksonModule());
         mapper.registerModule(new TypeJacksonModule());
         mapper.registerModule(new ColumnJacksonModule());
+        mapper.registerModule(new SchemaJacksonModule());
         mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
         mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
         mapper.registerModule(new JodaModule());  // jackson-datatype-joda

--- a/embulk-core/src/main/java/org/embulk/spi/Schema.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Schema.java
@@ -1,7 +1,5 @@
 package org.embulk.spi;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
@@ -28,7 +26,6 @@ public class Schema {
 
     private final ImmutableList<Column> columns;
 
-    @JsonCreator
     public Schema(List<Column> columns) {
         this.columns = ImmutableList.copyOf(columns);
     }
@@ -38,7 +35,6 @@ public class Schema {
      *
      * It always returns an immutable list.
      */
-    @JsonValue
     public List<Column> getColumns() {
         return columns;
     }

--- a/embulk-core/src/main/java/org/embulk/spi/Schema.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Schema.java
@@ -1,13 +1,14 @@
 package org.embulk.spi;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.embulk.spi.type.Type;
 
 public class Schema {
     public static class Builder {
-        private final ImmutableList.Builder<Column> columns = ImmutableList.builder();
+        private final ArrayList<Column> columns = new ArrayList<>();
         private int index = 0;  // next version of Guava will have ImmutableList.Builder.size()
 
         public synchronized Builder add(String name, Type type) {
@@ -16,7 +17,7 @@ public class Schema {
         }
 
         public Schema build() {
-            return new Schema(columns.build());
+            return new Schema(Collections.unmodifiableList(columns));
         }
     }
 
@@ -24,10 +25,10 @@ public class Schema {
         return new Builder();
     }
 
-    private final ImmutableList<Column> columns;
+    private final List<Column> columns;
 
     public Schema(List<Column> columns) {
-        this.columns = ImmutableList.copyOf(columns);
+        this.columns = Collections.unmodifiableList(new ArrayList<>(columns));
     }
 
     /**

--- a/embulk-core/src/main/java/org/embulk/spi/SchemaJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/spi/SchemaJacksonModule.java
@@ -1,0 +1,69 @@
+package org.embulk.spi;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdNodeBasedDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public final class SchemaJacksonModule extends SimpleModule {
+    public SchemaJacksonModule() {
+        this.addSerializer(Schema.class, new SchemaSerializer());
+        this.addDeserializer(Schema.class, new SchemaDeserializer());
+    }
+
+    private static class SchemaSerializer extends JsonSerializer<Schema> {
+        @Override
+        public void serialize(
+                final Schema value,
+                final JsonGenerator jsonGenerator,
+                final SerializerProvider provider)
+                throws IOException {
+            final ArrayNode array = OBJECT_MAPPER.createArrayNode();
+            for (final Column column : value.getColumns()) {
+                final ObjectNode object = OBJECT_MAPPER.createObjectNode();
+                object.put("index", column.getIndex());
+                object.put("name", column.getName());
+                object.put("type", column.getType().getName());
+                array.add(object);
+            }
+            jsonGenerator.writeTree(array);
+        }
+    }
+
+    private static class SchemaDeserializer extends StdNodeBasedDeserializer<Schema> {
+        protected SchemaDeserializer() {
+            super(Schema.class);
+        }
+
+        @Override
+        public Schema convert(
+                final JsonNode root,
+                final DeserializationContext context)
+                throws JsonProcessingException {
+            if (root == null || !root.isArray()) {
+                throw JsonMappingException.from(context.getParser(), "Schema expects a JSON Array node.");
+            }
+            final ArrayNode array = (ArrayNode) root;
+
+            final ArrayList<Column> builder = new ArrayList<>();
+            for (final JsonNode element : (Iterable<JsonNode>) () -> array.elements()) {
+                builder.add(ColumnJacksonModule.convertJsonNodeToColumn(element, context.getParser()));
+            }
+
+            return new Schema(Collections.unmodifiableList(builder));
+        }
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+}

--- a/embulk-core/src/test/java/org/embulk/spi/TestSchema.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestSchema.java
@@ -1,0 +1,140 @@
+package org.embulk.spi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.List;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ModelManager;
+import org.embulk.spi.Schema;
+import org.embulk.spi.type.Types;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestSchema {
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    @Test
+    public void testSerialization() throws IOException {
+        final ModelManager modelManager = Exec.getModelManager();
+        final Schema schema = Schema.builder().add("hoge", Types.DOUBLE).add("fuga", Types.JSON).build();
+        final String stringified = modelManager.writeObject(schema);
+        final JsonNode reparsed = (new ObjectMapper()).readTree(stringified);
+        assertTrue(reparsed.isArray());
+        final ArrayNode array = (ArrayNode) reparsed;
+        assertEquals(2, array.size());
+        final JsonNode object1 = array.get(0);
+        assertTrue(object1.isObject());
+        final JsonNode object2 = array.get(1);
+        assertTrue(object2.isObject());
+
+        final ObjectNode column1 = (ObjectNode) object1;
+        assertTrue(column1.get("index").isInt());
+        assertEquals(0, column1.get("index").intValue());
+        assertTrue(column1.get("name").isTextual());
+        assertEquals("hoge", column1.get("name").textValue());
+        assertTrue(column1.get("type").isTextual());
+        assertEquals("double", column1.get("type").textValue());
+
+        final ObjectNode column2 = (ObjectNode) object2;
+        assertTrue(column2.get("index").isInt());
+        assertEquals(1, column2.get("index").intValue());
+        assertTrue(column2.get("name").isTextual());
+        assertEquals("fuga", column2.get("name").textValue());
+        assertTrue(column2.get("type").isTextual());
+        assertEquals("json", column2.get("type").textValue());
+    }
+
+    @Test
+    public void testEmpty() {
+        final Schema schema = readSchema("[]");
+        assertEquals(0, schema.getColumns().size());
+        assertEquals(0, schema.size());
+        assertEquals(0, schema.getColumnCount());
+        assertTrue(schema.isEmpty());
+    }
+
+    @Test
+    public void testOne() {
+        final Schema schema = readSchema("[{\"index\":0,\"name\":\"foo\",\"type\":\"long\"}]");
+
+        final List<Column> columns = schema.getColumns();
+        assertEquals(1, columns.size());
+        assertEquals(0, columns.get(0).getIndex());
+        assertEquals("foo", columns.get(0).getName());
+        assertEquals(Types.LONG, columns.get(0).getType());
+
+        assertEquals(1, schema.size());
+        assertEquals(1, schema.getColumnCount());
+
+        assertEquals(0, schema.getColumn(0).getIndex());
+        assertEquals("foo", schema.getColumn(0).getName());
+        assertEquals(Types.LONG, schema.getColumn(0).getType());
+
+        assertEquals("foo", schema.getColumnName(0));
+        assertEquals(Types.LONG, schema.getColumnType(0));
+
+        schema.visitColumns(new ColumnVisitor() {
+                @Override
+                public void booleanColumn(Column column) {
+                    fail();
+                }
+
+                @Override
+                public void longColumn(Column column) {
+                    assertEquals(0, column.getIndex());
+                    assertEquals("foo", column.getName());
+                    assertEquals(Types.LONG, column.getType());
+                }
+
+                @Override
+                public void doubleColumn(Column column) {
+                    fail();
+                }
+
+                @Override
+                public void stringColumn(Column column) {
+                    fail();
+                }
+
+                @Override
+                public void timestampColumn(Column column) {
+                    fail();
+                }
+
+                @Override
+                public void jsonColumn(Column column) {
+                    fail();
+                }
+            });
+
+        assertFalse(schema.isEmpty());
+
+        assertEquals(columns.get(0), schema.lookupColumn("foo"));
+        assertSchemaConfigExceptionForLookupColumn(schema, "bar");
+
+        assertEquals(8, schema.getFixedStorageSize());
+    }
+
+    private static void assertSchemaConfigExceptionForLookupColumn(final Schema schema, final String unknown) {
+        try {
+            schema.lookupColumn(unknown);
+        } catch (final SchemaConfigException expected) {
+            return;
+        }
+        fail();
+    }
+
+    private static Schema readSchema(final String json) {
+        final ModelManager modelManager = Exec.getModelManager();
+        return modelManager.readObject(Schema.class, json);
+    }
+}


### PR DESCRIPTION
Similar to #1290, replacing Jackson annotation on `org.embulk.spi.Schema` to Jackson `Module`-based SerDe implementation.

This is needed to move `Schema` to `embulk-api` that is Jackson-independent. As its side effect, `Schema` will not be able to get converted out of `org.embulk.config.*` (including `ModelManager`), but we accept it.

We'll need another update for `embulk-util-config` once the new `embulk-api` including `Schema` is released.

----

This PR consists of two commits:
* eafe1cc41e48d918acee5a717209e74d81db856b: Just add a test of mapping JSON to `Schema`.
* 0eb374f02822a48a8ae3f613ad01f84506267cb4: Actual replacement.

It is confirmed that eafe1cc41e48d918acee5a717209e74d81db856b succeeds, and 0eb374f02822a48a8ae3f613ad01f84506267cb4 still succeeds with the replacement.