### PR TITLE
Suppress internal deprecation warnings for ConfigSource#loadConfig and TaskSource#loadTask

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -244,6 +244,7 @@ public class EmbulkEmbed {
                 .build();
     }
 
+    @SuppressWarnings("deprecation") // https://github.com/embulk/embulk/issues/1301
     public ResumeStateAction resumeState(final ConfigSource config, final ConfigSource resumeStateConfig) {
         logger.info("Started Embulk v" + EmbulkVersion.VERSION);
 

--- a/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
+++ b/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
@@ -230,11 +230,13 @@ public class DataSourceImpl implements ConfigSource, TaskSource, TaskReport, Con
     }
 
     @Override
+    @Deprecated
     public <T> T loadTask(Class<T> taskType) {
         return model.readObject(taskType, data.traverse());
     }
 
     @Override
+    @Deprecated
     public <T> T loadConfig(Class<T> taskType) {
         return model.readObjectWithConfigSerDe(taskType, data.traverse());
     }

--- a/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
+++ b/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
@@ -472,7 +472,7 @@ public class BulkLoader {
     }
 
     public void doCleanup(ConfigSource config, ResumeState resume) {
-        BulkLoaderTask task = config.loadConfig(BulkLoaderTask.class);
+        final BulkLoaderTask task = loadBulkLoaderTask(config);
         ProcessPluginSet plugins = new ProcessPluginSet(task);  // TODO don't create filter plugins
 
         ImmutableList.Builder<TaskReport> successfulInputTaskReports = ImmutableList.builder();
@@ -513,7 +513,7 @@ public class BulkLoader {
     }
 
     private ExecutionResult doRun(ConfigSource config) {
-        final BulkLoaderTask task = config.loadConfig(BulkLoaderTask.class);
+        final BulkLoaderTask task = loadBulkLoaderTask(config);
 
         final ExecutorPlugin exec = newExecutorPlugin(task);
         final ProcessPluginSet plugins = new ProcessPluginSet(task);
@@ -585,7 +585,7 @@ public class BulkLoader {
     }
 
     private ExecutionResult doResume(ConfigSource config, final ResumeState resume) {
-        final BulkLoaderTask task = config.loadConfig(BulkLoaderTask.class);
+        final BulkLoaderTask task = loadBulkLoaderTask(config);
 
         final ExecutorPlugin exec = newExecutorPlugin(task);
         final ProcessPluginSet plugins = new ProcessPluginSet(task);
@@ -708,6 +708,11 @@ public class BulkLoader {
         } catch (Exception ex) {
             state.getLogger().warn("Commit succeeded but cleanup failed. Ignoring this exception.", ex);  // TODO
         }
+    }
+
+    @SuppressWarnings("deprecation") // https://github.com/embulk/embulk/issues/1301
+    private static BulkLoaderTask loadBulkLoaderTask(final ConfigSource config) {
+        return config.loadConfig(BulkLoaderTask.class);
     }
 
     private static Schema first(List<Schema> schemas) {

--- a/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
@@ -83,7 +83,7 @@ public class PreviewExecutor {
     }
 
     private PreviewResult doPreview(ConfigSource config) {
-        PreviewTask task = config.loadConfig(PreviewTask.class);
+        final PreviewTask task = loadPreviewTask(config);
         InputPlugin inputPlugin = newInputPlugin(task);
         List<FilterPlugin> filterPlugins = newFilterPlugins(task);
 
@@ -100,7 +100,7 @@ public class PreviewExecutor {
     }
 
     private static ConfigSource createSampleBufferConfigFromExecConfig(ConfigSource execConfig) {
-        final PreviewExecutorTask execTask = execConfig.loadConfig(PreviewExecutorTask.class);
+        final PreviewExecutorTask execTask = loadPreviewExecutorTask(execConfig);
         return Exec.newConfigSource().set("sample_buffer_bytes", execTask.getSampleBufferBytes());
     }
 
@@ -191,6 +191,16 @@ public class PreviewExecutor {
                 pages = null;
             }
         }
+    }
+
+    @SuppressWarnings("deprecation") // https://github.com/embulk/embulk/issues/1301
+    private static PreviewTask loadPreviewTask(final ConfigSource config) {
+        return config.loadConfig(PreviewTask.class);
+    }
+
+    @SuppressWarnings("deprecation") // https://github.com/embulk/embulk/issues/1301
+    private static PreviewExecutorTask loadPreviewExecutorTask(final ConfigSource config) {
+        return config.loadConfig(PreviewExecutorTask.class);
     }
 
     private static final Logger logger = LoggerFactory.getLogger(PreviewExecutor.class);

--- a/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
@@ -57,7 +57,7 @@ public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugi
 
     @Override
     public ConfigDiff transaction(ConfigSource config, final InputPlugin.Control control) {
-        final RunnerTask task = config.loadConfig(RunnerTask.class);
+        final RunnerTask task = loadRunnerTask(config);
         return fileInputPlugin.transaction(config, new RunnerControl(task, control));
     }
 
@@ -65,7 +65,7 @@ public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugi
     public ConfigDiff resume(TaskSource taskSource,
             Schema schema, int taskCount,
             InputPlugin.Control control) {
-        final RunnerTask task = taskSource.loadTask(RunnerTask.class);
+        final RunnerTask task = loadRunnerTaskFromTaskSource(taskSource);
         return fileInputPlugin.resume(task.getFileInputTaskSource(), taskCount, new RunnerControl(task, control));
     }
 
@@ -126,7 +126,7 @@ public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugi
     @Override
     public TaskReport run(TaskSource taskSource, Schema schema, int taskIndex,
             PageOutput output) {
-        final RunnerTask task = taskSource.loadTask(RunnerTask.class);
+        final RunnerTask task = loadRunnerTaskFromTaskSource(taskSource);
         List<DecoderPlugin> decoderPlugins = newDecoderPlugins(task);
         ParserPlugin parserPlugin = newParserPlugin(task);
 
@@ -144,7 +144,18 @@ public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugi
         }
     }
 
+    @SuppressWarnings("deprecation") // https://github.com/embulk/embulk/issues/1301
     public static TaskSource getFileInputTaskSource(TaskSource runnerTaskSource) {
         return runnerTaskSource.loadTask(RunnerTask.class).getFileInputTaskSource();
+    }
+
+    @SuppressWarnings("deprecation") // https://github.com/embulk/embulk/issues/1301
+    private static RunnerTask loadRunnerTask(final ConfigSource config) {
+        return config.loadConfig(RunnerTask.class);
+    }
+
+    @SuppressWarnings("deprecation") // https://github.com/embulk/embulk/issues/1301
+    private static RunnerTask loadRunnerTaskFromTaskSource(final TaskSource taskSource) {
+        return taskSource.loadTask(RunnerTask.class);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/FileOutputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileOutputRunner.java
@@ -55,14 +55,14 @@ public class FileOutputRunner implements OutputPlugin {
     public ConfigDiff transaction(ConfigSource config,
             final Schema schema, final int taskCount,
             final OutputPlugin.Control control) {
-        final RunnerTask task = config.loadConfig(RunnerTask.class);
+        final RunnerTask task = loadRunnerTask(config);
         return fileOutputPlugin.transaction(config, taskCount, new RunnerControl(schema, task, control));
     }
 
     public ConfigDiff resume(TaskSource taskSource,
             Schema schema, int taskCount,
             final OutputPlugin.Control control) {
-        final RunnerTask task = taskSource.loadTask(RunnerTask.class);
+        final RunnerTask task = loadRunnerTaskFromTaskSource(taskSource);
         return fileOutputPlugin.resume(task.getFileOutputTaskSource(), taskCount, new RunnerControl(schema, task, control));
     }
 
@@ -109,7 +109,7 @@ public class FileOutputRunner implements OutputPlugin {
 
     @Override
     public TransactionalPageOutput open(TaskSource taskSource, Schema schema, int taskIndex) {
-        final RunnerTask task = taskSource.loadTask(RunnerTask.class);
+        final RunnerTask task = loadRunnerTaskFromTaskSource(taskSource);
         List<EncoderPlugin> encoderPlugins = newEncoderPlugins(task);
         FormatterPlugin formatterPlugin = newFormatterPlugin(task);
 
@@ -169,7 +169,18 @@ public class FileOutputRunner implements OutputPlugin {
         }
     }
 
+    @SuppressWarnings("deprecation") // https://github.com/embulk/embulk/issues/1301
     public static TaskSource getFileOutputTaskSource(TaskSource runnerTaskSource) {
         return runnerTaskSource.loadTask(RunnerTask.class).getFileOutputTaskSource();
+    }
+
+    @SuppressWarnings("deprecation") // https://github.com/embulk/embulk/issues/1301
+    private static RunnerTask loadRunnerTask(final ConfigSource config) {
+        return config.loadConfig(RunnerTask.class);
+    }
+
+    @SuppressWarnings("deprecation") // https://github.com/embulk/embulk/issues/1301
+    private static RunnerTask loadRunnerTaskFromTaskSource(final TaskSource taskSource) {
+        return taskSource.loadTask(RunnerTask.class);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
@@ -110,6 +110,7 @@ class DynamicColumnSetterFactory {
         }
     }
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1301
     private DynamicPageBuilder.ColumnOption getColumnOption(Column column) {
         ConfigSource option = task.getColumnOptions().get(column.getName());
         if (option != null) {


### PR DESCRIPTION
We have had a lot of deprecation warnings when building `embulk-core` since #1273. They have been deprecated for plugins, but the core still uses them for a while.

To avoid so noisy warnings, adding `@SuppressWarnings` there.