### PR TITLE
Suppress internal deprecation warnings for org.embulk.spi.util.Pages

### DIFF
--- a/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
+++ b/embulk-core/src/main/java/org/embulk/command/PreviewPrinter.java
@@ -21,7 +21,6 @@ import org.embulk.spi.unit.LocalFileJacksonModule;
 import org.embulk.spi.unit.ToStringJacksonModule;
 import org.embulk.spi.unit.ToStringMapJacksonModule;
 import org.embulk.spi.util.CharsetJacksonModule;
-import org.embulk.spi.util.Pages;
 import org.msgpack.value.Value;
 
 public abstract class PreviewPrinter implements Closeable {
@@ -54,8 +53,9 @@ public abstract class PreviewPrinter implements Closeable {
         this.objectMapper.registerModule(new JodaModule());
     }
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1306
     public final void printAllPages(List<Page> pages) throws IOException {
-        List<Object[]> records = Pages.toObjects(schema, pages, true);
+        List<Object[]> records = org.embulk.spi.util.Pages.toObjects(schema, pages, true);
         for (Object[] record : records) {
             printRecord(record);
         }


### PR DESCRIPTION
We have had a lot of deprecation warnings when building `embulk-core` since #1273. They have been deprecated for plugins, but the core still uses them for a while.

To avoid so noisy warnings, adding `@SuppressWarnings` there.