### PR TITLE
Deprecate Type#getJavaType and Type#getFixedStorageSize

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/Schema.java
+++ b/embulk-api/src/main/java/org/embulk/spi/Schema.java
@@ -101,6 +101,7 @@ public class Schema {
         throw new SchemaConfigException(String.format("Column '%s' is not found", name));
     }
 
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1324
     public int getFixedStorageSize() {
         int total = 0;
         for (final Column column : this.columns) {

--- a/embulk-api/src/main/java/org/embulk/spi/type/Type.java
+++ b/embulk-api/src/main/java/org/embulk/spi/type/Type.java
@@ -20,9 +20,30 @@ package org.embulk.spi.type;
  * Represents Embulk's data type.
  */
 public interface Type {
+    /**
+     * Returns the name of the Embulk data type.
+     *
+     * @return the name of the Embulk data type
+     */
     String getName();
 
+    /**
+     * Returns the Java type of the internal value in the Embulk data type.
+     *
+     * @deprecated It would be removed in Embulk v0.10 or v0.11. Do not use it.
+     *
+     * @return the Java type of the internal value in the Embulk data type
+     */
+    @Deprecated
     Class<?> getJavaType();
 
+    /**
+     * Returns the size of the internal value in the Embulk data type.
+     *
+     * @deprecated It would be removed in Embulk v0.10 or v0.11. Do not use it.
+     *
+     * @return the size of the internal value in the Embulk data type
+     */
+    @Deprecated
     byte getFixedStorageSize();
 }


### PR DESCRIPTION
`Type#getJavaType` and `Type#getFixedStorageSize` are mostly unused, but causing unnecessary tight coupling. They would be finally removed in Embulk v0.10 or v0.11.