### PR TITLE
Prepare org.embulk.spi.ExecInternal to contain Exec methods not for plugins

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
@@ -466,7 +466,6 @@ public class EmbulkRunner {
     //   end
     // end
 
-    // NOTE: The root logger directly from |LoggerFactory|, not from |Exec.getLogger| as it's outside of |Exec.doWith|.
     private static final Logger rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 
     private static final Pattern EXT_YAML = Pattern.compile(".*\\.ya?ml$");

--- a/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
@@ -27,7 +27,8 @@ import org.embulk.spi.Buffer;
 import org.embulk.spi.BufferImpl;
 import org.embulk.spi.Exec;
 import org.embulk.spi.ExecAction;
-import org.embulk.spi.ExecSession;
+import org.embulk.spi.ExecInternal;
+import org.embulk.spi.ExecSessionInternal;
 import org.embulk.spi.FileInput;
 import org.embulk.spi.FileInputRunner;
 import org.embulk.spi.GuessPlugin;
@@ -91,9 +92,9 @@ public class GuessExecutor {
         this.defaultGuessPlugins = Collections.unmodifiableList(guessPluginsBuilt);
     }
 
-    public ConfigDiff guess(ExecSession exec, final ConfigSource config) {
+    public ConfigDiff guess(ExecSessionInternal exec, final ConfigSource config) {
         try {
-            return Exec.doWith(exec, new ExecAction<ConfigDiff>() {
+            return ExecInternal.doWith(exec, new ExecAction<ConfigDiff>() {
                     public ConfigDiff run() {
                         try (SetCurrentThreadName dontCare = new SetCurrentThreadName("guess")) {
                             return doGuess(config);
@@ -112,7 +113,7 @@ public class GuessExecutor {
     }
 
     protected InputPlugin newInputPlugin(ConfigSource inputConfig) {
-        return Exec.newPlugin(InputPlugin.class, inputConfig.get(PluginType.class, "type"));
+        return ExecInternal.newPlugin(InputPlugin.class, inputConfig.get(PluginType.class, "type"));
     }
 
     private ConfigDiff doGuess(ConfigSource config) {
@@ -235,7 +236,7 @@ public class GuessExecutor {
             // load guess plugins
             ImmutableList.Builder<GuessPlugin> builder = ImmutableList.builder();
             for (PluginType guessType : task.getGuessPluginTypes()) {
-                GuessPlugin guess = Exec.newPlugin(GuessPlugin.class, guessType);
+                GuessPlugin guess = ExecInternal.newPlugin(GuessPlugin.class, guessType);
                 builder.add(guess);
             }
             List<GuessPlugin> guesses = builder.build();

--- a/embulk-core/src/main/java/org/embulk/spi/Exec.java
+++ b/embulk-core/src/main/java/org/embulk/spi/Exec.java
@@ -10,92 +10,158 @@ import org.embulk.config.TaskSource;
 import org.embulk.plugin.PluginType;
 import org.slf4j.Logger;
 
+/**
+ * Provides static access inside Embulk for plugins.
+ *
+ * <p>Some methods, such as {@code newPlugin}, are deprecated. Those methods will be removed soon during Embulk v0.10 when
+ * this {@link Exec} moves to {@code embulk-api} from {@code embulk-core}.
+ *
+ * <p>If access to the deprecated/removed methods is really needed, a plugin can technically call them via {@link ExecInternal}
+ * in {@code embulk-core}. It is the quickest way to catch-up with the latest Embulk v0.10. But once doing it, the plugin won't
+ * work with Embulk v0.9. To keep your plugin work for both, find another way to realize what you want.
+ *
+ * <p>Keeping on calling {@link ExecInternal} is strongly discouraged although it can be a short-term solution as shown above.
+ * Embulk does not guarantee any compatibility in {@code embulk-core} with plugins. The plugin may easily stop working at some
+ * point of Embulk versions. Do it at your own risk.
+ */
 public class Exec {
     private static final InheritableThreadLocal<ExecSession> session = new InheritableThreadLocal<ExecSession>();
 
     private Exec() {}
 
+    @Deprecated
     public static <T> T doWith(ExecSession session, ExecAction<T> action) throws ExecutionException {
-        Exec.session.set(session);
-        try {
-            return action.run();
-        } catch (Exception ex) {
-            throw new ExecutionException(ex);
-        } finally {
-            Exec.session.set(null);
-        }
+        throw new ExecutionException(new UnsupportedOperationException(
+                "Exec.doWith is no longer supported. "
+                + "If it is really needed, a plugin can call ExecInternal.doWith instead. "
+                + "But, keep it in mind that ExecInternal is strongly discouraged for plugins to call. "
+                + "Embulk does not guarantee any compatibility with ExecInternal. "
+                + "If you are trying to access ExecInternal from your plugin's non-test code, "
+                + "remember that your plugin may easily stop working from some version of Embulk."));
     }
 
+    /**
+     * To be called only from ExecInternal.doWith.
+     */
+    static void setThreadLocalSession(final ExecSession session) {
+        Exec.session.set(session);
+    }
+
+    @Deprecated
     public static ExecSession session() {
+        return sessionForInside();
+    }
+
+    private static ExecSession sessionForInside() {
         ExecSession session = Exec.session.get();
         if (session == null) {
-            throw new NullPointerException("Exec is used outside of Exec.doWith");
+            throw new NullPointerException("Exec is used outside of ExecInternal.doWith.");
         }
         return session;
     }
 
+    /**
+     * Returns Embulk's internal Guice Injector.
+     *
+     * <p>This method is deprecated, and it will be removed from {@link Exec} very soon during Embulk v0.10. If a plugin
+     * really needs it, a plugin can technically {@link ExecInternal#getInjector} in {@code embulk-core} instead.
+     *
+     * <p>But, it is strongly discouraged to keep on calling it for a long time. Embulk does not guarantee any compatibility in
+     * {@code embulk-core} with plugins. If a plugin calls it, the plugin may stop working at some point of Embulk versions.
+     * Do it at your own risk.
+     *
+     * @deprecated {@code getInjector} will be removed from {@link Exec} very soon during Embulk v0.10.
+     */
+    @Deprecated  // https://github.com/embulk/embulk/issues/1313
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1313
     public static Injector getInjector() {
-        return session().getInjector();
+        return sessionForInside().getInjector();
     }
 
-    @Deprecated
+    @Deprecated  // https://github.com/embulk/embulk/issues/1292
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public static org.embulk.spi.time.Timestamp getTransactionTime() {
-        return org.embulk.spi.time.Timestamp.ofInstant(session().getTransactionTimeInstant());
+        return org.embulk.spi.time.Timestamp.ofInstant(sessionForInside().getTransactionTimeInstant());
     }
 
     public static Instant getTransactionTimeInstant() {
-        return session().getTransactionTimeInstant();
+        return sessionForInside().getTransactionTimeInstant();
     }
 
     @Deprecated  // @see docs/design/slf4j.md
     @SuppressWarnings("deprecation")
     public static Logger getLogger(String name) {
-        return session().getLogger(name);
+        return sessionForInside().getLogger(name);
     }
 
     @Deprecated  // @see docs/design/slf4j.md
     @SuppressWarnings("deprecation")
     public static Logger getLogger(Class<?> name) {
-        return session().getLogger(name);
+        return sessionForInside().getLogger(name);
     }
 
     public static BufferAllocator getBufferAllocator() {
-        return session().getBufferAllocator();
+        return sessionForInside().getBufferAllocator();
     }
 
+    /**
+     * Returns Embulk's {@link org.embulk.config.ModelManager}.
+     *
+     * <p>This method is deprecated, and it will be removed from {@link Exec} very soon during Embulk v0.10. If a plugin
+     * really needs it, a plugin can technically {@link ExecInternal#getModelManager} in {@code embulk-core} instead.
+     *
+     * <p>But, it is strongly discouraged to keep on calling it for a long time. Embulk does not guarantee any compatibility in
+     * {@code embulk-core} with plugins. If a plugin calls it, the plugin may stop working at some point of Embulk versions.
+     * Do it at your own risk.
+     *
+     * @deprecated {@code getModelManager} will be removed from {@link Exec} very soon during Embulk v0.10.
+     */
     @Deprecated  // https://github.com/embulk/embulk/issues/1304
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     public static org.embulk.config.ModelManager getModelManager() {
-        return session().getModelManager();
+        return sessionForInside().getModelManager();
     }
 
+    /**
+     * Registers a new Embulk plugin.
+     *
+     * <p>This method is deprecated, and it will be removed from {@link Exec} very soon during Embulk v0.10. If a plugin
+     * really needs it, a plugin can technically {@link ExecInternal#newPlugin} in {@code embulk-core} instead.
+     *
+     * <p>But, it is strongly discouraged to keep on calling it for a long time. Embulk does not guarantee any compatibility in
+     * {@code embulk-core} with plugins. If a plugin calls it, the plugin may stop working at some point of Embulk versions.
+     * Do it at your own risk.
+     *
+     * @deprecated {@code newPlugin} will be removed from {@link Exec} very soon during Embulk v0.10.
+     */
+    @Deprecated  // https://github.com/embulk/embulk/issues/1309
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1309
     public static <T> T newPlugin(Class<T> iface, PluginType type) {
-        return session().newPlugin(iface, type);
+        return sessionForInside().newPlugin(iface, type);
     }
 
     public static TaskReport newTaskReport() {
-        return session().newTaskReport();
+        return sessionForInside().newTaskReport();
     }
 
     public static ConfigDiff newConfigDiff() {
-        return session().newConfigDiff();
+        return sessionForInside().newConfigDiff();
     }
 
     public static ConfigSource newConfigSource() {
-        return session().newConfigSource();
+        return sessionForInside().newConfigSource();
     }
 
     public static TaskSource newTaskSource() {
-        return session().newTaskSource();
+        return sessionForInside().newTaskSource();
     }
 
     // TODO this method is still beta
     public static TempFileSpace getTempFileSpace() {
-        return session().getTempFileSpace();
+        return sessionForInside().getTempFileSpace();
     }
 
     public static boolean isPreview() {
-        return session().isPreview();
+        return sessionForInside().isPreview();
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/ExecInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecInternal.java
@@ -1,0 +1,60 @@
+package org.embulk.spi;
+
+import com.google.inject.Injector;
+import java.util.concurrent.ExecutionException;
+import org.embulk.plugin.PluginType;
+
+/**
+ * Provides static access inside Embulk.
+ *
+ * <p>It complements methods deprecated/removed from {@link Exec}. It is used from {@code embulk-core} internally.
+ *
+ * <p>A plugin can technically call them via {@link ExecInternal} in {@code embulk-core} though it is strongly discouraged.
+ * Embulk does not guarantee any compatibility in {@code embulk-core} with plugins. The plugin may easily stop working at
+ * some point of Embulk versions. Do it at your own risk.
+ */
+public class ExecInternal {
+    private ExecInternal() {}
+
+    public static <T> T doWith(
+            final ExecSessionInternal sessionInternal,
+            final ExecAction<T> action)
+            throws ExecutionException {
+        ExecInternal.sessionInternal.set(sessionInternal);
+        Exec.setThreadLocalSession(sessionInternal);
+        try {
+            return action.run();
+        } catch (final Exception ex) {
+            throw new ExecutionException(ex);
+        } finally {
+            Exec.setThreadLocalSession(null);
+            ExecInternal.sessionInternal.set(null);
+        }
+    }
+
+    public static ExecSessionInternal sessionInternal() {
+        final ExecSessionInternal sessionInternal = ExecInternal.sessionInternal.get();
+        if (sessionInternal == null) {
+            throw new NullPointerException("Exec is used outside of ExecInternal.doWith");
+        }
+        return sessionInternal;
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1313
+    public static Injector getInjector() {
+        return sessionInternal().getInjector();
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
+    public static org.embulk.config.ModelManager getModelManager() {
+        return sessionInternal().getModelManager();
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1309
+    public static <T> T newPlugin(final Class<T> iface, final PluginType type) {
+        return sessionInternal().newPlugin(iface, type);
+    }
+
+    private static final InheritableThreadLocal<ExecSessionInternal> sessionInternal =
+            new InheritableThreadLocal<ExecSessionInternal>();
+}

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSession.java
@@ -2,302 +2,128 @@ package org.embulk.spi;
 
 import com.google.inject.Injector;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.Set;
-import org.embulk.EmbulkSystemProperties;
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
-import org.embulk.config.DataSourceImpl;
-import org.embulk.config.Task;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
-import org.embulk.jruby.JRubyPluginSource;
-import org.embulk.jruby.ScriptingContainerDelegate;
-import org.embulk.plugin.InjectedPluginSource;
-import org.embulk.plugin.PluginClassLoaderFactory;
-import org.embulk.plugin.PluginClassLoaderFactoryImpl;
-import org.embulk.plugin.PluginManager;
 import org.embulk.plugin.PluginType;
-import org.embulk.plugin.maven.MavenPluginSource;
-import org.embulk.spi.time.Instants;
 import org.embulk.spi.time.TimestampFormatter;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class ExecSession {
-    private static final Logger logger = LoggerFactory.getLogger(ExecSession.class);
-
-    private static final DateTimeFormatter ISO8601_BASIC =
-            DateTimeFormatter.ofPattern("uuuuMMdd'T'HHmmss'Z'", Locale.ENGLISH).withZone(ZoneOffset.UTC);
-
-    private final Injector injector;
-    private final EmbulkSystemProperties embulkSystemProperties;
-
-    @Deprecated  // https://github.com/embulk/embulk/issues/1304
-    private final org.embulk.config.ModelManager modelManager;
-
-    private final PluginClassLoaderFactory pluginClassLoaderFactory;
-    private final PluginManager pluginManager;
-    private final BufferAllocator bufferAllocator;
-
-    private final Instant transactionTime;
-    private final TempFileSpace tempFileSpace;
-
-    private final boolean preview;
-
-    @Deprecated  // TODO: Remove it.
-    private interface SessionTask extends Task {
-        @Config("transaction_time")
-        @ConfigDefault("null")
-        Optional<String> getTransactionTime();
+/**
+ * Provides access inside Embulk for plugins through a transactional session.
+ *
+ * <p>Some methods, such as {@code newPlugin}, are deprecated. Those methods will be removed soon during Embulk v0.10 when
+ * this {@link Exec} moves to {@code embulk-api} from {@code embulk-core}.
+ *
+ * <p>Accessing {@link ExecSession} from plugins is however discouraged though {@link ExecSession} is in {@code embulk-api},
+ * so accessible from plugins.
+ */
+public abstract class ExecSession {
+    /**
+     * A constructor for {@link ExecSessionInternal} inherited.
+     */
+    ExecSession() {
     }
 
+    @Deprecated
     public static class Builder {
-        private final Injector injector;
-        private EmbulkSystemProperties embulkSystemProperties;
-        private Set<String> parentFirstPackages;
-        private Set<String> parentFirstResources;
-        private Instant transactionTime;
-
-        public Builder(Injector injector) {
-            this.injector = injector;
-            this.embulkSystemProperties = null;
-            this.parentFirstPackages = null;
-            this.parentFirstResources = null;
-            this.transactionTime = null;
-        }
-
-        public Builder fromExecConfig(ConfigSource configSource) {
-            final Optional<Instant> transactionTime =
-                    toInstantFromString(configSource.get(String.class, "transaction_time", null));
-            if (transactionTime.isPresent()) {
-                this.transactionTime = transactionTime.get();
-            }
-            return this;
-        }
-
-        public Builder setEmbulkSystemProperties(final EmbulkSystemProperties embulkSystemProperties) {
-            this.embulkSystemProperties = embulkSystemProperties;
-            return this;
-        }
-
-        public Builder setParentFirstPackages(final Set<String> parentFirstPackages) {
-            this.parentFirstPackages = Collections.unmodifiableSet(new HashSet<>(parentFirstPackages));
-            return this;
-        }
-
-        public Builder setParentFirstResources(final Set<String> parentFirstResources) {
-            this.parentFirstResources = Collections.unmodifiableSet(new HashSet<>(parentFirstResources));
-            return this;
-        }
-
-        @Deprecated  // TODO: Add setTransactionTime(Instant) if needed. But no one looks using it. May not be needed.
-        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-        public Builder setTransactionTime(final org.embulk.spi.time.Timestamp timestamp) {
-            logger.warn("ExecSession.Builder#setTransactionTime is deprecated. Set it via ExecSession.Builder#fromExecConfig.");
-            this.transactionTime = timestamp.getInstant();
-            return this;
-        }
-
-        public ExecSession build() {
-            if (transactionTime == null) {
-                transactionTime = Instant.now();
-            }
-            if (this.embulkSystemProperties == null) {
-                logger.warn("EmbulkSystemProperties is not set when building ExecSession. "
-                            + "Use ExecSession.Builder#setEmbulkSystemProperties.");
-                this.embulkSystemProperties = this.injector.getInstance(EmbulkSystemProperties.class);
-            }
-            return new ExecSession(
-                    this.injector,
-                    this.transactionTime,
-                    this.embulkSystemProperties,
-                    this.parentFirstPackages,
-                    this.parentFirstResources);
-        }
     }
 
+    @Deprecated
+    @SuppressWarnings("deprecation")
     public static Builder builder(Injector injector) {
-        return new Builder(injector);
+        throw new UnsupportedOperationException(
+                "ExecSession.builder is no longer supported. "
+                + "If it is really needed, a plugin can call ExecSessionInternal.builder instead. "
+                + "But, keep it in mind that ExecSessionInternal is strongly discouraged for plugins to call. "
+                + "Embulk does not guarantee any compatibility with ExecSessionInternal. "
+                + "If you are trying to access ExecSessionInternal from your plugin's non-test code, "
+                + "remember that your plugin may easily stop working from some version of Embulk.");
     }
 
     @Deprecated
-    @SuppressWarnings("deprecation")  // For the use of SessionTask.
     public ExecSession(Injector injector, ConfigSource configSource) {
-        this(injector,
-             configSource.loadConfig(SessionTask.class).getTransactionTime().flatMap(ExecSession::toInstantFromString).orElse(
-                     Instant.now()),
-             injector.getInstance(EmbulkSystemProperties.class),
-             null,
-             null);
-        logger.warn("Constructing with ExecSession(Injector, ConfigSource) is deprecated. Use ExecSession.Builder instead.");
+        throw new UnsupportedOperationException(
+                "ExecSession's constructor is no longer supported. "
+                + "If it is really needed, a plugin can call ExecSessionInternal.builder instead. "
+                + "But, keep it in mind that ExecSessionInternal is strongly discouraged for plugins to call. "
+                + "Embulk does not guarantee any compatibility with ExecSessionInternal. "
+                + "If you are trying to access ExecSessionInternal from your plugin's non-test code, "
+                + "remember that your plugin may easily stop working from some version of Embulk.");
     }
 
-    private ExecSession(
-            final Injector injector,
-            final Instant transactionTime,
-            final EmbulkSystemProperties embulkSystemProperties,
-            final Set<String> parentFirstPackages,
-            final Set<String> parentFirstResources) {
-        if (parentFirstPackages == null) {
-            logger.warn("Parent-first packages are not set when building ExecSession. "
-                        + "Use ExecSession.Builder#setParentFirstPackages.");
-        }
-        if (parentFirstResources == null) {
-            logger.warn("Parent-first resources are not set when building ExecSession. "
-                        + "Use ExecSession.Builder#setParentFirstResources.");
-        }
-
-        this.injector = injector;
-        this.embulkSystemProperties = embulkSystemProperties;
-        this.modelManager = getModelManagerFromInjector(injector);
-
-        this.pluginClassLoaderFactory = PluginClassLoaderFactoryImpl.of(
-                (parentFirstPackages != null) ? parentFirstPackages : Collections.unmodifiableSet(new HashSet<>()),
-                (parentFirstResources != null) ? parentFirstResources : Collections.unmodifiableSet(new HashSet<>()));
-        this.pluginManager = PluginManager.with(
-                new InjectedPluginSource(injector),
-                new MavenPluginSource(injector, embulkSystemProperties, pluginClassLoaderFactory),
-                new JRubyPluginSource(injector.getInstance(ScriptingContainerDelegate.class), pluginClassLoaderFactory));
-
-        this.bufferAllocator = injector.getInstance(BufferAllocator.class);
-
-        this.transactionTime = transactionTime;
-
-        final TempFileSpaceAllocator tempFileSpaceAllocator = injector.getInstance(TempFileSpaceAllocator.class);
-        this.tempFileSpace = tempFileSpaceAllocator.newSpace(ISO8601_BASIC.format(this.transactionTime));
-
-        this.preview = false;
-    }
-
-    private ExecSession(ExecSession copy, boolean preview) {
-        this.injector = copy.injector;
-        this.embulkSystemProperties = copy.embulkSystemProperties;
-        this.modelManager = copy.modelManager;
-        this.pluginClassLoaderFactory = copy.pluginClassLoaderFactory;
-        this.pluginManager = copy.pluginManager;
-        this.bufferAllocator = copy.bufferAllocator;
-
-        this.transactionTime = copy.transactionTime;
-        this.tempFileSpace = copy.tempFileSpace;
-
-        this.preview = preview;
-    }
-
-    public ExecSession forPreview() {
-        return new ExecSession(this, true);
-    }
+    public abstract ExecSession forPreview();
 
     @Deprecated
-    public ConfigSource getSessionExecConfig() {
-        return newConfigSource()
-                .set("transaction_time", Instants.toString(this.transactionTime));
-    }
+    public abstract ConfigSource getSessionExecConfig();
 
-    public Injector getInjector() {
-        return injector;
-    }
+    /**
+     * Returns Embulk's internal Guice Injector.
+     *
+     * <p>This method is deprecated, and it will be removed from {@link ExecSession} very soon during Embulk v0.10
+     * although it will stay in {@link ExecSessionInternal}.
+     *
+     * @deprecated {@code getInjector} will be removed from {@link ExecSession} very soon during Embulk v0.10.
+     */
+    @Deprecated  // https://github.com/embulk/embulk/issues/1313
+    public abstract Injector getInjector();
 
-    @Deprecated
+    @Deprecated  // https://github.com/embulk/embulk/issues/1292
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
-    public org.embulk.spi.time.Timestamp getTransactionTime() {
-        return org.embulk.spi.time.Timestamp.ofInstant(this.transactionTime);
-    }
+    public abstract org.embulk.spi.time.Timestamp getTransactionTime();
 
-    public Instant getTransactionTimeInstant() {
-        return this.transactionTime;
-    }
+    public abstract Instant getTransactionTimeInstant();
 
-    public String getTransactionTimeString() {
-        return Instants.toString(this.transactionTime);
-    }
+    public abstract String getTransactionTimeString();
 
     @Deprecated  // @see docs/design/slf4j.md
-    public Logger getLogger(String name) {
-        return LoggerFactory.getLogger(name);
-    }
+    public abstract Logger getLogger(String name);
 
     @Deprecated  // @see docs/design/slf4j.md
-    public Logger getLogger(Class<?> clazz) {
-        return LoggerFactory.getLogger(clazz);
-    }
+    public abstract Logger getLogger(Class<?> clazz);
 
-    public BufferAllocator getBufferAllocator() {
-        return bufferAllocator;
-    }
+    public abstract BufferAllocator getBufferAllocator();
 
+    /**
+     * Returns Embulk's {@link org.embulk.config.ModelManager}.
+     *
+     * <p>This method is deprecated, and it will be removed from {@link ExecSession} very soon during Embulk v0.10
+     * although it will stay in {@link ExecSessionInternal}.
+     *
+     * @deprecated {@code getModelManager} will be removed from {@link Exec} very soon during Embulk v0.10.
+     */
     @Deprecated  // https://github.com/embulk/embulk/issues/1304
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
-    public org.embulk.config.ModelManager getModelManager() {
-        return modelManager;
-    }
+    public abstract org.embulk.config.ModelManager getModelManager();
 
-    public <T> T newPlugin(Class<T> iface, PluginType type) {
-        return pluginManager.newPlugin(iface, type);
-    }
+    /**
+     * Registers a new Embulk plugin.
+     *
+     * <p>This method is deprecated, and it will be removed from {@link ExecSession} very soon during Embulk v0.10
+     * although it will stay in {@link ExecSessionInternal}.
+     *
+     * @deprecated {@code newPlugin} will be removed from {@link Exec} very soon during Embulk v0.10.
+     */
+    @Deprecated  // https://github.com/embulk/embulk/issues/1309
+    public abstract <T> T newPlugin(Class<T> iface, PluginType type);
 
-    public TaskReport newTaskReport() {
-        return new DataSourceImpl(modelManager);
-    }
+    public abstract TaskReport newTaskReport();
 
-    public ConfigDiff newConfigDiff() {
-        return new DataSourceImpl(modelManager);
-    }
+    public abstract ConfigDiff newConfigDiff();
 
-    public ConfigSource newConfigSource() {
-        return new DataSourceImpl(modelManager);
-    }
+    public abstract ConfigSource newConfigSource();
 
-    public TaskSource newTaskSource() {
-        return new DataSourceImpl(modelManager);
-    }
+    public abstract TaskSource newTaskSource();
 
     // To be removed by v0.10 or earlier.
     @Deprecated  // https://github.com/embulk/embulk/issues/936
-    @SuppressWarnings("deprecation")
-    public TimestampFormatter newTimestampFormatter(String format, org.joda.time.DateTimeZone timezone) {
-        return new TimestampFormatter(format, timezone);
-    }
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/936
+    public abstract TimestampFormatter newTimestampFormatter(String format, org.joda.time.DateTimeZone timezone);
 
-    public TempFileSpace getTempFileSpace() {
-        return tempFileSpace;
-    }
+    public abstract TempFileSpace getTempFileSpace();
 
-    public boolean isPreview() {
-        return preview;
-    }
+    public abstract boolean isPreview();
 
-    public void cleanup() {
-        this.pluginClassLoaderFactory.clear();
-        tempFileSpace.cleanup();
-    }
-
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
-    private static org.embulk.config.ModelManager getModelManagerFromInjector(final Injector injector) {
-        return injector.getInstance(org.embulk.config.ModelManager.class);
-    }
-
-    private static Optional<Instant> toInstantFromString(final String string) {
-        if (string == null) {
-            return Optional.empty();
-        }
-
-        try {
-            return Optional.of(Instants.parseInstant(string));
-        } catch (final NumberFormatException ex) {
-            logger.warn("\"transaction_time\" is in an invalid format: '" + string + "'. "
-                        + "The transaction time is set to the present.", ex);
-            return Optional.empty();
-        } catch (final IllegalStateException ex) {
-            logger.error("Unexpected failure in parsing \"transaction_time\": '" + string + "'", ex);
-            throw ex;
-        }
-    }
+    public abstract void cleanup();
 }

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSessionInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSessionInternal.java
@@ -1,0 +1,334 @@
+package org.embulk.spi;
+
+import com.google.inject.Injector;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import org.embulk.EmbulkSystemProperties;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.DataSourceImpl;
+import org.embulk.config.Task;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.jruby.JRubyPluginSource;
+import org.embulk.jruby.ScriptingContainerDelegate;
+import org.embulk.plugin.InjectedPluginSource;
+import org.embulk.plugin.PluginClassLoaderFactory;
+import org.embulk.plugin.PluginClassLoaderFactoryImpl;
+import org.embulk.plugin.PluginManager;
+import org.embulk.plugin.PluginType;
+import org.embulk.plugin.maven.MavenPluginSource;
+import org.embulk.spi.time.Instants;
+import org.embulk.spi.time.TimestampFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides access inside Embulk through a transactional session.
+ *
+ * <p>It is internal implementation of {@link ExecSession} although some methods, such as {@code newPlugin}, are to be
+ * removed from {@link ExecSession} soon during Embulk v0.10 when {@link ExecSession} moves to {@code embulk-api} from
+ * {@code embulk-core}. Even after the removal, they stay in this {@link ExecSessionInternal} to be called through
+ * {@link ExecInternal}.
+ */
+public class ExecSessionInternal extends ExecSession {
+    private static final Logger logger = LoggerFactory.getLogger(ExecSessionInternal.class);
+
+    private static final DateTimeFormatter ISO8601_BASIC =
+            DateTimeFormatter.ofPattern("uuuuMMdd'T'HHmmss'Z'", Locale.ENGLISH).withZone(ZoneOffset.UTC);
+
+    private final Injector injector;
+    private final EmbulkSystemProperties embulkSystemProperties;
+
+    @Deprecated  // https://github.com/embulk/embulk/issues/1304
+    private final org.embulk.config.ModelManager modelManager;
+
+    private final PluginClassLoaderFactory pluginClassLoaderFactory;
+    private final PluginManager pluginManager;
+    private final BufferAllocator bufferAllocator;
+
+    private final Instant transactionTime;
+    private final TempFileSpace tempFileSpace;
+
+    private final boolean preview;
+
+    @Deprecated  // TODO: Remove it.
+    private interface SessionTask extends Task {
+        @Config("transaction_time")
+        @ConfigDefault("null")
+        Optional<String> getTransactionTime();
+    }
+
+    public static class Builder {
+        private final Injector injector;
+        private EmbulkSystemProperties embulkSystemProperties;
+        private Set<String> parentFirstPackages;
+        private Set<String> parentFirstResources;
+        private Instant transactionTime;
+
+        public Builder(Injector injector) {
+            this.injector = injector;
+            this.embulkSystemProperties = null;
+            this.parentFirstPackages = null;
+            this.parentFirstResources = null;
+            this.transactionTime = null;
+        }
+
+        public Builder fromExecConfig(ConfigSource configSource) {
+            final Optional<Instant> transactionTime =
+                    toInstantFromString(configSource.get(String.class, "transaction_time", null));
+            if (transactionTime.isPresent()) {
+                this.transactionTime = transactionTime.get();
+            }
+            return this;
+        }
+
+        public Builder setEmbulkSystemProperties(final EmbulkSystemProperties embulkSystemProperties) {
+            this.embulkSystemProperties = embulkSystemProperties;
+            return this;
+        }
+
+        public Builder setParentFirstPackages(final Set<String> parentFirstPackages) {
+            this.parentFirstPackages = Collections.unmodifiableSet(new HashSet<>(parentFirstPackages));
+            return this;
+        }
+
+        public Builder setParentFirstResources(final Set<String> parentFirstResources) {
+            this.parentFirstResources = Collections.unmodifiableSet(new HashSet<>(parentFirstResources));
+            return this;
+        }
+
+        @Deprecated  // TODO: Add setTransactionTime(Instant) if needed. But no one looks using it. May not be needed.
+        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
+        public Builder setTransactionTime(final org.embulk.spi.time.Timestamp timestamp) {
+            logger.warn("ExecSessionInternal.Builder#setTransactionTime is deprecated. Set it via ExecSessionInternal.Builder#fromExecConfig.");
+            this.transactionTime = timestamp.getInstant();
+            return this;
+        }
+
+        public ExecSessionInternal build() {
+            if (transactionTime == null) {
+                transactionTime = Instant.now();
+            }
+            if (this.embulkSystemProperties == null) {
+                logger.warn("EmbulkSystemProperties is not set when building ExecSessionInternal. "
+                            + "Use ExecSessionInternal.Builder#setEmbulkSystemProperties.");
+                this.embulkSystemProperties = this.injector.getInstance(EmbulkSystemProperties.class);
+            }
+            return new ExecSessionInternal(
+                    this.injector,
+                    this.transactionTime,
+                    this.embulkSystemProperties,
+                    this.parentFirstPackages,
+                    this.parentFirstResources);
+        }
+    }
+
+    public static Builder builderInternal(Injector injector) {
+        return new Builder(injector);
+    }
+
+    @Deprecated
+    @SuppressWarnings("deprecation")  // For the use of SessionTask.
+    public ExecSessionInternal(Injector injector, ConfigSource configSource) {
+        this(injector,
+             configSource.loadConfig(SessionTask.class).getTransactionTime().flatMap(ExecSessionInternal::toInstantFromString).orElse(
+                     Instant.now()),
+             injector.getInstance(EmbulkSystemProperties.class),
+             null,
+             null);
+        logger.warn("Constructing with ExecSession(Injector, ConfigSource) is deprecated. Use ExecSession.Builder instead.");
+    }
+
+    private ExecSessionInternal(
+            final Injector injector,
+            final Instant transactionTime,
+            final EmbulkSystemProperties embulkSystemProperties,
+            final Set<String> parentFirstPackages,
+            final Set<String> parentFirstResources) {
+        if (parentFirstPackages == null) {
+            logger.warn("Parent-first packages are not set when building ExecSession. "
+                        + "Use ExecSession.Builder#setParentFirstPackages.");
+        }
+        if (parentFirstResources == null) {
+            logger.warn("Parent-first resources are not set when building ExecSession. "
+                        + "Use ExecSession.Builder#setParentFirstResources.");
+        }
+
+        this.injector = injector;
+        this.embulkSystemProperties = embulkSystemProperties;
+        this.modelManager = getModelManagerFromInjector(injector);
+
+        this.pluginClassLoaderFactory = PluginClassLoaderFactoryImpl.of(
+                (parentFirstPackages != null) ? parentFirstPackages : Collections.unmodifiableSet(new HashSet<>()),
+                (parentFirstResources != null) ? parentFirstResources : Collections.unmodifiableSet(new HashSet<>()));
+        this.pluginManager = PluginManager.with(
+                new InjectedPluginSource(injector),
+                new MavenPluginSource(injector, embulkSystemProperties, pluginClassLoaderFactory),
+                new JRubyPluginSource(injector.getInstance(ScriptingContainerDelegate.class), pluginClassLoaderFactory));
+
+        this.bufferAllocator = injector.getInstance(BufferAllocator.class);
+
+        this.transactionTime = transactionTime;
+
+        final TempFileSpaceAllocator tempFileSpaceAllocator = injector.getInstance(TempFileSpaceAllocator.class);
+        this.tempFileSpace = tempFileSpaceAllocator.newSpace(ISO8601_BASIC.format(this.transactionTime));
+
+        this.preview = false;
+    }
+
+    private ExecSessionInternal(ExecSessionInternal copy, boolean preview) {
+        this.injector = copy.injector;
+        this.embulkSystemProperties = copy.embulkSystemProperties;
+        this.modelManager = copy.modelManager;
+        this.pluginClassLoaderFactory = copy.pluginClassLoaderFactory;
+        this.pluginManager = copy.pluginManager;
+        this.bufferAllocator = copy.bufferAllocator;
+
+        this.transactionTime = copy.transactionTime;
+        this.tempFileSpace = copy.tempFileSpace;
+
+        this.preview = preview;
+    }
+
+    @Override
+    public ExecSessionInternal forPreview() {
+        return new ExecSessionInternal(this, true);
+    }
+
+    @Deprecated
+    @Override
+    @SuppressWarnings("deprecation")
+    public ConfigSource getSessionExecConfig() {
+        return newConfigSource()
+                .set("transaction_time", Instants.toString(this.transactionTime));
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1313
+    @Override
+    public Injector getInjector() {
+        return injector;
+    }
+
+    @Deprecated
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
+    @Override
+    public org.embulk.spi.time.Timestamp getTransactionTime() {
+        return org.embulk.spi.time.Timestamp.ofInstant(this.transactionTime);
+    }
+
+    @Override
+    public Instant getTransactionTimeInstant() {
+        return this.transactionTime;
+    }
+
+    @Override
+    public String getTransactionTimeString() {
+        return Instants.toString(this.transactionTime);
+    }
+
+    @Deprecated  // @see docs/design/slf4j.md
+    @Override
+    @SuppressWarnings("deprecation")
+    public Logger getLogger(String name) {
+        return LoggerFactory.getLogger(name);
+    }
+
+    @Deprecated  // @see docs/design/slf4j.md
+    @Override
+    @SuppressWarnings("deprecation")
+    public Logger getLogger(Class<?> clazz) {
+        return LoggerFactory.getLogger(clazz);
+    }
+
+    @Override
+    public BufferAllocator getBufferAllocator() {
+        return bufferAllocator;
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
+    @Override
+    public org.embulk.config.ModelManager getModelManager() {
+        return modelManager;
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1309
+    @Override
+    public <T> T newPlugin(Class<T> iface, PluginType type) {
+        return pluginManager.newPlugin(iface, type);
+    }
+
+    @Override
+    public TaskReport newTaskReport() {
+        return new DataSourceImpl(modelManager);
+    }
+
+    @Override
+    public ConfigDiff newConfigDiff() {
+        return new DataSourceImpl(modelManager);
+    }
+
+    @Override
+    public ConfigSource newConfigSource() {
+        return new DataSourceImpl(modelManager);
+    }
+
+    @Override
+    public TaskSource newTaskSource() {
+        return new DataSourceImpl(modelManager);
+    }
+
+    // To be removed by v0.10 or earlier.
+    @Deprecated  // https://github.com/embulk/embulk/issues/936
+    @SuppressWarnings("deprecation")
+    @Override
+    public TimestampFormatter newTimestampFormatter(String format, org.joda.time.DateTimeZone timezone) {
+        return new TimestampFormatter(format, timezone);
+    }
+
+    @Override
+    public TempFileSpace getTempFileSpace() {
+        return tempFileSpace;
+    }
+
+    @Override
+    public boolean isPreview() {
+        return preview;
+    }
+
+    @Override
+    public void cleanup() {
+        this.pluginClassLoaderFactory.clear();
+        tempFileSpace.cleanup();
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
+    private static org.embulk.config.ModelManager getModelManagerFromInjector(final Injector injector) {
+        return injector.getInstance(org.embulk.config.ModelManager.class);
+    }
+
+    private static Optional<Instant> toInstantFromString(final String string) {
+        if (string == null) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(Instants.parseInstant(string));
+        } catch (final NumberFormatException ex) {
+            logger.warn("\"transaction_time\" is in an invalid format: '" + string + "'. "
+                        + "The transaction time is set to the present.", ex);
+            return Optional.empty();
+        } catch (final IllegalStateException ex) {
+            logger.error("Unexpected failure in parsing \"transaction_time\": '" + string + "'", ex);
+            throw ex;
+        }
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/FileOutputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileOutputRunner.java
@@ -10,7 +10,7 @@ import org.embulk.config.Task;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.plugin.PluginType;
-import org.embulk.spi.util.Encoders;
+import org.embulk.spi.util.EncodersInternal;
 
 public class FileOutputRunner implements OutputPlugin {
     private final FileOutputPlugin fileOutputPlugin;
@@ -44,11 +44,11 @@ public class FileOutputRunner implements OutputPlugin {
     }
 
     protected List<EncoderPlugin> newEncoderPlugins(RunnerTask task) {
-        return Encoders.newEncoderPlugins(Exec.session(), task.getEncoderConfigs());
+        return EncodersInternal.newEncoderPlugins(ExecInternal.sessionInternal(), task.getEncoderConfigs());
     }
 
     protected FormatterPlugin newFormatterPlugin(RunnerTask task) {
-        return Exec.newPlugin(FormatterPlugin.class, task.getFormatterConfig().get(PluginType.class, "type"));
+        return ExecInternal.newPlugin(FormatterPlugin.class, task.getFormatterConfig().get(PluginType.class, "type"));
     }
 
     @Override
@@ -85,7 +85,7 @@ public class FileOutputRunner implements OutputPlugin {
         @Override
         public List<TaskReport> run(final TaskSource fileOutputTaskSource) {
             final List<TaskReport> taskReports = new ArrayList<TaskReport>();
-            Encoders.transaction(encoderPlugins, task.getEncoderConfigs(), new Encoders.Control() {
+            EncodersInternal.transaction(encoderPlugins, task.getEncoderConfigs(), new EncodersInternal.Control() {
                     public void run(final List<TaskSource> encoderTaskSources) {
                         formatterPlugin.transaction(task.getFormatterConfig(), schema, new FormatterPlugin.Control() {
                                 public void run(final TaskSource formatterTaskSource) {
@@ -119,7 +119,7 @@ public class FileOutputRunner implements OutputPlugin {
                 aborter.abortThis(finalOutput);
                 closer.closeThis(finalOutput);
 
-                FileOutput encodedOutput = Encoders.open(encoderPlugins, task.getEncoderTaskSources(), finalOutput);
+                FileOutput encodedOutput = EncodersInternal.open(encoderPlugins, task.getEncoderTaskSources(), finalOutput);
                 closer.closeThis(encodedOutput);
 
                 PageOutput output = formatterPlugin.open(task.getFormatterTaskSource(), schema, encodedOutput);

--- a/embulk-core/src/main/java/org/embulk/spi/ProcessTask.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ProcessTask.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import org.embulk.config.TaskSource;
 import org.embulk.plugin.PluginType;
-import org.embulk.spi.util.Executors;
+import org.embulk.spi.util.ExecutorsInternal;
 
 public class ProcessTask {
     private final PluginType inputPluginType;
@@ -83,12 +83,12 @@ public class ProcessTask {
 
     @JsonIgnore
     public Schema getInputSchema() {
-        return Executors.getInputSchema(schemas);
+        return ExecutorsInternal.getInputSchema(schemas);
     }
 
     @JsonIgnore
     public Schema getOutputSchema() {
-        return Executors.getOutputSchema(schemas);
+        return ExecutorsInternal.getOutputSchema(schemas);
     }
 
     @JsonIgnore

--- a/embulk-core/src/main/java/org/embulk/spi/util/Decoders.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Decoders.java
@@ -1,72 +1,43 @@
 package org.embulk.spi.util;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskSource;
-import org.embulk.plugin.PluginType;
 import org.embulk.spi.DecoderPlugin;
 import org.embulk.spi.ExecSession;
+import org.embulk.spi.ExecSessionInternal;
 import org.embulk.spi.FileInput;
 
+/**
+ * Utility class for handling multiple decoder plugins.
+ *
+ * <p>It is considered to be an internal class, not for plugins. To make it explicit, {@link EncodersInternal} replaces it.
+ */
+@Deprecated
 public abstract class Decoders {
     private Decoders() {}
 
     public static List<DecoderPlugin> newDecoderPlugins(ExecSession exec, List<ConfigSource> configs) {
-        ImmutableList.Builder<DecoderPlugin> builder = ImmutableList.builder();
-        for (ConfigSource config : configs) {
-            builder.add(exec.newPlugin(DecoderPlugin.class, config.get(PluginType.class, "type")));
+        if (!(exec instanceof ExecSessionInternal)) {
+            throw new IllegalArgumentException(new ClassCastException());
         }
-        return builder.build();
+        final ExecSessionInternal execInternal = (ExecSessionInternal) exec;
+
+        return DecodersInternal.newDecoderPlugins(execInternal, configs);
     }
 
-    public interface Control {
+    public interface Control extends DecodersInternal.Control {
+        @Override
         public void run(List<TaskSource> taskSources);
     }
 
     public static void transaction(List<DecoderPlugin> plugins, List<ConfigSource> configs,
             Decoders.Control control) {
-        new RecursiveControl(plugins, configs, control).transaction();
+        DecodersInternal.transaction(plugins, configs, control);
     }
 
     public static FileInput open(List<DecoderPlugin> plugins, List<TaskSource> taskSources,
             FileInput input) {
-        FileInput in = input;
-        int pos = 0;
-        while (pos < plugins.size()) {
-            in = plugins.get(pos).open(taskSources.get(pos), in);
-            pos++;
-        }
-        return in;
-    }
-
-    private static class RecursiveControl {
-        private final List<DecoderPlugin> plugins;
-        private final List<ConfigSource> configs;
-        private final Decoders.Control finalControl;
-        private final ImmutableList.Builder<TaskSource> taskSources;
-        private int pos;
-
-        RecursiveControl(List<DecoderPlugin> plugins, List<ConfigSource> configs,
-                Decoders.Control finalControl) {
-            this.plugins = plugins;
-            this.configs = configs;
-            this.finalControl = finalControl;
-            this.taskSources = ImmutableList.builder();
-        }
-
-        public void transaction() {
-            if (pos < plugins.size()) {
-                plugins.get(pos).transaction(configs.get(pos), new DecoderPlugin.Control() {
-                        public void run(TaskSource taskSource) {
-                            taskSources.add(taskSource);
-                            pos++;
-                            transaction();
-                        }
-                    });
-            } else {
-                finalControl.run(taskSources.build());
-            }
-        }
+        return DecodersInternal.open(plugins, taskSources, input);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/DecodersInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DecodersInternal.java
@@ -1,0 +1,70 @@
+package org.embulk.spi.util;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskSource;
+import org.embulk.plugin.PluginType;
+import org.embulk.spi.DecoderPlugin;
+import org.embulk.spi.ExecSessionInternal;
+import org.embulk.spi.FileInput;
+
+public abstract class DecodersInternal {
+    private DecodersInternal() {}
+
+    public static List<DecoderPlugin> newDecoderPlugins(ExecSessionInternal execInternal, List<ConfigSource> configs) {
+        ImmutableList.Builder<DecoderPlugin> builder = ImmutableList.builder();
+        for (ConfigSource config : configs) {
+            builder.add(execInternal.newPlugin(DecoderPlugin.class, config.get(PluginType.class, "type")));
+        }
+        return builder.build();
+    }
+
+    public interface Control {
+        public void run(List<TaskSource> taskSources);
+    }
+
+    public static void transaction(List<DecoderPlugin> plugins, List<ConfigSource> configs, DecodersInternal.Control control) {
+        new RecursiveControl(plugins, configs, control).transaction();
+    }
+
+    public static FileInput open(List<DecoderPlugin> plugins, List<TaskSource> taskSources, FileInput input) {
+        FileInput in = input;
+        int pos = 0;
+        while (pos < plugins.size()) {
+            in = plugins.get(pos).open(taskSources.get(pos), in);
+            pos++;
+        }
+        return in;
+    }
+
+    private static class RecursiveControl {
+        private final List<DecoderPlugin> plugins;
+        private final List<ConfigSource> configs;
+        private final DecodersInternal.Control finalControl;
+        private final ImmutableList.Builder<TaskSource> taskSources;
+        private int pos;
+
+        RecursiveControl(List<DecoderPlugin> plugins, List<ConfigSource> configs,
+                DecodersInternal.Control finalControl) {
+            this.plugins = plugins;
+            this.configs = configs;
+            this.finalControl = finalControl;
+            this.taskSources = ImmutableList.builder();
+        }
+
+        public void transaction() {
+            if (pos < plugins.size()) {
+                plugins.get(pos).transaction(configs.get(pos), new DecoderPlugin.Control() {
+                        public void run(TaskSource taskSource) {
+                            taskSources.add(taskSource);
+                            pos++;
+                            transaction();
+                        }
+                    });
+            } else {
+                finalControl.run(taskSources.build());
+            }
+        }
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/util/Encoders.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Encoders.java
@@ -1,72 +1,42 @@
 package org.embulk.spi.util;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskSource;
-import org.embulk.plugin.PluginType;
 import org.embulk.spi.EncoderPlugin;
 import org.embulk.spi.ExecSession;
+import org.embulk.spi.ExecSessionInternal;
 import org.embulk.spi.FileOutput;
 
+/**
+ * Utility class for handling multiple encoder plugins.
+ *
+ * <p>It is considered to be an internal class, not for plugins. To make it explicit, {@link EncodersInternal} replaces it.
+ */
+@Deprecated
 public abstract class Encoders {
     private Encoders() {}
 
     public static List<EncoderPlugin> newEncoderPlugins(ExecSession exec, List<ConfigSource> configs) {
-        ImmutableList.Builder<EncoderPlugin> builder = ImmutableList.builder();
-        for (ConfigSource config : configs) {
-            builder.add(exec.newPlugin(EncoderPlugin.class, config.get(PluginType.class, "type")));
+        if (!(exec instanceof ExecSessionInternal)) {
+            throw new IllegalArgumentException(new ClassCastException());
         }
-        return builder.build();
+        final ExecSessionInternal execInternal = (ExecSessionInternal) exec;
+
+        return EncodersInternal.newEncoderPlugins(execInternal, configs);
     }
 
-    public interface Control {
+    public interface Control extends EncodersInternal.Control {
         public void run(List<TaskSource> taskSources);
     }
 
     public static void transaction(List<EncoderPlugin> plugins, List<ConfigSource> configs,
             Encoders.Control control) {
-        new RecursiveControl(plugins, configs, control).transaction();
+        EncodersInternal.transaction(plugins, configs, control);
     }
 
     public static FileOutput open(List<EncoderPlugin> plugins, List<TaskSource> taskSources,
             FileOutput output) {
-        FileOutput out = output;
-        int pos = 0;
-        while (pos < plugins.size()) {
-            out = plugins.get(pos).open(taskSources.get(pos), out);
-            pos++;
-        }
-        return out;
-    }
-
-    private static class RecursiveControl {
-        private final List<EncoderPlugin> plugins;
-        private final List<ConfigSource> configs;
-        private final Encoders.Control finalControl;
-        private final ImmutableList.Builder<TaskSource> taskSources;
-        private int pos;
-
-        RecursiveControl(List<EncoderPlugin> plugins, List<ConfigSource> configs,
-                Encoders.Control finalControl) {
-            this.plugins = plugins;
-            this.configs = configs;
-            this.finalControl = finalControl;
-            this.taskSources = ImmutableList.builder();
-        }
-
-        public void transaction() {
-            if (pos < plugins.size()) {
-                plugins.get(pos).transaction(configs.get(pos), new EncoderPlugin.Control() {
-                        public void run(TaskSource taskSource) {
-                            taskSources.add(taskSource);
-                            pos++;
-                            transaction();
-                        }
-                    });
-            } else {
-                finalControl.run(taskSources.build());
-            }
-        }
+        return EncodersInternal.open(plugins, taskSources, output);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/EncodersInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/EncodersInternal.java
@@ -1,0 +1,72 @@
+package org.embulk.spi.util;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskSource;
+import org.embulk.plugin.PluginType;
+import org.embulk.spi.EncoderPlugin;
+import org.embulk.spi.ExecSessionInternal;
+import org.embulk.spi.FileOutput;
+
+public abstract class EncodersInternal {
+    private EncodersInternal() {}
+
+    public static List<EncoderPlugin> newEncoderPlugins(ExecSessionInternal exec, List<ConfigSource> configs) {
+        ImmutableList.Builder<EncoderPlugin> builder = ImmutableList.builder();
+        for (ConfigSource config : configs) {
+            builder.add(exec.newPlugin(EncoderPlugin.class, config.get(PluginType.class, "type")));
+        }
+        return builder.build();
+    }
+
+    public interface Control {
+        public void run(List<TaskSource> taskSources);
+    }
+
+    public static void transaction(List<EncoderPlugin> plugins, List<ConfigSource> configs,
+            EncodersInternal.Control control) {
+        new RecursiveControl(plugins, configs, control).transaction();
+    }
+
+    public static FileOutput open(List<EncoderPlugin> plugins, List<TaskSource> taskSources,
+            FileOutput output) {
+        FileOutput out = output;
+        int pos = 0;
+        while (pos < plugins.size()) {
+            out = plugins.get(pos).open(taskSources.get(pos), out);
+            pos++;
+        }
+        return out;
+    }
+
+    private static class RecursiveControl {
+        private final List<EncoderPlugin> plugins;
+        private final List<ConfigSource> configs;
+        private final EncodersInternal.Control finalControl;
+        private final ImmutableList.Builder<TaskSource> taskSources;
+        private int pos;
+
+        RecursiveControl(List<EncoderPlugin> plugins, List<ConfigSource> configs,
+                EncodersInternal.Control finalControl) {
+            this.plugins = plugins;
+            this.configs = configs;
+            this.finalControl = finalControl;
+            this.taskSources = ImmutableList.builder();
+        }
+
+        public void transaction() {
+            if (pos < plugins.size()) {
+                plugins.get(pos).transaction(configs.get(pos), new EncoderPlugin.Control() {
+                        public void run(TaskSource taskSource) {
+                            taskSources.add(taskSource);
+                            pos++;
+                            transaction();
+                        }
+                    });
+            } else {
+                finalControl.run(taskSources.build());
+            }
+        }
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/util/Executors.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Executors.java
@@ -3,82 +3,68 @@ package org.embulk.spi.util;
 import java.util.List;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
-import org.embulk.spi.AbortTransactionResource;
-import org.embulk.spi.CloseResource;
 import org.embulk.spi.ExecSession;
+import org.embulk.spi.ExecSessionInternal;
 import org.embulk.spi.FilterPlugin;
 import org.embulk.spi.InputPlugin;
 import org.embulk.spi.OutputPlugin;
-import org.embulk.spi.PageOutput;
 import org.embulk.spi.ProcessTask;
 import org.embulk.spi.Schema;
-import org.embulk.spi.TransactionalPageOutput;
 
+/**
+ * Utility class for handling an executor plugin.
+ *
+ * <p>It is considered to be an internal class, not for plugins. To make it explicit, {@link ExecutorsInternal} replaces it.
+ */
+@Deprecated
 public abstract class Executors {
     private Executors() {}
 
-    public interface ProcessStateCallback {
+    public interface ProcessStateCallback extends ExecutorsInternal.ProcessStateCallback {
+        @Override
         public void started();
 
+        @Override
         public void inputCommitted(TaskReport report);
 
+        @Override
         public void outputCommitted(TaskReport report);
     }
 
     public static void process(ExecSession exec,
             ProcessTask task, int taskIndex,
             ProcessStateCallback callback) {
-        InputPlugin inputPlugin = exec.newPlugin(InputPlugin.class, task.getInputPluginType());
-        List<FilterPlugin> filterPlugins = Filters.newFilterPlugins(exec, task.getFilterPluginTypes());
-        OutputPlugin outputPlugin = exec.newPlugin(OutputPlugin.class, task.getOutputPluginType());
+        if (!(exec instanceof ExecSessionInternal)) {
+            throw new IllegalArgumentException(new ClassCastException());
+        }
+        final ExecSessionInternal execInternal = (ExecSessionInternal) exec;
 
-        // TODO assert task.getExecutorSchema().equals task.getOutputSchema()
-
-        process(exec, taskIndex,
-                inputPlugin, task.getInputSchema(), task.getInputTaskSource(),
-                filterPlugins, task.getFilterSchemas(), task.getFilterTaskSources(),
-                outputPlugin, task.getOutputSchema(), task.getOutputTaskSource(),
-                callback);
+        ExecutorsInternal.process(execInternal, task, taskIndex, callback);
     }
 
-    public static void process(ExecSession exec, int taskIndex,
+    public static void process(ExecSessionInternal exec, int taskIndex,
             InputPlugin inputPlugin, Schema inputSchema, TaskSource inputTaskSource,
             List<FilterPlugin> filterPlugins, List<Schema> filterSchemas, List<TaskSource> filterTaskSources,
             OutputPlugin outputPlugin, Schema outputSchema, TaskSource outputTaskSource,
             ProcessStateCallback callback) {
-        final TransactionalPageOutput tran = outputPlugin.open(outputTaskSource, outputSchema, taskIndex);
-
-        callback.started();
-        // here needs to use try-with-resource to add exception happend at close() or abort()
-        // to suppressed exception. otherwise exception happend at close() or abort() overwrites
-        // essential exception.
-        try (CloseResource closer = new CloseResource(tran)) {
-            try (AbortTransactionResource aborter = new AbortTransactionResource(tran)) {
-                PageOutput filtered = Filters.open(filterPlugins, filterTaskSources, filterSchemas, tran);
-                closer.closeThis(filtered);
-
-                TaskReport inputTaskReport = inputPlugin.run(inputTaskSource, inputSchema, taskIndex, filtered);
-
-                if (inputTaskReport == null) {
-                    inputTaskReport = exec.newTaskReport();
-                }
-                callback.inputCommitted(inputTaskReport);
-
-                TaskReport outputTaskReport = tran.commit();
-                aborter.dontAbort();
-                if (outputTaskReport == null) {
-                    outputTaskReport = exec.newTaskReport();
-                }
-                callback.outputCommitted(outputTaskReport);  // TODO check output.finish() is called. wrap or abstract
-            }
+        if (!(exec instanceof ExecSessionInternal)) {
+            throw new IllegalArgumentException(new ClassCastException());
         }
+        final ExecSessionInternal execInternal = (ExecSessionInternal) exec;
+
+        ExecutorsInternal.process(
+                execInternal, taskIndex,
+                inputPlugin, inputSchema, inputTaskSource,
+                filterPlugins, filterSchemas, filterTaskSources,
+                outputPlugin, outputSchema, outputTaskSource,
+                callback);
     }
 
     public static Schema getInputSchema(List<Schema> schemas) {
-        return schemas.get(0);
+        return ExecutorsInternal.getInputSchema(schemas);
     }
 
     public static Schema getOutputSchema(List<Schema> schemas) {
-        return schemas.get(schemas.size() - 1);
+        return ExecutorsInternal.getOutputSchema(schemas);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/ExecutorsInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/ExecutorsInternal.java
@@ -1,0 +1,84 @@
+package org.embulk.spi.util;
+
+import java.util.List;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.AbortTransactionResource;
+import org.embulk.spi.CloseResource;
+import org.embulk.spi.ExecSessionInternal;
+import org.embulk.spi.FilterPlugin;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.ProcessTask;
+import org.embulk.spi.Schema;
+import org.embulk.spi.TransactionalPageOutput;
+
+public abstract class ExecutorsInternal {
+    private ExecutorsInternal() {}
+
+    public interface ProcessStateCallback {
+        public void started();
+
+        public void inputCommitted(TaskReport report);
+
+        public void outputCommitted(TaskReport report);
+    }
+
+    public static void process(ExecSessionInternal exec,
+            ProcessTask task, int taskIndex,
+            ProcessStateCallback callback) {
+        InputPlugin inputPlugin = exec.newPlugin(InputPlugin.class, task.getInputPluginType());
+        List<FilterPlugin> filterPlugins = FiltersInternal.newFilterPlugins(exec, task.getFilterPluginTypes());
+        OutputPlugin outputPlugin = exec.newPlugin(OutputPlugin.class, task.getOutputPluginType());
+
+        // TODO assert task.getExecutorSchema().equals task.getOutputSchema()
+
+        process(exec, taskIndex,
+                inputPlugin, task.getInputSchema(), task.getInputTaskSource(),
+                filterPlugins, task.getFilterSchemas(), task.getFilterTaskSources(),
+                outputPlugin, task.getOutputSchema(), task.getOutputTaskSource(),
+                callback);
+    }
+
+    public static void process(ExecSessionInternal exec, int taskIndex,
+            InputPlugin inputPlugin, Schema inputSchema, TaskSource inputTaskSource,
+            List<FilterPlugin> filterPlugins, List<Schema> filterSchemas, List<TaskSource> filterTaskSources,
+            OutputPlugin outputPlugin, Schema outputSchema, TaskSource outputTaskSource,
+            ProcessStateCallback callback) {
+        final TransactionalPageOutput tran = outputPlugin.open(outputTaskSource, outputSchema, taskIndex);
+
+        callback.started();
+        // here needs to use try-with-resource to add exception happend at close() or abort()
+        // to suppressed exception. otherwise exception happend at close() or abort() overwrites
+        // essential exception.
+        try (CloseResource closer = new CloseResource(tran)) {
+            try (AbortTransactionResource aborter = new AbortTransactionResource(tran)) {
+                PageOutput filtered = FiltersInternal.open(filterPlugins, filterTaskSources, filterSchemas, tran);
+                closer.closeThis(filtered);
+
+                TaskReport inputTaskReport = inputPlugin.run(inputTaskSource, inputSchema, taskIndex, filtered);
+
+                if (inputTaskReport == null) {
+                    inputTaskReport = exec.newTaskReport();
+                }
+                callback.inputCommitted(inputTaskReport);
+
+                TaskReport outputTaskReport = tran.commit();
+                aborter.dontAbort();
+                if (outputTaskReport == null) {
+                    outputTaskReport = exec.newTaskReport();
+                }
+                callback.outputCommitted(outputTaskReport);  // TODO check output.finish() is called. wrap or abstract
+            }
+        }
+    }
+
+    public static Schema getInputSchema(List<Schema> schemas) {
+        return schemas.get(0);
+    }
+
+    public static Schema getOutputSchema(List<Schema> schemas) {
+        return schemas.get(schemas.size() - 1);
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/util/FiltersInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/FiltersInternal.java
@@ -1,0 +1,88 @@
+package org.embulk.spi.util;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskSource;
+import org.embulk.plugin.PluginType;
+import org.embulk.spi.ExecSessionInternal;
+import org.embulk.spi.FilterPlugin;
+import org.embulk.spi.PageOutput;
+import org.embulk.spi.Schema;
+
+public abstract class FiltersInternal {
+    private FiltersInternal() {}
+
+    public static List<PluginType> getPluginTypes(List<ConfigSource> configs) {
+        ImmutableList.Builder<PluginType> builder = ImmutableList.builder();
+        for (ConfigSource config : configs) {
+            builder.add(config.get(PluginType.class, "type"));
+        }
+        return builder.build();
+    }
+
+    public static List<FilterPlugin> newFilterPluginsFromConfigSources(ExecSessionInternal exec, List<ConfigSource> configs) {
+        return newFilterPlugins(exec, getPluginTypes(configs));
+    }
+
+    public static List<FilterPlugin> newFilterPlugins(ExecSessionInternal exec, List<PluginType> pluginTypes) {
+        ImmutableList.Builder<FilterPlugin> builder = ImmutableList.builder();
+        for (PluginType pluginType : pluginTypes) {
+            builder.add(exec.newPlugin(FilterPlugin.class, pluginType));
+        }
+        return builder.build();
+    }
+
+    public interface Control {
+        public void run(List<TaskSource> taskSources, List<Schema> filterSchemas);
+    }
+
+    public static void transaction(List<FilterPlugin> plugins, List<ConfigSource> configs,
+            Schema inputSchema, FiltersInternal.Control control) {
+        new RecursiveControl(plugins, configs, control).transaction(inputSchema);
+    }
+
+    public static PageOutput open(List<FilterPlugin> plugins, List<TaskSource> taskSources,
+            List<Schema> filterSchemas, PageOutput output) {
+        PageOutput out = output;
+        int pos = plugins.size() - 1;
+        while (pos >= 0) {
+            out = plugins.get(pos).open(taskSources.get(pos), filterSchemas.get(pos), filterSchemas.get(pos + 1), out);
+            pos--;
+        }
+        return out;
+    }
+
+    private static class RecursiveControl {
+        private final List<FilterPlugin> plugins;
+        private final List<ConfigSource> configs;
+        private final FiltersInternal.Control finalControl;
+        private final ImmutableList.Builder<TaskSource> taskSources;
+        private final ImmutableList.Builder<Schema> filterSchemas;
+        private int pos;
+
+        RecursiveControl(List<FilterPlugin> plugins, List<ConfigSource> configs,
+                FiltersInternal.Control finalControl) {
+            this.plugins = plugins;
+            this.configs = configs;
+            this.finalControl = finalControl;
+            this.taskSources = ImmutableList.builder();
+            this.filterSchemas = ImmutableList.builder();
+        }
+
+        public void transaction(Schema inputSchema) {
+            filterSchemas.add(inputSchema);
+            if (pos < plugins.size()) {
+                plugins.get(pos).transaction(configs.get(pos), inputSchema, new FilterPlugin.Control() {
+                        public void run(TaskSource taskSource, Schema outputSchema) {
+                            taskSources.add(taskSource);
+                            pos++;
+                            transaction(outputSchema);
+                        }
+                    });
+            } else {
+                finalControl.run(taskSources.build(), filterSchemas.build());
+            }
+        }
+    }
+}

--- a/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
+++ b/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
@@ -16,9 +16,9 @@ import org.embulk.jruby.JRubyScriptingModule;
 import org.embulk.plugin.PluginClassLoaderFactory;
 import org.embulk.plugin.PluginClassLoaderFactoryImpl;
 import org.embulk.spi.BufferAllocator;
-import org.embulk.spi.Exec;
 import org.embulk.spi.ExecAction;
-import org.embulk.spi.ExecSession;
+import org.embulk.spi.ExecInternal;
+import org.embulk.spi.ExecSessionInternal;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
@@ -36,16 +36,16 @@ public class EmbulkTestRuntime extends GuiceBinder {
         }
     }
 
-    private ExecSession exec;
+    private ExecSessionInternal exec;
 
     public EmbulkTestRuntime() {
         super(new TestRuntimeModule());
         Injector injector = getInjector();
         ConfigSource execConfig = new DataSourceImpl(injector.getInstance(ModelManager.class));
-        this.exec = ExecSession.builder(injector).fromExecConfig(execConfig).build();
+        this.exec = ExecSessionInternal.builderInternal(injector).fromExecConfig(execConfig).build();
     }
 
-    public ExecSession getExec() {
+    public ExecSessionInternal getExec() {
         return exec;
     }
 
@@ -71,7 +71,7 @@ public class EmbulkTestRuntime extends GuiceBinder {
         return new Statement() {
             public void evaluate() throws Throwable {
                 try {
-                    Exec.doWith(exec, new ExecAction<Void>() {
+                    ExecInternal.doWith(exec, new ExecAction<Void>() {
                             public Void run() {
                                 try {
                                     superStatement.evaluate();

--- a/embulk-junit4/src/main/java/org/embulk/test/TestingBulkLoader.java
+++ b/embulk-junit4/src/main/java/org/embulk/test/TestingBulkLoader.java
@@ -16,8 +16,8 @@ import org.embulk.config.TaskReport;
 import org.embulk.exec.BulkLoader;
 import org.embulk.exec.ExecutionResult;
 import org.embulk.exec.ResumeState;
-import org.embulk.spi.Exec;
-import org.embulk.spi.ExecSession;
+import org.embulk.spi.ExecInternal;
+import org.embulk.spi.ExecSessionInternal;
 import org.embulk.spi.InputPlugin;
 import org.embulk.spi.Schema;
 import org.slf4j.Logger;
@@ -56,7 +56,7 @@ class TestingBulkLoader extends BulkLoader {
         @Override
         public ExecutionResult buildExecuteResultWithWarningException(Throwable ex) {
             ExecutionResult result = super.buildExecuteResultWithWarningException(ex);
-            return new TestingExecutionResult(result, buildResumeState(Exec.session()), Exec.session());
+            return new TestingExecutionResult(result, buildResumeState(ExecInternal.sessionInternal()), ExecInternal.sessionInternal());
         }
     }
 
@@ -67,7 +67,7 @@ class TestingBulkLoader extends BulkLoader {
         private final List<TaskReport> outputTaskReports;
 
         public TestingExecutionResult(ExecutionResult orig,
-                ResumeState resumeState, ExecSession session) {
+                ResumeState resumeState, ExecSessionInternal session) {
             super(orig.getConfigDiff(), orig.isSkipped(), orig.getIgnoredExceptions());
             this.inputSchema = resumeState.getInputSchema();
             this.outputSchema = resumeState.getOutputSchema();
@@ -75,7 +75,7 @@ class TestingBulkLoader extends BulkLoader {
             this.outputTaskReports = buildReports(resumeState.getOutputTaskReports(), session);
         }
 
-        private static List<TaskReport> buildReports(List<Optional<TaskReport>> optionalReports, ExecSession session) {
+        private static List<TaskReport> buildReports(List<Optional<TaskReport>> optionalReports, ExecSessionInternal session) {
             ImmutableList.Builder<TaskReport> reports = ImmutableList.builder();
             for (Optional<TaskReport> report : optionalReports) {
                 reports.add(report.or(session.newTaskReport()));


### PR DESCRIPTION
It is planned to move `org.embulk.spi.Exec` to `embulk-api`, but some methods should be removed before that because :
* `getInjector`: `Injector` would be hidden from plugins.
* `getModelManager`: `ModelManager` is deprecated.
* `newPlugin`: not for plugins, and its argument `PluginType` blocks from hiding Jackson from plugins.

But, they are still needed in `embulk-core`, and some (hacky) plugins are using `newPlugin`.

Then, this commit introduces `ExecInternal` for `embulk-core` inside, and hacky plugins so that they can technically call it (although calling it is discouraged -- no guarantee in compatibility).
