### PR TITLE
Load a Maven-based plugin from a simple plugin type with Embulk system properties

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import org.embulk.EmbulkSystemProperties;
 import org.embulk.deps.maven.MavenArtifactFinder;
 import org.embulk.deps.maven.MavenPluginPaths;
+import org.embulk.plugin.DefaultPluginType;
 import org.embulk.plugin.MavenPluginType;
 import org.embulk.plugin.PluginClassLoaderFactory;
 import org.embulk.plugin.PluginSource;
@@ -65,10 +66,20 @@ public class MavenPluginSource implements PluginSource {
             throw new PluginSourceNotMatchException("Plugin interface " + pluginInterface + " is not supported.");
         }
 
-        if (pluginType.getSourceType() != PluginSource.Type.MAVEN) {
-            throw new PluginSourceNotMatchException();
+        final MavenPluginType mavenPluginType;
+        switch (pluginType.getSourceType()) {
+            case DEFAULT:
+                mavenPluginType = MavenPluginType.createFromDefaultPluginType(
+                        category, (DefaultPluginType) pluginType, this.embulkSystemProperties);
+                break;
+
+            case MAVEN:
+                mavenPluginType = (MavenPluginType) pluginType;
+                break;
+
+            default:
+                throw new PluginSourceNotMatchException();
         }
-        final MavenPluginType mavenPluginType = (MavenPluginType) pluginType;
 
         final MavenArtifactFinder mavenArtifactFinder;
         try {

--- a/embulk-core/src/test/java/org/embulk/plugin/TestPluginType.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/TestPluginType.java
@@ -4,8 +4,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.HashMap;
+import java.util.Properties;
+import org.embulk.EmbulkSystemProperties;
 import org.junit.Test;
 
 public class TestPluginType {
@@ -74,5 +77,75 @@ public class TestPluginType {
         assertEquals("0.1.2", mavenType.getVersion());
         assertEquals("bar", mavenType.getClassifier());
         assertEquals("maven:org.embulk.foobar:e:0.1.2:bar", mavenType.getFullName());
+    }
+
+    @Test
+    public void testMavenFail1() {
+        final DefaultPluginType type = (DefaultPluginType) PluginType.createFromStringForTesting("qux");
+
+        try {
+            MavenPluginType.createFromDefaultPluginType("input", type, EmbulkSystemProperties.of(new Properties()));
+        } catch (final PluginSourceNotMatchException ex) {
+            assertEquals("Embulk system property \"plugins.input.qux\" is not set.", ex.getMessage());
+            return;
+        }
+        fail("PluginSourceNotMatchException is not thrown.");
+    }
+
+    @Test
+    public void testMavenFail2() {
+        final DefaultPluginType type = (DefaultPluginType) PluginType.createFromStringForTesting("foo");
+
+        try {
+            final Properties properties = new Properties();
+            properties.setProperty("plugins.filter.foo", "maven:foo");
+            MavenPluginType.createFromDefaultPluginType("filter", type, EmbulkSystemProperties.of(properties));
+        } catch (final PluginSourceNotMatchException ex) {
+            assertEquals("Embulk system property \"plugins.filter.foo\" is invalid: \"maven:foo\"",
+                         ex.getMessage());
+            return;
+        }
+        fail("PluginSourceNotMatchException is not thrown.");
+    }
+
+    @Test
+    public void testMavenFail3() {
+        final DefaultPluginType type = (DefaultPluginType) PluginType.createFromStringForTesting("test");
+
+        try {
+            final Properties properties = new Properties();
+            properties.setProperty("plugins.output.test", "nonmaven:org.embulk.foo:test:0.2.4");
+            MavenPluginType.createFromDefaultPluginType("output", type, EmbulkSystemProperties.of(properties));
+        } catch (final PluginSourceNotMatchException ex) {
+            assertEquals("Embulk system property \"plugins.output.test\" is invalid: \"nonmaven:org.embulk.foo:test:0.2.4\"",
+                         ex.getMessage());
+            return;
+        }
+        fail("PluginSourceNotMatchException is not thrown.");
+    }
+
+    @Test
+    public void testMaven() throws PluginSourceNotMatchException {
+        final DefaultPluginType type = (DefaultPluginType) PluginType.createFromStringForTesting("some");
+
+        final Properties properties1 = new Properties();
+        properties1.setProperty("plugins.input.some", "maven:org.embulk.baz:some:0.2.3");
+        properties1.setProperty("plugins.filter.some", "maven:com.example:some:0.4.1:alpha");
+
+        final MavenPluginType mavenType1 =
+                MavenPluginType.createFromDefaultPluginType("input", type, EmbulkSystemProperties.of(properties1));
+        assertEquals("some", mavenType1.getName());
+        assertEquals("org.embulk.baz", mavenType1.getGroup());
+        assertEquals("0.2.3", mavenType1.getVersion());
+        assertEquals(null, mavenType1.getClassifier());
+        assertEquals("maven:org.embulk.baz:some:0.2.3", mavenType1.getFullName());
+
+        final MavenPluginType mavenType2 =
+                MavenPluginType.createFromDefaultPluginType("filter", type, EmbulkSystemProperties.of(properties1));
+        assertEquals("some", mavenType2.getName());
+        assertEquals("com.example", mavenType2.getGroup());
+        assertEquals("0.4.1", mavenType2.getVersion());
+        assertEquals("alpha", mavenType2.getClassifier());
+        assertEquals("maven:com.example:some:0.4.1:alpha", mavenType2.getFullName());
     }
 }


### PR DESCRIPTION
It is to look for a Maven-based plugin even when only a simple plugin type is specified like `type: ftp` in user configuration, if a corresponding Embulk system property is configured.

For example, assume a user configuration is like below:

```
in:
  type: ftp
  host: ...
  ...
```

Embulk has looked only for a RubyGem-based plugin so far in this case.

By this pull request, Embulk looks for a Maven-based plugin if an Embulk system property `plugins.input.ftp` is set like `maven:org.embulk:ftp:0.3.0`.