### PR TITLE
Remove embedded gems: msgpack, bundler, liquid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -279,6 +279,7 @@ repositories {
 
 configurations {
     embed
+    jruby
 }
 
 dependencies {
@@ -293,6 +294,9 @@ dependencies {
         exclude group: 'org.apache.commons', module: 'commons-lang3'  // Included in embulk-core.
         exclude group: 'com.google.guava', module: 'guava'  // Included in embulk-core.
     }
+
+    // Only to install the msgpack gem in embulk/build/.
+    jruby "org.jruby:jruby-complete:9.1.15.0"
 }
 
 def listEmbedDependencies = { rootModuleName, prefix ->
@@ -359,6 +363,19 @@ task executableJar(dependsOn: "jar") {
         destination.append(jar.outputs.files.singleFile.readBytes())
         destination.setExecutable(true)
     }
+}
+
+task installGemsForTesting(type: JavaExec) {
+    doFirst {
+        delete("${buildDir}/gems_for_testing")
+        mkdir("${buildDir}/gems_for_testing")
+    }
+
+    workingDir = file("${projectDir}")
+    classpath = configurations.jruby
+    main = "org.jruby.Main"
+    args = [ "-S", "gem", "install", "msgpack:1.1.0" ]
+    environment "GEM_HOME": "${buildDir}/gems_for_testing"
 }
 
 task releaseCheck {

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -6,7 +6,7 @@ ext {
 
 // include ruby scripts to jar. don't use sourceSets.main.resources.srcDirs
 // because IntelliJ causes error if srcDirs includes files out of projectDir.
-processResources.from("${buildDir}/embulk_gem_as_resources", "${buildDir}/dependency_gems_as_resources")
+processResources.from("${buildDir}/embulk_gem_as_resources")
 
 configurations {
     jruby
@@ -54,8 +54,6 @@ dependencies {
     // This statement gets it loaded by the top-level ClassLoader.
     testImplementation project(":embulk-deps")
 
-    jruby "org.jruby:jruby-complete:9.1.15.0"
-
     rubyTestRuntime project(":embulk-api")
     rubyTestRuntime project(":embulk-spi")
     rubyTestRuntime project(":embulk-core")
@@ -65,14 +63,14 @@ dependencies {
 task rubyTestVanilla(type: JavaExec, dependsOn: [
         "jar",
         "prepareDependencyJars",
-        "installDependencyGems",
         ":embulk-deps:prepareDependencyJars",
+        ":installGemsForTesting",
         ]) {
     workingDir = file("${projectDir}");
     classpath = configurations.rubyTestRuntime
     main = "org.jruby.Main"
     args = ["-Isrc/main/ruby", "-Isrc/test/ruby", "--debug", "./src/test/ruby/vanilla/run-test.rb"]
-    environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
+    environment "GEM_HOME": "${rootProject.buildDir}/gems_for_testing"
 }
 
 test.dependsOn(['rubyTestVanilla', ":test-helpers:deploy"])
@@ -89,39 +87,6 @@ String buildRubyStyleVersionFromJavaStyleVersion(String javaStyleVersion) {
         return javaStyleVersion;
     }
 }
-
-task installDependencyGems(type: JavaExec) {
-    doFirst {
-        delete("${buildDir}/dependency_gems_installed")
-        mkdir("${buildDir}/dependency_gems_installed")
-    }
-
-    workingDir = file("${projectDir}")
-    classpath = configurations.jruby
-    main = "org.jruby.Main"
-    args = ["-S", "gem", "install", "msgpack:1.1.0", "bundler:1.16.0", "liquid:4.0.0", "simplecov:0.10.0", "test-unit:3.0.9"]
-    environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
-}
-
-task unpackDependencyGems(type: Copy, dependsOn: "installDependencyGems") {
-    doFirst {
-        delete("${buildDir}/dependency_gems_as_resources")
-    }
-
-    from "${buildDir}/dependency_gems_installed"
-    into "${buildDir}/dependency_gems_as_resources"
-    include "gems/bundler-1.16.0/**"
-    include "gems/liquid-4.0.0/**"
-    include "gems/msgpack-1.1.0-java/**"
-    include "specifications/bundler-1.16.0.gemspec"
-    include "specifications/liquid-4.0.0.gemspec"
-    include "specifications/msgpack-1.1.0-java.gemspec"
-
-    doLast {
-        fileTree(dir: "${buildDir}/dependency_gems_as_resources", include: "**/.jrubydir").each { f -> f.delete() }
-    }
-}
-processResources.dependsOn("unpackDependencyGems")
 
 task buildEmbulkGem {
     doFirst {
@@ -166,18 +131,12 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<bundler>.freeze, [">= 1.10.6"])
       s.add_runtime_dependency(%q<msgpack>.freeze, ["~> 1.1.0"])
-      s.add_runtime_dependency(%q<liquid>.freeze, ["~> 4.0.0"])
     else
-      s.add_dependency(%q<bundler>.freeze, [">= 1.10.6"])
       s.add_dependency(%q<msgpack>.freeze, ["~> 1.1.0"])
-      s.add_dependency(%q<liquid>.freeze, ["~> 4.0.0"])
     end
   else
-    s.add_dependency(%q<bundler>.freeze, [">= 1.10.6"])
     s.add_dependency(%q<msgpack>.freeze, ["~> 1.1.0"])
-    s.add_dependency(%q<liquid>.freeze, ["~> 4.0.0"])
   end
 end
 /$)

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -131,12 +131,12 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<msgpack>.freeze, ["~> 1.1.0"])
+      s.add_runtime_dependency(%q<msgpack>.freeze, [">= 1.1.0"])
     else
-      s.add_dependency(%q<msgpack>.freeze, ["~> 1.1.0"])
+      s.add_dependency(%q<msgpack>.freeze, [">= 1.1.0"])
     end
   else
-    s.add_dependency(%q<msgpack>.freeze, ["~> 1.1.0"])
+    s.add_dependency(%q<msgpack>.freeze, ["=> 1.1.0"])
   end
 end
 /$)

--- a/embulk-core/src/test/ruby/vanilla/run-test.rb
+++ b/embulk-core/src/test/ruby/vanilla/run-test.rb
@@ -29,23 +29,6 @@ end
 # https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#calling-masked-or-unreachable-java-methods-with-java_send
 static_initializer.java_send :initialize
 
-Gem.path << File.join(core_dir, 'build', 'dependency_gems_as_resources')
-Gem.path << File.join(core_dir, 'build', 'embulk_gems_as_resources')
-Gem::Specification.reset
-
-=begin
-require 'simplecov'
-# fix inaccurate coverage
-# see: https://github.com/colszowka/simplecov/blob/82920ca1502be78ccde4fd315634066093bb855d/lib/simplecov.rb#L7
-ENV['JRUBY_OPTS'] = '-Xcli.debug=true --debug'
-SimpleCov.profiles.define 'embulk' do
-  add_filter 'test/'
-
-  add_group 'Libraries', 'lib'
-end
-SimpleCov.start 'embulk'
-=end
-
 require 'test/unit'
 
 require 'embulk/java/bootstrap'

--- a/embulk-standards/build.gradle
+++ b/embulk-standards/build.gradle
@@ -13,7 +13,6 @@ repositories {
 }
 
 configurations {
-    jruby
     rubyTestRuntime
     compileClasspath.resolutionStrategy.activateDependencyLocking()
     runtimeClasspath.resolutionStrategy.activateDependencyLocking()
@@ -52,40 +51,30 @@ dependencies {
 
     testImplementation "org.jruby:jruby-complete:9.1.15.0"
 
-    jruby "org.jruby:jruby-complete:9.1.15.0"
-
     rubyTestRuntime project(":embulk-api")
     rubyTestRuntime project(":embulk-spi")
     rubyTestRuntime project(":embulk-core")
     rubyTestRuntime "org.jruby:jruby-complete:9.1.15.0"
 }
 
+test.dependsOn(":installGemsForTesting")
+test {
+    environment "GEM_HOME", "${rootProject.buildDir}/gems_for_testing"
+}
+
 task rubyTestVanilla(type: JavaExec, dependsOn: [
         "jar",
         "prepareDependencyJars",
-        "installDependencyGems",
         ":embulk-deps:prepareDependencyJars",
+        ":installGemsForTesting",
         ]) {
     workingDir = file("${project.projectDir}");
     classpath = configurations.rubyTestRuntime
     main = "org.jruby.Main"
     args = ["-Isrc/main/ruby", "-Isrc/test/ruby", "--debug", "./src/test/ruby/vanilla/run-test.rb"]
-    environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
+    environment "GEM_HOME": "${rootProject.buildDir}/gems_for_testing"
 }
 test.dependsOn(['rubyTestVanilla'])
-
-task installDependencyGems(type: JavaExec) {
-    doFirst {
-        delete("${buildDir}/dependency_gems_installed")
-        mkdir("${buildDir}/dependency_gems_installed")
-    }
-
-    workingDir = file("${projectDir}")
-    classpath = configurations.jruby
-    main = "org.jruby.Main"
-    args = ["-S", "gem", "install", "simplecov:0.10.0", "test-unit:3.0.9"]
-    environment "GEM_HOME": "${buildDir}/dependency_gems_installed"
-}
 
 String buildRubyStyleVersionFromJavaStyleVersion(String javaStyleVersion) {
     if (javaStyleVersion.contains('-')) {

--- a/embulk-standards/src/test/ruby/vanilla/run-test.rb
+++ b/embulk-standards/src/test/ruby/vanilla/run-test.rb
@@ -29,23 +29,6 @@ end
 # https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#calling-masked-or-unreachable-java-methods-with-java_send
 static_initializer.java_send :initialize
 
-Gem.path << File.join(core_dir, 'build', 'dependency_gems_as_resources')
-Gem.path << File.join(core_dir, 'build', 'embulk_gems_as_resources')
-Gem::Specification.reset
-
-=begin
-require 'simplecov'
-# fix inaccurate coverage
-# see: https://github.com/colszowka/simplecov/blob/82920ca1502be78ccde4fd315634066093bb855d/lib/simplecov.rb#L7
-ENV['JRUBY_OPTS'] = '-Xcli.debug=true --debug'
-SimpleCov.profiles.define 'embulk' do
-  add_filter 'test/'
-
-  add_group 'Libraries', 'lib'
-end
-SimpleCov.start 'embulk'
-=end
-
 require 'test/unit'
 
 require 'embulk/java/bootstrap'


### PR DESCRIPTION
After removing JRuby from Embulk executable binary, it also removes embedded RubyGem libraries: `msgpack`, `bundler`, and `liquid`.

* `msgpack` is mandatory for Ruby-based Embulk plugins. Users would have to install it with `embulk gem install msgpack` by themselves.
* `bundler` has not been mandatory, but some CLI users have used it for maintaining plugin installation. Actually `bundler` is preinstalled in some JRuby versions, so it depends on users which JRuby to use.
* `liquid` has not been mandatory, but some CLI users have used it for templating Embulk configs. JFYI: its's not available for `EmbulkEmbed` users. Users would have to install it with `embulk gem install liquid` by themselves.