### PR TITLE
Fix Javadocs of DecoderPlugin, EncoderPlugin, FileInputPlugin, FileOutputPlugin, and GuessPlugin

### DIFF
--- a/embulk-spi/src/main/java/org/embulk/spi/DecoderPlugin.java
+++ b/embulk-spi/src/main/java/org/embulk/spi/DecoderPlugin.java
@@ -22,7 +22,8 @@ import org.embulk.config.TaskSource;
 /**
  * The main class that a Decoder Plugin implements.
  *
- * <p>It converts a byte sequence {@link org.embulk.spi.FileInput} to another byte sequence {@link org.embulk.spi.FileInput}.
+ * <p>A Decoder Plugin converts a set of byte buffers in {@link org.embulk.spi.FileInput} to another set of byte buffers of
+ * {@link org.embulk.spi.FileInput}.
  */
 public interface DecoderPlugin {
     /**
@@ -30,7 +31,7 @@ public interface DecoderPlugin {
      */
     interface Control {
         /**
-         * Runs the following tasks of the decoder plugin.
+         * Runs the following tasks of the Decoder Plugin.
          *
          * <p>It would be executed at the end of {@link #transaction(org.embulk.config.ConfigSource, DecoderPlugin.Control)}.
          *
@@ -42,17 +43,21 @@ public interface DecoderPlugin {
     /**
      * Processes the entire decoding transaction.
      *
-     * @param config  a configuration for the decoder plugin given from a user
+     * @param config  a configuration for the Decoder Plugin given from a user
      * @param control  a controller of the following tasks provided from the Embulk core
      */
     void transaction(ConfigSource config, DecoderPlugin.Control control);
 
     /**
-     * Processes each decoding task.
+     * Opens a {@link org.embulk.spi.FileInput} instance that receives {@link org.embulk.spi.Buffer}s from a File Input Plugin,
+     * or another Decoder Plugin, so that decoded input is read from a Parser Plugin, or another Decoder Plugin
+     *
+     * <p>It processes each decoding task.
      *
      * @param taskSource  a configuration processed for the task from {@link org.embulk.config.ConfigSource}
-     * @param fileInput  an input from a File Input Plugin, or another Decoder Plugin
-     * @return an input for a Parser Plugin, or another Decoder Plugin
+     * @param fileInput  {@link org.embulk.spi.FileInput} to read byte buffers from a File Input Plugin, or another Decoder Plugin
+     * @return an implementation of {@link org.embulk.spi.FileInput} that receives {@link org.embulk.spi.Buffer}s from a File
+     *     Input Plugin, or another Decoder Plugin, so that decoded input is read from a Parser Plugin, or another Decoder Plugin
      */
     FileInput open(TaskSource taskSource, FileInput fileInput);
 }

--- a/embulk-spi/src/main/java/org/embulk/spi/EncoderPlugin.java
+++ b/embulk-spi/src/main/java/org/embulk/spi/EncoderPlugin.java
@@ -22,7 +22,8 @@ import org.embulk.config.TaskSource;
 /**
  * The main class that an Encoder Plugin implements.
  *
- * <p>It converts a byte sequence {@link org.embulk.spi.FileOutput} to another byte sequence {@link org.embulk.spi.FileOutput}.
+ * <p>An Encoder Plugin converts a set of byte buffers in {@link org.embulk.spi.FileOutput} to another set of byte buffers of
+ * {@link org.embulk.spi.FileOutput}.
  */
 public interface EncoderPlugin {
     /**
@@ -30,7 +31,7 @@ public interface EncoderPlugin {
      */
     interface Control {
         /**
-         * Runs the following tasks of the encoder plugin.
+         * Runs the following tasks of the Encoder Plugin.
          *
          * <p>It would be executed at the end of {@link #transaction(org.embulk.config.ConfigSource, EncoderPlugin.Control)}.
          *
@@ -42,17 +43,22 @@ public interface EncoderPlugin {
     /**
      * Processes the entire encoding transaction.
      *
-     * @param config  a configuration for the encoder plugin given from a user
+     * @param config  a configuration for the Encoder Plugin given from a user
      * @param control  a controller of the following tasks provided from the Embulk core
      */
     void transaction(ConfigSource config, EncoderPlugin.Control control);
 
     /**
-     * Processes each encoding task.
+     * Opens a {@link org.embulk.spi.FileOutput} instance that receives {@link org.embulk.spi.Buffer}s from a Formatter Plugin,
+     * or another Encoder Plugin, and writes encoded output into {@link org.embulk.spi.FileOutput} {@code fileOutput} in the
+     * parameter list.
      *
      * @param taskSource  a configuration processed for the task from {@link org.embulk.config.ConfigSource}
-     * @param fileOutput  an output from a Formatter Plugin, or another Encoder Plugin
-     * @return an output for a File Output Plugin, or another Encoder Plugin
+     * @param fileOutput  {@link org.embulk.spi.FileOutput} to write encoded output for a File Output Plugin, or another Encoder
+     *     Plugin
+     * @return an implementation of {@link org.embulk.spi.FileOutput} that receives {@link org.embulk.spi.Buffer}s from a Formatter
+     *     Plugin, or another Encoder Plugin, and writes encoded output into {@link org.embulk.spi.FileOutput} {@code fileOutput}
+     *     in the parameter list
      */
     FileOutput open(TaskSource taskSource, FileOutput fileOutput);
 }

--- a/embulk-spi/src/main/java/org/embulk/spi/FileInputPlugin.java
+++ b/embulk-spi/src/main/java/org/embulk/spi/FileInputPlugin.java
@@ -25,7 +25,8 @@ import org.embulk.config.TaskSource;
 /**
  * The main class that a File Input Plugin implements.
  *
- * <p>It reads a byte sequence into {@link org.embulk.spi.TransactionalFileInput} in a transaction.
+ * <p>A File Input Plugin reads file-like byte sequences from the configured source into a set of byte buffers
+ * {@link org.embulk.spi.Buffer} of {@link org.embulk.spi.TransactionalFileInput}.
  */
 public interface FileInputPlugin {
     /**
@@ -39,7 +40,7 @@ public interface FileInputPlugin {
          *
          * @param taskSource  {@link org.embulk.config.TaskSource} processed for tasks from {@link org.embulk.config.ConfigSource}
          * @param taskCount  the number of tasks
-         * @return reports
+         * @return reports of tasks
          */
         List<TaskReport> run(TaskSource taskSource, int taskCount);
     }
@@ -68,16 +69,20 @@ public interface FileInputPlugin {
      *
      * @param taskSource  a configuration processed for the task from {@link org.embulk.config.ConfigSource}
      * @param taskCount  the number of tasks
-     * @param successTaskReports  {@link org.embulk.config.TaskReport}s of successful tasks
+     * @param successTaskReports  reports of successful tasks
      */
     void cleanup(TaskSource taskSource, int taskCount, List<TaskReport> successTaskReports);
 
     /**
-     * Processes each file input task.
+     * Opens a {@link org.embulk.spi.TransactionalFileInput} instance so that {@link org.embulk.spi.Buffer}s read from
+     * the configured source are read from a Parser Plugin, or a Decoder Plugin.
+     *
+     * <p>It processes each file input task.
      *
      * @param taskSource  a configuration processed for the task from {@link org.embulk.config.ConfigSource}
      * @param taskIndex  the index number of the task
-     * @return an input for a Parser Plugin, or a Decoder Plugin
+     * @return an implementation of {@link org.embulk.spi.TransactionalFileInput} so that {@link org.embulk.spi.Buffer}s
+     *     read from the configured source are read from a Parser Plugin, or a Decoder Plugin
      */
     TransactionalFileInput open(TaskSource taskSource, int taskIndex);
 }

--- a/embulk-spi/src/main/java/org/embulk/spi/FileOutputPlugin.java
+++ b/embulk-spi/src/main/java/org/embulk/spi/FileOutputPlugin.java
@@ -25,7 +25,8 @@ import org.embulk.config.TaskSource;
 /**
  * The main class that a File Output Plugin implements.
  *
- * <p>It writes {@link org.embulk.spi.TransactionalFileOutput} as a byte sequence in a transaction.
+ * <p>A File Output Plugin writes file-like byte sequences from a Formatter Plugin, or an Encoder Plugin, into the configured
+ * destination.
  */
 public interface FileOutputPlugin {
     /**
@@ -38,7 +39,7 @@ public interface FileOutputPlugin {
          * <p>It would be executed in {@link #resume(org.embulk.config.TaskSource, int, FileOutputPlugin.Control)}.
          *
          * @param taskSource  {@link org.embulk.config.TaskSource} processed for tasks from {@link org.embulk.config.ConfigSource}
-         * @return reports
+         * @return reports of tasks
          */
         List<TaskReport> run(TaskSource taskSource);
     }
@@ -49,7 +50,7 @@ public interface FileOutputPlugin {
      * @param config  a configuration for the File Output Plugin given from a user
      * @param taskCount  the number of tasks
      * @param control  a controller of the following tasks provided from the Embulk core
-     * @return {@link org.embulk.config.ConfigDiff} to represent the difference the next incremental run
+[     * @return {@link org.embulk.config.ConfigDiff} to represent the difference the next incremental run
      */
     ConfigDiff transaction(ConfigSource config, int taskCount, FileOutputPlugin.Control control);
 
@@ -68,16 +69,20 @@ public interface FileOutputPlugin {
      *
      * @param taskSource  a configuration processed for the task from {@link org.embulk.config.ConfigSource}
      * @param taskCount  the number of tasks
-     * @param successTaskReports  {@link org.embulk.config.TaskReport}s of successful tasks
+     * @param successTaskReports  reports of successful tasks
      */
     void cleanup(TaskSource taskSource, int taskCount, List<TaskReport> successTaskReports);
 
     /**
-     * Processes each file input task.
+     * Opens a {@link org.embulk.spi.TransactionalFileOutput} instance that receives {@link org.embulk.spi.Buffer}s from a
+     * Formatter Plugin, or an Encoder Plugin, and writes them into the configured destination.
+     *
+     * <p>It processes each file output task.
      *
      * @param taskSource  a configuration processed for the task from {@link org.embulk.config.ConfigSource}
      * @param taskIndex  the index number of the task
-     * @return an output for a Formatter Plugin, or another Encoder Plugin
+     * @return an implementation of {@link org.embulk.spi.TransactionalFileOutput} that receives {@link org.embulk.spi.Buffer}s
+     *     from a Formatter Plugin, or an Encoder Plugin, and writes them into the configured destination
      */
     TransactionalFileOutput open(TaskSource taskSource, int taskIndex);
 }

--- a/embulk-spi/src/main/java/org/embulk/spi/GuessPlugin.java
+++ b/embulk-spi/src/main/java/org/embulk/spi/GuessPlugin.java
@@ -23,13 +23,14 @@ import org.embulk.spi.Buffer;
 /**
  * The main class that a Guess Plugin implements.
  *
- * <p>It guesses a configuration {@link org.embulk.config.ConfigDiff} from a byte sequence {@link org.embulk.spi.Buffer}.
+ * <p>A Guess Plugin guesses a configuration {@link org.embulk.config.ConfigDiff} from a partial configuration for input,
+ * and a byte sequence {@link org.embulk.spi.Buffer}.
  */
 public interface GuessPlugin {
     /**
      * Performs the guess.
      *
-     * @param config  a configuration for the guess plugin given from a user
+     * @param config  a partial configuration for input given from a user
      * @param sample  a sample data to guess
      * @return a new configuration guessed based on {@code config} and {@code sample}
      */


### PR DESCRIPTION
SPI Javadocs, that are introduced in #1254 and #1274, have not been accurate, especially about input/output directions of `FileOutput` and `PageOutput`. This PR is fixing the problems, and some English representations.