### PR TITLE
Initialize embedded JAR resources in the very beginning, without SLF4J

### DIFF
--- a/embulk-core/src/main/java/org/embulk/cli/CliManifest.java
+++ b/embulk-core/src/main/java/org/embulk/cli/CliManifest.java
@@ -6,8 +6,6 @@ import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class CliManifest {
     private CliManifest() {
@@ -27,31 +25,32 @@ final class CliManifest {
                 try {
                     protectionDomain = CliManifest.class.getProtectionDomain();
                 } catch (final SecurityException ex) {
-                    logger.error("Manifest unavailable: ProtectionDomain inaccessible.", ex);
+                    System.err.println("Manifest unavailable: ProtectionDomain inaccessible.");
+                    ex.printStackTrace();
                     return null;
                 }
 
                 final CodeSource codeSource = protectionDomain.getCodeSource();
                 if (codeSource == null) {
-                    logger.error("Manifest unavailable: CodeSource inaccessible.");
+                    System.err.println("Manifest unavailable: CodeSource inaccessible.");
                     return null;
                 }
 
                 final URL selfJarUrl = codeSource.getLocation();
                 if (selfJarUrl == null) {
-                    logger.error("Manifest unavailable: location unavailable from CodeSource.");
+                    System.err.println("Manifest unavailable: location unavailable from CodeSource.");
                     return null;
                 } else if (!selfJarUrl.getProtocol().equals("file")) {
-                    logger.error("Manifest unavailable: invalid location: " + selfJarUrl.toString());
+                    System.err.println("Manifest unavailable: invalid location: " + selfJarUrl.toString());
                     return null;
                 }
 
                 final String selfJarPathString = selfJarUrl.getPath();
                 if (selfJarPathString == null) {
-                    logger.error("Manifest unavailable: path unavailable in CodeSource location: " + selfJarUrl.toString());
+                    System.err.println("Manifest unavailable: path unavailable in CodeSource location: " + selfJarUrl.toString());
                     return null;
                 } else if (selfJarPathString.isEmpty()) {
-                    logger.error("Manifest unavailable: empty path from CodeSource location: " + selfJarUrl.toString());
+                    System.err.println("Manifest unavailable: empty path from CodeSource location: " + selfJarUrl.toString());
                     return null;
                 }
 
@@ -59,25 +58,28 @@ final class CliManifest {
                     try {
                         return selfJarFile.getManifest();
                     } catch (final IllegalStateException ex) {
-                        logger.error("Manifest unavailable: JAR closed unexpectedly.", ex);
+                        System.err.println("Manifest unavailable: JAR closed unexpectedly.");
+                        ex.printStackTrace();
                         return null;
                     } catch (final IOException ex) {
-                        logger.error("Manifest unavailable: I/O error in reading manifest.", ex);
+                        System.err.println("Manifest unavailable: I/O error in reading manifest.");
+                        ex.printStackTrace();
                         return null;
                     }
                 } catch (final SecurityException ex) {
-                    logger.error("Manifest unavailable: JAR file inaccessible.", ex);
+                    System.err.println("Manifest unavailable: JAR file inaccessible.");
+                    ex.printStackTrace();
                     return null;
                 } catch (final IOException ex) {
-                    logger.error("Manifest unavailable: I/O error in reading JAR.", ex);
+                    System.err.println("Manifest unavailable: I/O error in reading JAR.");
+                    ex.printStackTrace();
                     return null;
                 }
             } catch (final Throwable ex) {
-                logger.error("Manifest unavailable: unknown error.", ex);
+                System.err.println("Manifest unavailable: unknown error.");
+                ex.printStackTrace();
                 return null;
             }
         }
     }
-
-    private static final Logger logger = LoggerFactory.getLogger(CliManifest.class);
 }

