### PR TITLE
Upgrade depended slf4j-api to 1.7.30

### DIFF
--- a/embulk-api/build.gradle
+++ b/embulk-api/build.gradle
@@ -11,5 +11,5 @@ configurations {
 
 dependencies {
     api "org.msgpack:msgpack-core:0.8.11"
-    api "org.slf4j:slf4j-api:1.7.12"
+    api "org.slf4j:slf4j-api:1.7.30"
 }

--- a/embulk-api/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-api/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,4 +2,4 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30

--- a/embulk-api/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-api/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,4 +2,4 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30

--- a/embulk-core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-core/gradle/dependency-locks/compileClasspath.lockfile
@@ -21,4 +21,4 @@ org.apache.bval:bval-jsr303:0.5
 org.apache.commons:commons-lang3:3.4
 org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30

--- a/embulk-core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -21,4 +21,4 @@ org.apache.bval:bval-jsr303:0.5
 org.apache.commons:commons-lang3:3.4
 org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30

--- a/embulk-deps/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/gradle/dependency-locks/compileClasspath.lockfile
@@ -43,5 +43,5 @@ org.codehaus.plexus:plexus-utils:3.2.0
 org.embulk:embulk-util-timestamp:0.2.1
 org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30
 org.yaml:snakeyaml:1.18

--- a/embulk-junit4/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-junit4/gradle/dependency-locks/compileClasspath.lockfile
@@ -24,4 +24,4 @@ org.hamcrest:hamcrest-core:1.3
 org.hamcrest:hamcrest-library:1.3
 org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30

--- a/embulk-junit4/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-junit4/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -24,4 +24,4 @@ org.hamcrest:hamcrest-core:1.3
 org.hamcrest:hamcrest-library:1.3
 org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30

--- a/embulk-spi/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-spi/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,4 +2,4 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30

--- a/embulk-spi/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-spi/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,4 +2,4 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30

--- a/embulk-standards/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-standards/gradle/dependency-locks/compileClasspath.lockfile
@@ -22,4 +22,4 @@ org.apache.commons:commons-compress:1.10
 org.apache.commons:commons-lang3:3.4
 org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30


### PR DESCRIPTION
Upgrading `slf4j-api` to the latest `1.7`. It is required to use `SubstituteLogger` in next PRs #1333 and #1334.

We don't use `slf4j-api` `1.8.*` nor `2.0.*` because :
* SLF4J 1.8 will never be "released".
  * http://mailman.qos.ch/pipermail/slf4j-user/2020-August/001748.html
* SLF4J 2.0 has a different mechanism to find a logging driver. It can cause severe incompatibility problems with plugins.