### PR TITLE
Deprecate org.embulk.spi.time.Timestamp

### DIFF
--- a/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
@@ -9,12 +9,13 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import org.embulk.spi.Page;
 import org.embulk.spi.Schema;
 import org.embulk.spi.time.DateTimeZoneJacksonModule;
-import org.embulk.spi.time.Timestamp;
+import org.embulk.spi.time.Instants;
 import org.embulk.spi.time.TimestampJacksonModule;
 import org.embulk.spi.unit.LocalFileJacksonModule;
 import org.embulk.spi.unit.ToStringJacksonModule;
@@ -54,7 +55,7 @@ public abstract class PreviewPrinter implements Closeable {
     }
 
     public final void printAllPages(List<Page> pages) throws IOException {
-        List<Object[]> records = Pages.toObjects(schema, pages);
+        List<Object[]> records = Pages.toObjects(schema, pages, true);
         for (Object[] record : records) {
             printRecord(record);
         }
@@ -93,8 +94,8 @@ public abstract class PreviewPrinter implements Closeable {
                 return numberFormat.format(((Long) obj).longValue());
             }
             return obj.toString();
-        } else if (obj instanceof Timestamp) {
-            return obj.toString();
+        } else if (obj instanceof Instant) {
+            return Instants.toString((Instant) obj);
         } else if (obj instanceof Value) {
             return obj.toString();
         } else {

--- a/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageBuilder.java
@@ -1,5 +1,6 @@
 package org.embulk.spi;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -117,12 +118,25 @@ public class PageBuilder implements AutoCloseable {
         }
     }
 
+    @Deprecated
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void setTimestamp(Column column, Timestamp value) {
         // TODO check type?
-        setTimestamp(column.getIndex(), value);
+        this.setTimestamp(column, value.getInstant());
     }
 
