### PR TITLE
Bump up to v0.10.21-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {  // Applies all projects including the root project as well.
     }
 }
 
-version = "0.10.20-SNAPSHOT"
+version = "0.10.21-SNAPSHOT"
 
 description = 'Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control.'
 


### PR DESCRIPTION
As the JRuby removal is a big change, I'm going to split versions released.

* #1332, #1337, #1333, #1334: v0.10.20
* #1336, #1338: v0.10.21