### PR TITLE
Fix "missing class name (`java.time.Timestamp')"

### DIFF
--- a/embulk-core/src/main/ruby/embulk/page_builder.rb
+++ b/embulk-core/src/main/ruby/embulk/page_builder.rb
@@ -15,7 +15,7 @@ module Embulk
         self.java_send(:set, [::Java::java.lang.String], ruby_object.to_java(::Java::java.lang.String))
       elsif ruby_object.kind_of?(Time)
         self.java_send(:set, [::Java::java.time.Instant],
-                       ::Java::java.time.Timestamp.ofEpochSecond(ruby_object.to_i, ruby_object.nsec))
+                       ::Java::java.time.Instant.ofEpochSecond(ruby_object.to_i, ruby_object.nsec))
       else
         self.java_send(:set, [::Java::org.msgpack.value.Value],
                        ::Java::org.msgpack.core.MessagePack.newDefaultUnpacker(ruby_object.to_msgpack.to_java_bytes).unpackValue())


### PR DESCRIPTION
`java.time.Timestamp` does not exist. It was a mistake in:
https://github.com/embulk/embulk/pull/1336/files#diff-2bf34f7ba0b21cdb2a58e98bae5967a04e5c0673b83ae17d7d0b8104cd48754aR17-R18