--- a/embulk-core/src/main/java/org/embulk/cli/Main.java
+++ b/embulk-core/src/main/java/org/embulk/cli/Main.java
@@ -9,6 +9,10 @@ import org.embulk.deps.EmbulkSelfContainedJarFiles;
 
 public class Main {
     public static void main(final String[] args) {
+        // They are loaded before SLF4J is initialized along with Logback. They don't use SLF4J for error logging.
+        EmbulkSelfContainedJarFiles.staticInitializer().addFromManifest(CliManifest.getManifest()).initialize();
+        EmbulkDependencyClassLoaders.staticInitializer().useSelfContainedJarFiles().initialize();
+
         final ArrayList<String> jrubyOptions = new ArrayList<String>();
 
         int i;
@@ -57,8 +61,6 @@ public class Main {
         }
 
         CliLogbackConfigurator.configure(Optional.ofNullable(logPath), Optional.ofNullable(logLevel));
-        EmbulkSelfContainedJarFiles.staticInitializer().addFromManifest(CliManifest.getManifest()).initialize();
-        EmbulkDependencyClassLoaders.staticInitializer().useSelfContainedJarFiles().initialize();
 
         final EmbulkRun run = new EmbulkRun(EmbulkVersion.VERSION);
         final int error = run.run(Collections.unmodifiableList(embulkArgs), Collections.unmodifiableList(jrubyOptions));

--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
@@ -4,8 +4,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents a pre-defined set of class loaders to load dependency libraries for the Embulk core.
@@ -61,7 +59,8 @@ public final class EmbulkDependencyClassLoaders {
 
         static {
             if (DEPENDENCIES.isEmpty() && !USE_SELF_CONTAINED_JAR_FILES.get()) {
-                logger.warn("Hidden dependencies are uninitialized. Maybe using classes loaded by Embulk's top-level ClassLoader.");
+                System.err.println(
+                        "Hidden dependencies are uninitialized. Maybe using classes loaded by Embulk's top-level ClassLoader.");
             }
             DEPENDENCY_CLASS_LOADER = new DependencyClassLoader(DEPENDENCIES, CLASS_LOADER);
         }
@@ -80,8 +79,6 @@ public final class EmbulkDependencyClassLoaders {
             }
         }
     }
-
-    private static final Logger logger = LoggerFactory.getLogger(EmbulkDependencyClassLoaders.class);
 
     private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.class.getClassLoader();
     private static final ArrayList<Path> DEPENDENCIES = new ArrayList<>();

--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkSelfContainedJarFiles.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkSelfContainedJarFiles.java
@@ -10,8 +10,6 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents a pre-defined set of self-contained JAR file resources in the Embulk JAR file.
@@ -129,8 +127,6 @@ public final class EmbulkSelfContainedJarFiles {
 
         return list;
     }
-
-    private static final Logger logger = LoggerFactory.getLogger(EmbulkSelfContainedJarFiles.class);
 
     private static final ArrayList<String> JAR_RESOURCE_NAMES = new ArrayList<>();
 }

--- a/embulk-core/src/main/java/org/embulk/deps/Resource.java
+++ b/embulk-core/src/main/java/org/embulk/deps/Resource.java
@@ -5,8 +5,6 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.security.CodeSigner;
 import java.util.jar.Manifest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class Resource {
     Resource(
@@ -37,7 +35,8 @@ final class Resource {
                             + this.name,
                     new JarEmbeddedUrlStreamHandler(this.jarFile.getInnerResourcesBinary(), this.begin, this.end));
         } catch (final MalformedURLException ex) {
-            logger.error("Failed to build an internal resource URL unexpectedly.", ex);
+            System.err.println("Failed to build an internal resource URL unexpectedly.");
+            ex.printStackTrace();
             return null;
         }
     }
@@ -64,8 +63,6 @@ final class Resource {
     public String toString() {
         return "[" + this.name + ":" + this.begin + "-" + this.end + "]";
     }
-
-    private static final Logger logger = LoggerFactory.getLogger(Resource.class);
 
     private final String name;
     private final SelfContainedJarFile jarFile;


### PR DESCRIPTION
Before upcoming changes to refactor command line processing, and Embulk system properties, changing the loader of JAR resources (in the command-line Embulk executable binary) to log just with `System.err`, not with SLF4J.

It is because :
* They are loaded (initialized) in the very beginning of Embulk CLI, when SLF4J and Logback are not initialized.
* We can use `SubstituteLogger` of SLF4J for delayed logging, but their all "logs" are about critical cases. When they are logged, Embulk is failing.
* For critical error messages, not SLF4J logging, but `System.err` would fit well.