### PR TITLE
Cleanup and refactor PluginClassLoader and its Factory

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactory.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactory.java
@@ -6,17 +6,5 @@ import java.util.Collection;
 public interface PluginClassLoaderFactory {
     PluginClassLoader create(Collection<URL> flatJarUrls, ClassLoader parentClassLoader);
 
-    PluginClassLoader createForNestedJar(
-            final ClassLoader parentClassLoader, final URL oneNestedJarUrl);
-
-    default PluginClassLoader createForNestedJarWithDependencies(
-            final ClassLoader parentClassLoader,
-            final URL oneNestedJarUrl,
-            final Collection<URL> dependencyJarUrls) {
-        return this.createForNestedJar(
-                parentClassLoader,
-                oneNestedJarUrl);
-    }
-
     void clear();
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactoryImpl.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactoryImpl.java
@@ -21,38 +21,9 @@ public class PluginClassLoaderFactoryImpl implements PluginClassLoaderFactory {
 
     @Override
     public PluginClassLoader create(final Collection<URL> urls, final ClassLoader parentClassLoader) {
-        final PluginClassLoader created = PluginClassLoader.createForFlatJars(
+        final PluginClassLoader created = PluginClassLoader.create(
                 parentClassLoader,
                 urls,
-                parentFirstPackages,
-                parentFirstResources);
-        this.createdPluginClassLoaders.add(created);
-        return created;
-    }
-
-    @Override
-    public PluginClassLoader createForNestedJar(
-            final ClassLoader parentClassLoader,
-            final URL oneNestedJarUrl) {
-        final PluginClassLoader created = PluginClassLoader.createForNestedJar(
-                parentClassLoader,
-                oneNestedJarUrl,
-                null,
-                parentFirstPackages,
-                parentFirstResources);
-        this.createdPluginClassLoaders.add(created);
-        return created;
-    }
-
-    @Override
-    public PluginClassLoader createForNestedJarWithDependencies(
-            final ClassLoader parentClassLoader,
-            final URL oneNestedJarUrl,
-            final Collection<URL> dependencyJarUrls) {
-        final PluginClassLoader created = PluginClassLoader.createForNestedJar(
-                parentClassLoader,
-                oneNestedJarUrl,
-                dependencyJarUrls,
                 parentFirstPackages,
                 parentFirstResources);
         this.createdPluginClassLoaders.add(created);

--- a/embulk-core/src/main/java/org/embulk/plugin/jar/JarPluginLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/jar/JarPluginLoader.java
@@ -121,6 +121,7 @@ public class JarPluginLoader implements AutoCloseable {
         }
 
         final List<URL> dependencyJarUrls = new ArrayList<>();
+        dependencyJarUrls.add(fileUrlJar);
         for (final Path dependencyJarPath : dependencyJarPaths) {
             final URI dependencyJarUri;
             try {
@@ -142,16 +143,8 @@ public class JarPluginLoader implements AutoCloseable {
             }
         }
 
-        final PluginClassLoader pluginClassLoader;
-        if (!dependencyJarPaths.isEmpty()) {
-            pluginClassLoader = pluginClassLoaderFactory.createForNestedJarWithDependencies(
-                    JarPluginLoader.class.getClassLoader(),
-                    fileUrlJar,
-                    dependencyJarUrls);
-        } else {
-            pluginClassLoader = pluginClassLoaderFactory.createForNestedJar(
-                    JarPluginLoader.class.getClassLoader(), fileUrlJar);
-        }
+        final PluginClassLoader pluginClassLoader = pluginClassLoaderFactory.create(
+                dependencyJarUrls, JarPluginLoader.class.getClassLoader());
 
         final Class pluginMainClass;
         try {


### PR DESCRIPTION
`PluginClassLoader` had had a mechanism to load a JARs-in-JAR-style nested JAR plugin, but it has been removed since v0.9.17 by: #1111

This commit is to remove some remaining code for nested JAR plugins.