+    public void setTimestamp(final Column column, final Instant value) {
+        // TODO check type?
+        this.setTimestamp(column.getIndex(), value);
+    }
+
+    @Deprecated
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void setTimestamp(int columnIndex, Timestamp value) {
+        this.setTimestamp(columnIndex, value.getInstant());
+    }
+
+    public void setTimestamp(final int columnIndex, final Instant value) {
         if (value == null) {
             setNull(columnIndex);
         } else {
@@ -169,7 +183,8 @@ public class PageBuilder implements AutoCloseable {
         clearNull(columnIndex);
     }
 
-    private void writeTimestamp(int columnIndex, Timestamp value) {
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
+    private void writeTimestamp(int columnIndex, Instant value) {
         int offset = getOffset(columnIndex);
         bufferSlice.setLong(offset, value.getEpochSecond());
         bufferSlice.setInt(offset + 8, value.getNano());
@@ -302,7 +317,7 @@ public class PageBuilder implements AutoCloseable {
             values[columnIndex].setJson(value);
         }
 
-        private void setTimestamp(int columnIndex, Timestamp value) {
+        private void setTimestamp(int columnIndex, Instant value) {
             values[columnIndex].setTimestamp(value);
         }
 
@@ -324,7 +339,7 @@ public class PageBuilder implements AutoCloseable {
 
         void setJson(Value value);
 
-        void setTimestamp(Timestamp value);
+        void setTimestamp(Instant value);
 
         void setNull();
 
@@ -359,7 +374,7 @@ public class PageBuilder implements AutoCloseable {
             throw new IllegalStateException("Not reach here");
         }
 
-        public void setTimestamp(Timestamp value) {
+        public void setTimestamp(Instant value) {
             throw new IllegalStateException("Not reach here");
         }
 
@@ -474,14 +489,14 @@ public class PageBuilder implements AutoCloseable {
     }
 
     private static class TimestampColumnValue extends AbstractColumnValue {
-        private Timestamp value;
+        private Instant value;
 
         TimestampColumnValue(Column column) {
             super(column);
         }
 
         @Override
-        public void setTimestamp(Timestamp value) {
+        public void setTimestamp(Instant value) {
             this.value = value;
             this.isNull = false;
         }

--- a/embulk-core/src/main/java/org/embulk/spi/PageReader.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageReader.java
@@ -1,5 +1,6 @@
 package org.embulk.spi;
 
+import java.time.Instant;
 import org.embulk.deps.buffer.Slice;
 import org.embulk.spi.time.Timestamp;
 import org.msgpack.value.Value;
@@ -97,19 +98,42 @@ public class PageReader implements AutoCloseable {
         return page.getStringReference(index);
     }
 
+    /**
+     * Returns a Timestamp value.
+     *
+     * @deprecated Use {@link #getTimestampInstant(Column)} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public Timestamp getTimestamp(Column column) {
         // TODO check type?
-        return getTimestamp(column.getIndex());
+        return Timestamp.ofInstant(this.getTimestampInstant(column.getIndex()));
     }
 
+    /**
+     * Returns a Timestamp value.
+     *
+     * @deprecated Use {@link #getTimestampInstant(int)} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public Timestamp getTimestamp(int columnIndex) {
+        return Timestamp.ofInstant(this.getTimestampInstant(columnIndex));
+    }
+
+    public Instant getTimestampInstant(final Column column) {
+        // TODO check type?
+        return this.getTimestampInstant(column.getIndex());
+    }
+
+    public Instant getTimestampInstant(final int columnIndex) {
         if (isNull(columnIndex)) {
             return null;
         }
         int offset = getOffset(columnIndex);
         long sec = pageSlice.getLong(offset);
         int nsec = pageSlice.getInt(offset + 8);
-        return Timestamp.ofEpochSecond(sec, nsec);
+        return Instant.ofEpochSecond(sec, nsec);
     }
 
     public Value getJson(Column column) {

--- a/embulk-core/src/main/java/org/embulk/spi/time/Timestamp.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/Timestamp.java
@@ -1,6 +1,11 @@
 package org.embulk.spi.time;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Represents an instance of Embulk's Timestamp type.
@@ -18,7 +23,7 @@ public class Timestamp implements Comparable<Timestamp> {
     }
 
     public static Timestamp ofString(final String string) {
-        return new Timestamp(Instants.parseInstant(string));
+        return new Timestamp(parseInstant(string));
     }
 
     public static Timestamp ofInstant(final Instant instant) {
@@ -77,8 +82,117 @@ public class Timestamp implements Comparable<Timestamp> {
 
     @Override
     public String toString() {
-        return Instants.toString(this.instant);
+        return toString(this.instant);
     }
+
+    private static String toString(final Instant instant) {
+        // This is the same implementation with org.embulk.spi.time.Instants#toString(Instant),
+        // but this org.embulk.spi.time.Timestamp has to have its own implementation because
+        //
+        // 1) org.embulk.spi.time.Timestamp is moved to embulk-api, which does not depend on others.
+        // 2) org.embulk.spi.time.Timestamp is deprecated, and to be removed in the (remote) future.
+        //    So, embulk-core should not call Timestamp#toString.
+        //
+        // The duplication would be resolved when we can finally remove org.embulk.spi.time.Timestamp.
+
+        if (instant == null) {
+            throw new NullPointerException("Timestamp owns a null Instant.");
+        }
+
+        final int nano = instant.getNano();
+        if (nano == 0) {
+            return INSTANT_FORMATTER_SECONDS.format(instant) + " UTC";
+        } else if (nano % 1000000 == 0) {
+            return INSTANT_FORMATTER_MILLISECONDS.format(instant) + " UTC";
+        } else {
+            final StringBuilder builder = new StringBuilder();
+            INSTANT_FORMATTER_SECONDS.formatTo(instant, builder);
+            builder.append(".");
+
+            final String digits;
+            final int zeroDigits;
+            if (nano % 1000 == 0) {
+                digits = Integer.toString(nano / 1000);
+                zeroDigits = 6 - digits.length();
+            } else {
+                digits = Integer.toString(nano);
+                zeroDigits = 9 - digits.length();
+            }
+            builder.append(digits);
+            for (int i = 0; i < zeroDigits; i++) {
+                builder.append('0');
+            }
+
+            builder.append(" UTC");
+            return builder.toString();
+        }
+    }
+
+    private static Instant parseInstant(final String string) {
+        // This is the same implementation with org.embulk.spi.time.Instants#parseInstant(String),
+        // but this org.embulk.spi.time.Timestamp has to have its own implementation because
+        //
+        // 1) org.embulk.spi.time.Timestamp is moved to embulk-api, which does not depend on others.
+        // 2) org.embulk.spi.time.Timestamp is deprecated, and to be removed in the (remote) future.
+        //    So, embulk-core should not call Timestamp#ofString.
+        //
+        // The duplication would be resolved when we can finally remove org.embulk.spi.time.Timestamp.
+
+        if (string == null) {
+            throw new NullPointerException("Timestamp#ofString receives only a non-null String.");
+        }
+
+        final Matcher matcher = INSTANT_PATTERN.matcher(string);
+        if (!matcher.matches()) {
+            throw new NumberFormatException("Timestamp#ofString received an invalid format: '" + string + "'");
+        }
+
+        // If the string matches INSTANT_PATTERN, all parsing below should be successful.
+        // Any Exception would be considered as an unexpected error.
+
+        final String integral;
+        try {
+            integral = matcher.group(1);
+        } catch (final Exception ex) {
+            throw new IllegalStateException("Unexpected error in retrieving the integral part of: '" + string + "'", ex);
+        }
+
+        final long epochSecond;
+        try {
+            epochSecond = LocalDateTime.parse(integral, INSTANT_FORMATTER_SECONDS).toEpochSecond(ZoneOffset.UTC);
+        } catch (final Exception ex) {
+            throw new IllegalStateException("Unexpected error in parsing: '" + integral + "'", ex);
+        }
+
+        final String fractional;
+        try {
+            fractional = matcher.group(2);
+        } catch (final Exception ex) {
+            throw new IllegalStateException("Unexpected error in retrieving the fractional part of: '" + string + "'", ex);
+        }
+
+        final int nanoAdjustment;
+        if (fractional == null) {
+            nanoAdjustment = 0;
+        } else {
+            try {
+                nanoAdjustment = Integer.parseInt(fractional) * (int) Math.pow(10, 9 - fractional.length());
+            } catch (final Exception ex) {
+                throw new IllegalStateException("Unexpected error in parsing: '" + fractional + "'", ex);
+            }
+        }
+
+        return Instant.ofEpochSecond(epochSecond, nanoAdjustment);
+    }
+
+    private static final Pattern INSTANT_PATTERN =
+            Pattern.compile("(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})(?:\\.(\\d{1,9}))? (?:UTC|\\+?00\\:?00)");
+
+    private static final DateTimeFormatter INSTANT_FORMATTER_SECONDS =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC);
+
+    private static final DateTimeFormatter INSTANT_FORMATTER_MILLISECONDS =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
 
     private final Instant instant;
 }

--- a/embulk-core/src/main/java/org/embulk/spi/time/Timestamp.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/Timestamp.java
@@ -2,6 +2,16 @@ package org.embulk.spi.time;
 
 import java.time.Instant;
 
+/**
+ * Represents an instance of Embulk's Timestamp type.
+ *
+ * <p>Embulk needed this till v0.8 because v0.8 expected Java 7, which does not have {@link java.time.Instant}.
+ * Embulk v0.9 requires Java 8, and it expects {@link java.time.Instant}. {@link org.embulk.spi.time.Timestamp}
+ * remains here for compatibility.
+ *
+ * @deprecated Use {@link java.time.Instant} instead as much as possible.
+ */
+@Deprecated
 public class Timestamp implements Comparable<Timestamp> {
     private Timestamp(final Instant instant) {
         this.instant = instant;

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetter.java
@@ -1,5 +1,6 @@
 package org.embulk.spi.util;
 
+import java.time.Instant;
 import org.embulk.spi.time.Timestamp;
 import org.msgpack.value.Value;
 
@@ -14,7 +15,13 @@ public interface DynamicColumnSetter {
 
     void set(String value);
 
+    @Deprecated
+    @SuppressWarnings("deprecation")
     void set(Timestamp value);
+
+    default void set(Instant value) {
+        this.set(Timestamp.ofInstant(value));
+    }
 
     void set(Value value);
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/AbstractDynamicColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/AbstractDynamicColumnSetter.java
@@ -1,5 +1,6 @@
 package org.embulk.spi.util.dynamic;
 
+import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
@@ -28,7 +29,15 @@ public abstract class AbstractDynamicColumnSetter implements DynamicColumnSetter
 
     public abstract void set(String value);
 
+    @Deprecated
+    @SuppressWarnings("deprecation")
     public abstract void set(Timestamp value);
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void set(Instant value) {
+        this.set(Timestamp.ofInstant(value));
+    }
 
     public abstract void set(Value value);
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/BooleanColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/BooleanColumnSetter.java
@@ -1,6 +1,7 @@
 package org.embulk.spi.util.dynamic;
 
 import com.google.common.collect.ImmutableSet;
+import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
@@ -50,7 +51,13 @@ public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void set(Timestamp v) {
+        defaultValue.setBoolean(pageBuilder, column);
+    }
+
+    @Override
+    public void set(Instant v) {
         defaultValue.setBoolean(pageBuilder, column);
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/DoubleColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/DoubleColumnSetter.java
@@ -1,5 +1,6 @@
 package org.embulk.spi.util.dynamic;
 
+import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
@@ -44,7 +45,15 @@ public class DoubleColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void set(Timestamp v) {
+        double sec = (double) v.getEpochSecond();
+        double frac = v.getNano() / 1000000000.0;
+        pageBuilder.setDouble(column, sec + frac);
+    }
+
+    @Override
+    public void set(Instant v) {
         double sec = (double) v.getEpochSecond();
         double frac = v.getNano() / 1000000000.0;
         pageBuilder.setDouble(column, sec + frac);

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/JsonColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/JsonColumnSetter.java
@@ -1,5 +1,6 @@
 package org.embulk.spi.util.dynamic;
 
+import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
@@ -43,8 +44,14 @@ public class JsonColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void set(Timestamp v) {
         pageBuilder.setJson(column, ValueFactory.newString(timestampFormatter.format(v)));
+    }
+
+    @Override
+    public void set(Instant v) {
+        pageBuilder.setJson(column, ValueFactory.newString(timestampFormatter.format(Timestamp.ofInstant(v))));
     }
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/LongColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/LongColumnSetter.java
@@ -2,6 +2,7 @@ package org.embulk.spi.util.dynamic;
 
 import com.google.common.math.DoubleMath;
 import java.math.RoundingMode;
+import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
@@ -55,7 +56,13 @@ public class LongColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void set(Timestamp v) {
+        pageBuilder.setLong(column, v.getEpochSecond());
+    }
+
+    @Override
+    public void set(Instant v) {
         pageBuilder.setLong(column, v.getEpochSecond());
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/SkipColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/SkipColumnSetter.java
@@ -1,5 +1,6 @@
 package org.embulk.spi.util.dynamic;
 
+import java.time.Instant;
 import org.embulk.spi.time.Timestamp;
 import org.msgpack.value.Value;
 
@@ -30,7 +31,11 @@ public class SkipColumnSetter extends AbstractDynamicColumnSetter {
     public void set(String v) {}
 
     @Override
+    @SuppressWarnings("deprecation")
     public void set(Timestamp v) {}
+
+    @Override
+    public void set(Instant v) {}
 
     @Override
     public void set(Value v) {}

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/StringColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/StringColumnSetter.java
@@ -1,5 +1,6 @@
 package org.embulk.spi.util.dynamic;
 
+import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
@@ -42,8 +43,14 @@ public class StringColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void set(Timestamp v) {
         pageBuilder.setString(column, timestampFormatter.format(v));
+    }
+
+    @Override
+    public void set(Instant v) {
+        pageBuilder.setString(column, timestampFormatter.format(Timestamp.ofInstant(v)));
     }
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/TimestampColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/TimestampColumnSetter.java
@@ -1,5 +1,6 @@
 package org.embulk.spi.util.dynamic;
 
+import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
@@ -50,7 +51,13 @@ public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void set(Timestamp v) {
+        pageBuilder.setTimestamp(column, v);
+    }
+
+    @Override
+    public void set(Instant v) {
         pageBuilder.setTimestamp(column, v);
     }
 

--- a/embulk-core/src/test/java/org/embulk/spi/MockFormatterPlugin.java
+++ b/embulk-core/src/test/java/org/embulk/spi/MockFormatterPlugin.java
@@ -67,7 +67,7 @@ public class MockFormatterPlugin implements FormatterPlugin {
 
                         public void timestampColumn(Column column) {
                             if (!pageReader.isNull(column)) {
-                                record.add(pageReader.getTimestamp(column));
+                                record.add(pageReader.getTimestampInstant(column));
                             }
                         }
 

--- a/embulk-core/src/test/java/org/embulk/spi/MockParserPlugin.java
+++ b/embulk-core/src/test/java/org/embulk/spi/MockParserPlugin.java
@@ -1,11 +1,11 @@
 package org.embulk.spi;
 
+import java.time.Instant;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.json.JsonParser;
-import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.type.Type;
 
 public class MockParserPlugin implements ParserPlugin {
@@ -46,7 +46,7 @@ public class MockParserPlugin implements ParserPlugin {
                                 pageBuilder.setString(column, "45");
                                 break;
                             case "timestamp":
-                                pageBuilder.setTimestamp(column, Timestamp.ofEpochMilli(678L));
+                                pageBuilder.setTimestamp(column, Instant.ofEpochMilli(678L));
                                 break;
                             case "json":
                                 pageBuilder.setJson(

--- a/embulk-core/src/test/java/org/embulk/spi/PageTestUtils.java
+++ b/embulk-core/src/test/java/org/embulk/spi/PageTestUtils.java
@@ -1,5 +1,6 @@
 package org.embulk.spi;
 
+import java.time.Instant;
 import java.util.List;
 import org.embulk.spi.TestPageBuilderReader.MockPageOutput;
 import org.embulk.spi.time.Timestamp;
@@ -30,6 +31,8 @@ public class PageTestUtils {
                         builder.setString(column, (String) value);
                     } else if (value instanceof Timestamp) {
                         builder.setTimestamp(column, (Timestamp) value);
+                    } else if (value instanceof Instant) {
+                        builder.setTimestamp(column, (Instant) value);
                     } else if (value instanceof Value) {
                         builder.setJson(column, (Value) value);
                     } else {

--- a/embulk-core/src/test/java/org/embulk/spi/TestFileInputRunner.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestFileInputRunner.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -15,7 +16,6 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.TestPageBuilderReader.MockPageOutput;
-import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.util.Pages;
 import org.junit.Before;
 import org.junit.Rule;
@@ -123,7 +123,7 @@ public class TestFileInputRunner {
                 .loadConfig(MockParserPlugin.PluginTask.class)
                 .getSchemaConfig().toSchema();
 
-        List<Object[]> records = Pages.toObjects(schema, output.pages);
+        List<Object[]> records = Pages.toObjects(schema, output.pages, true);
         assertEquals(2, records.size());
         for (Object[] record : records) {
             assertEquals(6, record.length);
@@ -131,7 +131,7 @@ public class TestFileInputRunner {
             assertEquals(2L, record[1]);
             assertEquals(3.0D, (Double) record[2], 0.01D);
             assertEquals("45", record[3]);
-            assertEquals(678L, ((Timestamp) record[4]).toEpochMilli());
+            assertEquals(678L, ((Instant) record[4]).toEpochMilli());
             assertEquals("{\"_c2\":10,\"_c1\":true,\"_c4\":{\"k\":\"v\"},\"_c3\":\"embulk\"}", record[5].toString());
         }
     }

--- a/embulk-core/src/test/java/org/embulk/spi/TestFileOutputRunner.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestFileOutputRunner.java
@@ -8,6 +8,7 @@ import static org.msgpack.value.ValueFactory.newString;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.embulk.EmbulkTestRuntime;
@@ -16,7 +17,6 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
-import org.embulk.spi.time.Timestamp;
 import org.junit.Rule;
 import org.junit.Test;
 import org.msgpack.value.ImmutableMapValue;
@@ -116,8 +116,8 @@ public class TestFileOutputRunner {
                     );
                     for (Page page : PageTestUtils.buildPage(
                             runtime.getBufferAllocator(), schema, true, 2L,
-                            3.0D, "45", Timestamp.ofEpochMilli(678L), jsonValue, true, 2L,
-                            3.0D, "45", Timestamp.ofEpochMilli(678L), jsonValue)) {
+                            3.0D, "45", Instant.ofEpochMilli(678L), jsonValue, true, 2L,
+                            3.0D, "45", Instant.ofEpochMilli(678L), jsonValue)) {
                         tran.add(page);
                     }
                     tran.commit();
@@ -139,7 +139,7 @@ public class TestFileOutputRunner {
             assertEquals(2L, record.get(1));
             assertEquals(3.0D, (Double) record.get(2), 0.1D);
             assertEquals("45", record.get(3));
-            assertEquals(678L, ((Timestamp) record.get(4)).toEpochMilli());
+            assertEquals(678L, ((Instant) record.get(4)).toEpochMilli());
             assertEquals("{\"_c1\":true,\"_c2\":10,\"_c3\":\"embulk\",\"_c4\":{\"k\":\"v\"}}", record.get(5).toString());
         }
     }

--- a/embulk-core/src/test/java/org/embulk/spi/TestPageBuilderReader.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestPageBuilderReader.java
@@ -14,10 +14,10 @@ import static org.msgpack.value.ValueFactory.newInteger;
 import static org.msgpack.value.ValueFactory.newMap;
 import static org.msgpack.value.ValueFactory.newString;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.embulk.EmbulkTestRuntime;
-import org.embulk.spi.time.Timestamp;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -111,7 +111,7 @@ public class TestPageBuilderReader {
     @Test
     public void testTimestamp() {
         check(Schema.builder().add("col1", TIMESTAMP).build(),
-                Timestamp.ofEpochMilli(0), Timestamp.ofEpochMilli(10));
+                Instant.ofEpochMilli(0), Instant.ofEpochMilli(10));
     }
 
     @Test
@@ -143,8 +143,8 @@ public class TestPageBuilderReader {
                     .add("col2", TIMESTAMP)
                     .add("col4", JSON)
                     .build(),
-                8122.0, "val1", 3L, false, Timestamp.ofEpochMilli(0), getJsonSampleData(),
-                140.15, "val2", Long.MAX_VALUE, true, Timestamp.ofEpochMilli(10), getJsonSampleData());
+                8122.0, "val1", 3L, false, Instant.ofEpochMilli(0), getJsonSampleData(),
+                140.15, "val2", Long.MAX_VALUE, true, Instant.ofEpochMilli(10), getJsonSampleData());
     }
 
     private void check(Schema schema, Object... objects) {
@@ -175,8 +175,8 @@ public class TestPageBuilderReader {
                     builder.setLong(column, (Long) value);
                 } else if (value instanceof String) {
                     builder.setString(column, (String) value);
-                } else if (value instanceof Timestamp) {
-                    builder.setTimestamp(column, (Timestamp) value);
+                } else if (value instanceof Instant) {
+                    builder.setTimestamp(column, (Instant) value);
                 } else if (value instanceof Value) {
                     builder.setJson(column, (Value) value);
                 } else {
@@ -209,8 +209,8 @@ public class TestPageBuilderReader {
                     assertEquals(value, reader.getLong(column));
                 } else if (value instanceof String) {
                     assertEquals(value, reader.getString(column));
-                } else if (value instanceof Timestamp) {
-                    assertEquals(value, reader.getTimestamp(column));
+                } else if (value instanceof Instant) {
+                    assertEquals(value, reader.getTimestampInstant(column));
                 } else if (value instanceof Value) {
                     assertEquals(value, reader.getJson(column));
                 } else {


### PR DESCRIPTION
This deprecation does not mean immediate removal of `Timestamp`, but as javadoc'ed for `Timestamp`, `java.time.Instant` can be a perfect alternative of `org.embulk.spi.time.Timestamp`, and we are going to use `Instant` instead of `Timestamp` almost everywhere.