### PR TITLE
Suppress internal deprecation warnings for TimestampFormatter and TimestampParser

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
@@ -4,8 +4,6 @@ import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.TimestampFormatter;
-import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.BooleanType;
 import org.embulk.spi.type.DoubleType;
 import org.embulk.spi.type.JsonType;
@@ -52,6 +50,7 @@ class DynamicColumnSetterFactory {
         return new NullDefaultValueSetter();
     }
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public DynamicColumnSetter newColumnSetter(PageBuilder pageBuilder, Column column) {
         Type type = column.getType();
         if (type instanceof BooleanType) {
@@ -61,23 +60,23 @@ class DynamicColumnSetterFactory {
         } else if (type instanceof DoubleType) {
             return new DoubleColumnSetter(pageBuilder, column, defaultValue);
         } else if (type instanceof StringType) {
-            TimestampFormatter formatter = TimestampFormatter.of(
+            final org.embulk.spi.time.TimestampFormatter formatter = org.embulk.spi.time.TimestampFormatter.of(
                     getTimestampFormatForFormatter(column), getTimeZoneId(column));
             return new StringColumnSetter(pageBuilder, column, defaultValue, formatter);
         } else if (type instanceof TimestampType) {
             // TODO use flexible time format like Ruby's Time.parse
-            final TimestampParser parser;
+            final org.embulk.spi.time.TimestampParser parser;
             if (this.useColumnForTimestampMetadata) {
                 final TimestampType timestampType = (TimestampType) type;
                 // https://github.com/embulk/embulk/issues/935
-                parser = TimestampParser.of(getFormatFromTimestampTypeWithDepracationSuppressed(timestampType),
-                                            getTimeZoneId(column));
+                parser = org.embulk.spi.time.TimestampParser.of(
+                        getFormatFromTimestampTypeWithDepracationSuppressed(timestampType), getTimeZoneId(column));
             } else {
-                parser = TimestampParser.of(getTimestampFormatForParser(column), getTimeZoneId(column));
+                parser = org.embulk.spi.time.TimestampParser.of(getTimestampFormatForParser(column), getTimeZoneId(column));
             }
             return new TimestampColumnSetter(pageBuilder, column, defaultValue, parser);
         } else if (type instanceof JsonType) {
-            TimestampFormatter formatter = TimestampFormatter.of(
+            final org.embulk.spi.time.TimestampFormatter formatter = org.embulk.spi.time.TimestampFormatter.of(
                     getTimestampFormatForFormatter(column), getTimeZoneId(column));
             return new JsonColumnSetter(pageBuilder, column, defaultValue, formatter);
         }

--- a/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
@@ -6,25 +6,27 @@ import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
-import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.type.TimestampType;
 
 public class PagePrinter {
     private final Schema schema;
-    private final TimestampFormatter[] timestampFormatters;
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
+    private final org.embulk.spi.time.TimestampFormatter[] timestampFormatters;
+
     private final ArrayList<String> record;
 
     // To be removed by v0.10 or earlier.
     @Deprecated  // https://github.com/embulk/embulk/issues/937
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292, https://github.com/embulk/embulk/issues/1298
     public PagePrinter(final Schema schema, final org.joda.time.DateTimeZone timezone) {
         this.schema = schema;
-        this.timestampFormatters = new TimestampFormatter[schema.getColumnCount()];
+        this.timestampFormatters = new org.embulk.spi.time.TimestampFormatter[schema.getColumnCount()];
         for (int i = 0; i < timestampFormatters.length; i++) {
             if (schema.getColumnType(i) instanceof TimestampType) {
                 TimestampType type = (TimestampType) schema.getColumnType(i);
                 // Constructor of TimestampFormatter is deprecated.
-                timestampFormatters[i] = new TimestampFormatter(
+                timestampFormatters[i] = new org.embulk.spi.time.TimestampFormatter(
                         getFormatFromTimestampTypeWithDeprecationSuppressed(type), timezone);
             }
         }
@@ -35,13 +37,14 @@ public class PagePrinter {
         }
     }
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public PagePrinter(final Schema schema, final String timeZoneId) {
         this.schema = schema;
-        this.timestampFormatters = new TimestampFormatter[schema.getColumnCount()];
+        this.timestampFormatters = new org.embulk.spi.time.TimestampFormatter[schema.getColumnCount()];
         for (int i = 0; i < timestampFormatters.length; i++) {
             if (schema.getColumnType(i) instanceof TimestampType) {
                 TimestampType type = (TimestampType) schema.getColumnType(i);
-                timestampFormatters[i] = TimestampFormatter.of(
+                timestampFormatters[i] = org.embulk.spi.time.TimestampFormatter.of(
                         getFormatFromTimestampTypeWithDeprecationSuppressed(type), timeZoneId);
             }
         }
@@ -103,6 +106,7 @@ public class PagePrinter {
             string = reader.getString(column);
         }
 
+        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
         public void timestampColumn(Column column) {
             string = timestampFormatters[column.getIndex()].format(reader.getTimestamp(column));
         }

--- a/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
@@ -7,38 +7,42 @@ import org.embulk.spi.Column;
 import org.embulk.spi.ColumnConfig;
 import org.embulk.spi.Schema;
 import org.embulk.spi.SchemaConfig;
-import org.embulk.spi.time.TimestampFormatter;
-import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.TimestampType;
 
+@Deprecated  // Along with TimestampFormatter and TimestampParser: https://github.com/embulk/embulk/issues/1298
 public class Timestamps {
     private Timestamps() {}
 
-    private interface TimestampColumnOption extends Task, TimestampParser.TimestampColumnOption {}
+    private interface TimestampColumnOption extends Task, org.embulk.spi.time.TimestampParser.TimestampColumnOption {}
 
-    public static TimestampParser[] newTimestampColumnParsers(
-            TimestampParser.Task parserTask, SchemaConfig schema) {
-        TimestampParser[] parsers = new TimestampParser[schema.getColumnCount()];
+    @Deprecated
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1289
+    public static org.embulk.spi.time.TimestampParser[] newTimestampColumnParsers(
+            org.embulk.spi.time.TimestampParser.Task parserTask, SchemaConfig schema) {
+        org.embulk.spi.time.TimestampParser[] parsers = new org.embulk.spi.time.TimestampParser[schema.getColumnCount()];
         int i = 0;
         for (ColumnConfig column : schema.getColumns()) {
             if (column.getType() instanceof TimestampType) {
                 TimestampColumnOption option = column.getOption().loadConfig(TimestampColumnOption.class);
-                parsers[i] = TimestampParser.of(parserTask, option);
+                parsers[i] = org.embulk.spi.time.TimestampParser.of(parserTask, option);
             }
             i++;
         }
         return parsers;
     }
 
-    public static TimestampFormatter[] newTimestampColumnFormatters(
-            TimestampFormatter.Task formatterTask, Schema schema,
-            Map<String, ? extends TimestampFormatter.TimestampColumnOption> columnOptions) {
-        TimestampFormatter[] formatters = new TimestampFormatter[schema.getColumnCount()];
+    @Deprecated
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1289
+    public static org.embulk.spi.time.TimestampFormatter[] newTimestampColumnFormatters(
+            org.embulk.spi.time.TimestampFormatter.Task formatterTask, Schema schema,
+            Map<String, ? extends org.embulk.spi.time.TimestampFormatter.TimestampColumnOption> columnOptions) {
+        org.embulk.spi.time.TimestampFormatter[] formatters = new org.embulk.spi.time.TimestampFormatter[schema.getColumnCount()];
         int i = 0;
         for (Column column : schema.getColumns()) {
             if (column.getType() instanceof TimestampType) {
-                Optional<TimestampFormatter.TimestampColumnOption> option = Optional.fromNullable(columnOptions.get(column.getName()));
-                formatters[i] = TimestampFormatter.of(formatterTask, option);
+                final Optional<org.embulk.spi.time.TimestampFormatter.TimestampColumnOption> option =
+                        Optional.fromNullable(columnOptions.get(column.getName()));
+                formatters[i] = org.embulk.spi.time.TimestampFormatter.of(formatterTask, option);
             }
             i++;
         }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/JsonColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/JsonColumnSetter.java
@@ -3,16 +3,17 @@ package org.embulk.spi.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.TimestampFormatter;
 import org.msgpack.value.Value;
 import org.msgpack.value.ValueFactory;
 
 public class JsonColumnSetter extends AbstractDynamicColumnSetter {
-    private final TimestampFormatter timestampFormatter;
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
+    private final org.embulk.spi.time.TimestampFormatter timestampFormatter;
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public JsonColumnSetter(PageBuilder pageBuilder, Column column,
                             DefaultValueSetter defaultValue,
-                            TimestampFormatter timestampFormatter) {
+                            org.embulk.spi.time.TimestampFormatter timestampFormatter) {
         super(pageBuilder, column, defaultValue);
         this.timestampFormatter = timestampFormatter;
     }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/StringColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/StringColumnSetter.java
@@ -3,15 +3,16 @@ package org.embulk.spi.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.TimestampFormatter;
 import org.msgpack.value.Value;
 
 public class StringColumnSetter extends AbstractDynamicColumnSetter {
-    private final TimestampFormatter timestampFormatter;
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
+    private final org.embulk.spi.time.TimestampFormatter timestampFormatter;
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public StringColumnSetter(PageBuilder pageBuilder, Column column,
             DefaultValueSetter defaultValue,
-            TimestampFormatter timestampFormatter) {
+            org.embulk.spi.time.TimestampFormatter timestampFormatter) {
         super(pageBuilder, column, defaultValue);
         this.timestampFormatter = timestampFormatter;
     }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/TimestampColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/TimestampColumnSetter.java
@@ -3,16 +3,16 @@ package org.embulk.spi.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.TimestampParseException;
-import org.embulk.spi.time.TimestampParser;
 import org.msgpack.value.Value;
 
 public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
-    private final TimestampParser timestampParser;
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
+    private final org.embulk.spi.time.TimestampParser timestampParser;
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public TimestampColumnSetter(PageBuilder pageBuilder, Column column,
             DefaultValueSetter defaultValue,
-            TimestampParser timestampParser) {
+            org.embulk.spi.time.TimestampParser timestampParser) {
         super(pageBuilder, column, defaultValue);
         this.timestampParser = timestampParser;
     }
@@ -43,10 +43,11 @@ public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
     }
 
     @Override
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
     public void set(String v) {
         try {
             pageBuilder.setTimestamp(column, timestampParser.parse(v));
-        } catch (TimestampParseException e) {
+        } catch (org.embulk.spi.time.TimestampParseException e) {
             defaultValue.setTimestamp(pageBuilder, column);
         }
     }


### PR DESCRIPTION
We have had a lot of deprecation warnings when building `embulk-core` since #1273. They have been deprecated for plugins, but the core still uses them for a while.

To avoid so noisy warnings, adding `@SuppressWarnings` there.