### PR TITLE
Deprecate ModelManager

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -18,7 +18,6 @@ import java.util.function.Function;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigLoader;
 import org.embulk.config.ConfigSource;
-import org.embulk.config.ModelManager;
 import org.embulk.exec.BulkLoader;
 import org.embulk.exec.ExecModule;
 import org.embulk.exec.ExecutionResult;
@@ -153,8 +152,10 @@ public class EmbulkEmbed {
         return injector;
     }
 
-    public ModelManager getModelManager() {
-        return injector.getInstance(ModelManager.class);
+    @Deprecated  // https://github.com/embulk/embulk/issues/1304
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
+    public org.embulk.config.ModelManager getModelManager() {
+        return injector.getInstance(org.embulk.config.ModelManager.class);
     }
 
     public BufferAllocator getBufferAllocator() {

--- a/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
@@ -17,7 +17,6 @@ import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.DataSource;
-import org.embulk.config.ModelManager;
 import org.embulk.deps.config.YamlProcessor;
 import org.embulk.exec.ExecutionResult;
 import org.embulk.exec.PreviewResult;
@@ -433,15 +432,17 @@ public class EmbulkRunner {
         return yamlString;
     }
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     private String dumpDataSourceInYaml(final DataSource modelObject) {
-        final ModelManager modelManager = this.embed.getModelManager();
+        final org.embulk.config.ModelManager modelManager = this.embed.getModelManager();
         final Object object = modelManager.readObject(Object.class, modelManager.writeObject(modelObject));
         final YamlProcessor yamlProc = YamlProcessor.create(false);
         return yamlProc.dump(object);
     }
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     private String dumpResumeStateInYaml(final ResumeState modelObject) {
-        final ModelManager modelManager = this.embed.getModelManager();
+        final org.embulk.config.ModelManager modelManager = this.embed.getModelManager();
         final Object object = modelManager.readObject(Object.class, modelManager.writeObject(modelObject));
         final YamlProcessor yamlProc = YamlProcessor.create(false);
         return yamlProc.dump(object);

--- a/embulk-core/src/main/java/org/embulk/config/ConfigLoader.java
+++ b/embulk-core/src/main/java/org/embulk/config/ConfigLoader.java
@@ -17,9 +17,11 @@ import java.util.Properties;
 import org.embulk.deps.config.YamlProcessor;
 
 public class ConfigLoader {
+    @Deprecated  // https://github.com/embulk/embulk/issues/1304
     private final ModelManager model;
 
     @Inject
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     public ConfigLoader(ModelManager model) {
         this.model = model;
     }

--- a/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
+++ b/embulk-core/src/main/java/org/embulk/config/DataSourceImpl.java
@@ -12,18 +12,23 @@ import java.util.Map;
 
 public class DataSourceImpl implements ConfigSource, TaskSource, TaskReport, ConfigDiff {
     protected final ObjectNode data;
+
+    @Deprecated  // https://github.com/embulk/embulk/issues/1304
     protected final ModelManager model;
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     public DataSourceImpl(ModelManager model) {
         this(model, new ObjectNode(JsonNodeFactory.instance));
     }
 
     // visible for DataSourceSerDe, ConfigSourceLoader and TaskInvocationHandler.dump
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     public DataSourceImpl(ModelManager model, ObjectNode data) {
         this.data = data;
         this.model = model;
     }
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     protected DataSourceImpl newInstance(ModelManager model, ObjectNode data) {
         return new DataSourceImpl(model, (ObjectNode) data);
     }

--- a/embulk-core/src/main/java/org/embulk/config/DataSourceSerDe.java
+++ b/embulk-core/src/main/java/org/embulk/config/DataSourceSerDe.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 
 public class DataSourceSerDe {
     public static class SerDeModule extends SimpleModule {
-        @SuppressWarnings("deprecation")
+        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
         public SerDeModule(final ModelManager model) {
             // DataSourceImpl
             addSerializer(DataSourceImpl.class, new DataSourceSerializer<DataSourceImpl>(model));
@@ -42,9 +42,12 @@ public class DataSourceSerDe {
 
     // TODO T extends DataSource super DataSourceImpl
     private static class DataSourceDeserializer<T extends DataSource> extends JsonDeserializer<T> {
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
         private final ModelManager model;
+
         private final ObjectMapper treeObjectMapper;
 
+        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
         DataSourceDeserializer(ModelManager model) {
             this.model = model;
             this.treeObjectMapper = new ObjectMapper();
@@ -62,8 +65,10 @@ public class DataSourceSerDe {
     }
 
     private static class DataSourceSerializer<T extends DataSource> extends JsonSerializer<T> {
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
         private final ModelManager model;
 
+        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
         DataSourceSerializer(final ModelManager model) {
             this.model = model;
         }

--- a/embulk-core/src/main/java/org/embulk/config/ModelManager.java
+++ b/embulk-core/src/main/java/org/embulk/config/ModelManager.java
@@ -9,6 +9,7 @@ import com.google.inject.Injector;
 import javax.validation.Validation;
 import org.apache.bval.jsr303.ApacheValidationProvider;
 
+@Deprecated  // https://github.com/embulk/embulk/issues/1304
 public class ModelManager {
     private final Injector injector;
     private final ObjectMapper objectMapper;

--- a/embulk-core/src/main/java/org/embulk/config/TaskInvocationHandler.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskInvocationHandler.java
@@ -12,11 +12,14 @@ import java.util.Map;
 import java.util.Set;
 
 class TaskInvocationHandler implements InvocationHandler {
+    @Deprecated  // https://github.com/embulk/embulk/issues/1304
     private final ModelManager model;
+
     private final Class<?> iface;
     private final Map<String, Object> objects;
     private final Set<String> injectedFields;
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     public TaskInvocationHandler(ModelManager model, Class<?> iface, Map<String, Object> objects, Set<String> injectedFields) {
         this.model = model;
         this.iface = iface;

--- a/embulk-core/src/main/java/org/embulk/config/TaskSerDe.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskSerDe.java
@@ -67,11 +67,15 @@ class TaskSerDe {
 
     public static class TaskDeserializer<T> extends JsonDeserializer<T> {
         private final ObjectMapper nestedObjectMapper;
+
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
         private final ModelManager model;
+
         private final Class<?> iface;
         private final Multimap<String, FieldEntry> mappings;
         private final List<InjectEntry> injects;
 
+        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
         public TaskDeserializer(ObjectMapper nestedObjectMapper, ModelManager model, Class<T> iface) {
             this.nestedObjectMapper = nestedObjectMapper;
             this.model = model;
@@ -244,6 +248,7 @@ class TaskSerDe {
     }
 
     public static class ConfigTaskDeserializer<T> extends TaskDeserializer<T> {
+        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
         public ConfigTaskDeserializer(ObjectMapper nestedObjectMapper, ModelManager model, Class<T> iface) {
             super(nestedObjectMapper, model, iface);
         }
@@ -270,8 +275,11 @@ class TaskSerDe {
 
     public static class TaskDeserializerModule extends Module {  // can't use just SimpleModule, due to generic types
         protected final ObjectMapper nestedObjectMapper;
+
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
         protected final ModelManager model;
 
+        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
         public TaskDeserializerModule(ObjectMapper nestedObjectMapper, ModelManager model) {
             this.nestedObjectMapper = nestedObjectMapper;
             this.model = model;
@@ -311,6 +319,7 @@ class TaskSerDe {
     }
 
     public static class ConfigTaskDeserializerModule extends TaskDeserializerModule {
+        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
         public ConfigTaskDeserializerModule(ObjectMapper nestedObjectMapper, ModelManager model) {
             super(nestedObjectMapper, model);
         }

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -14,7 +14,6 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.embulk.EmbulkSystemProperties;
-import org.embulk.config.ModelManager;
 import org.embulk.deps.buffer.PooledBufferAllocator;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.ColumnJacksonModule;
@@ -36,7 +35,8 @@ public class ExecModule implements Module {
         this.embulkSystemProperties = embulkSystemProperties;
     }
 
-    @SuppressWarnings("deprecation")
+    // DateTimeZoneJacksonModule, TimestampJacksonModule, ToStringJacksonModule, ToStringMapJacksonModule
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304 and Jackson Modules
     @Override
     public void configure(final Binder binder) {
         if (binder == null) {
@@ -48,7 +48,7 @@ public class ExecModule implements Module {
         // TODO: Remove this ILoggerFactory binding.
         binder.bind(ILoggerFactory.class).toProvider(LoggerProvider.class).in(Scopes.SINGLETON);
 
-        binder.bind(ModelManager.class).in(Scopes.SINGLETON);
+        binder.bind(org.embulk.config.ModelManager.class).in(Scopes.SINGLETON);
         binder.bind(BufferAllocator.class).toInstance(this.createBufferAllocatorFromSystemConfig());
         binder.bind(TempFileSpaceAllocator.class).toInstance(new SimpleTempFileSpaceAllocator());
 

--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyInitializer.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyInitializer.java
@@ -8,7 +8,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.embulk.config.ModelManager;
 import org.embulk.spi.BufferAllocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,7 +134,7 @@ public final class JRubyInitializer {
 
         final Object injected = jruby.runScriptlet("Embulk::Java::Injected");
         jruby.callMethod(injected, "const_set", "Injector", injector);
-        jruby.callMethod(injected, "const_set", "ModelManager", injector.getInstance(ModelManager.class));
+        constSetModelManager(jruby, injected, injector);
         jruby.callMethod(injected, "const_set", "BufferAllocator", injector.getInstance(BufferAllocator.class));
 
         jruby.callMethod(jruby.runScriptlet("Embulk"), "logger=", jruby.callMethod(
@@ -285,6 +284,14 @@ public final class JRubyInitializer {
         }
 
         return userHome.toAbsolutePath().resolve(".embulk");
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
+    private static void constSetModelManager(
+            final ScriptingContainerDelegate jruby,
+            final Object injected,
+            final Injector injector) {
+        jruby.callMethod(injected, "const_set", "ModelManager", injector.getInstance(org.embulk.config.ModelManager.class));
     }
 
     private final Injector injector;

--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
@@ -13,7 +13,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.embulk.EmbulkSystemProperties;
-import org.embulk.config.ModelManager;
 import org.embulk.spi.BufferAllocator;
 import org.slf4j.LoggerFactory;
 
@@ -71,10 +70,11 @@ public class JRubyScriptingModule implements Module {
         }
 
         @Override  // from |com.google.inject.spi.HasDependencies|
+        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
         public Set<Dependency<?>> getDependencies() {
             // get() depends on other modules
             final HashSet<Dependency<?>> built = new HashSet<>();
-            built.add(Dependency.get(Key.get(ModelManager.class)));
+            built.add(Dependency.get(Key.get(org.embulk.config.ModelManager.class)));
             built.add(Dependency.get(Key.get(BufferAllocator.class)));
             return Collections.unmodifiableSet(built);
         }

--- a/embulk-core/src/main/java/org/embulk/spi/Exec.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Exec.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
-import org.embulk.config.ModelManager;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.plugin.PluginType;
@@ -65,7 +64,9 @@ public class Exec {
         return session().getBufferAllocator();
     }
 
-    public static ModelManager getModelManager() {
+    @Deprecated  // https://github.com/embulk/embulk/issues/1304
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
+    public static org.embulk.config.ModelManager getModelManager() {
         return session().getModelManager();
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -15,7 +15,6 @@ import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.DataSourceImpl;
-import org.embulk.config.ModelManager;
 import org.embulk.config.Task;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
@@ -41,7 +40,9 @@ public class ExecSession {
     private final Injector injector;
     private final EmbulkSystemProperties embulkSystemProperties;
 
-    private final ModelManager modelManager;
+    @Deprecated  // https://github.com/embulk/embulk/issues/1304
+    private final org.embulk.config.ModelManager modelManager;
+
     private final PluginClassLoaderFactory pluginClassLoaderFactory;
     private final PluginManager pluginManager;
     private final BufferAllocator bufferAllocator;
@@ -156,7 +157,7 @@ public class ExecSession {
 
         this.injector = injector;
         this.embulkSystemProperties = embulkSystemProperties;
-        this.modelManager = injector.getInstance(ModelManager.class);
+        this.modelManager = getModelManagerFromInjector(injector);
 
         this.pluginClassLoaderFactory = PluginClassLoaderFactoryImpl.of(
                 (parentFirstPackages != null) ? parentFirstPackages : Collections.unmodifiableSet(new HashSet<>()),
@@ -232,7 +233,9 @@ public class ExecSession {
         return bufferAllocator;
     }
 
-    public ModelManager getModelManager() {
+    @Deprecated  // https://github.com/embulk/embulk/issues/1304
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
+    public org.embulk.config.ModelManager getModelManager() {
         return modelManager;
     }
 
@@ -274,6 +277,11 @@ public class ExecSession {
     public void cleanup() {
         this.pluginClassLoaderFactory.clear();
         tempFileSpace.cleanup();
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
+    private static org.embulk.config.ModelManager getModelManagerFromInjector(final Injector injector) {
+        return injector.getInstance(org.embulk.config.ModelManager.class);
     }
 
     private static Optional<Instant> toInstantFromString(final String string) {


### PR DESCRIPTION
`ModelManager` is one of the biggest source of complicated dependencies in `embulk-core`. Once plugins start using `embulk-util-config` instead of `ConfigSource#loadConfig` and `TaskSource#loadTask`, it will finally be unnecessary.

To show it will be finally away, marking it `@Deprecated`. Plugins should not use it!