### PR TITLE
Reenable multiple types of self-contained JAR resource files

### DIFF
--- a/embulk-core/src/main/java/org/embulk/deps/DependencyClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/deps/DependencyClassLoader.java
@@ -126,7 +126,7 @@ final class DependencyClassLoader extends URLClassLoader {
         }
 
         // TODO: Consider duplicated resources.
-        final Resource resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName);
+        final Resource resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName, EmbulkSelfContainedJarFiles.CORE);
         if (resource == null) {
             return null;
         }
@@ -156,7 +156,8 @@ final class DependencyClassLoader extends URLClassLoader {
         final Enumeration<URL> resourceUrlsFromSuper = super.findResources(resourceName);
 
         // Even if some resources are found from the delegation parent class loader, it looks into self-contained JAR files.
-        final Collection<Resource> resources = EmbulkSelfContainedJarFiles.getMultipleResources(resourceName);
+        final Collection<Resource> resources =
+                EmbulkSelfContainedJarFiles.getMultipleResources(resourceName, EmbulkSelfContainedJarFiles.CORE);
 
         final Vector<URL> resourceUrls = new Vector<URL>();
         while (resourceUrlsFromSuper.hasMoreElements()) {
@@ -189,7 +190,7 @@ final class DependencyClassLoader extends URLClassLoader {
         final String resourceName = className.replace('.', '/').concat(".class");
 
         // Class must be singular.
-        final Resource resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName);
+        final Resource resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName, EmbulkSelfContainedJarFiles.CORE);
         if (resource == null) {
             throw new ClassNotFoundException(className);
         }

--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkSelfContainedJarFiles.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkSelfContainedJarFiles.java
@@ -24,22 +24,24 @@ public final class EmbulkSelfContainedJarFiles {
 
     public static final class StaticInitializer {
         private StaticInitializer() {
-            this.jarFileResources = new ArrayList<>();
+            this.jarFileResources = new HashMap<>();
         }
 
-        public StaticInitializer addJarFileResource(final String resource) {
-            this.jarFileResources.add(resource);
-            return this;
-        }
-
-        public StaticInitializer addJarFileResources(final Collection<String> resources) {
-            this.jarFileResources.addAll(resources);
+        public StaticInitializer addJarFileResources(final String category, final Collection<String> resources) {
+            this.jarFileResources.compute(category, (dummy, old) -> {
+                final ArrayList<String> targetList = (old != null) ? old : new ArrayList();
+                targetList.addAll(resources);
+                return targetList;
+            });
             return this;
         }
 
         public StaticInitializer addFromManifest(final Manifest manifest) {
             final Attributes attributes = manifest.getMainAttributes();
-            this.addJarFileResources(splitAttribute(attributes.getValue("Embulk-Resource-Class-Path")));
+
+            // embulk-core's own self-contained dependencies
+            this.addJarFileResources(CORE, splitAttribute(attributes.getValue("Embulk-Resource-Class-Path")));
+
             return this;
         }
 
@@ -47,7 +49,7 @@ public final class EmbulkSelfContainedJarFiles {
             initializeAll(this.jarFileResources);
         }
 
-        private final ArrayList<String> jarFileResources;
+        private final HashMap<String, ArrayList<String>> jarFileResources;
     }
 
     public static StaticInitializer staticInitializer() {
@@ -59,20 +61,26 @@ public final class EmbulkSelfContainedJarFiles {
      *
      * public to be called from org.embulk.cli. Not for plugins. Not guaranteed.
      */
-    private static void initializeAll(final ArrayList<String> jarFileResources) {
+    private static void initializeAll(final HashMap<String, ArrayList<String>> jarFileResources) {
         synchronized (JAR_RESOURCE_NAMES) {
             if (JAR_RESOURCE_NAMES.isEmpty()) {
-                JAR_RESOURCE_NAMES.addAll(jarFileResources);
+                for (final Map.Entry<String, ArrayList<String>> entry : jarFileResources.entrySet()) {
+                    JAR_RESOURCE_NAMES.put(entry.getKey(), entry.getValue());
+                }
             } else {
                 throw new LinkageError("Double initialization of self-contained JAR files.");
             }
         }
     }
 
-    static Resource getSingleResource(final String targetResourceName) {
+    static Resource getSingleResource(final String targetResourceName, final String category) {
+        if (category == null) {
+            return null;
+        }
+
         String foundJarResourceName = null;
         Resource resourceToReturn = null;
-        for (final String jarResourceName : JAR_RESOURCE_NAMES) {
+        for (final String jarResourceName : JAR_RESOURCE_NAMES.get(category)) {
             final SelfContainedJarFile selfContainedJarFile = Holder.INSTANCE.get(jarResourceName);
             final Resource resourceFound = selfContainedJarFile.getResource(targetResourceName);
             if (resourceFound != null) {
@@ -86,9 +94,13 @@ public final class EmbulkSelfContainedJarFiles {
         return resourceToReturn;
     }
 
-    static Collection<Resource> getMultipleResources(final String targetResourceName) {
+    static Collection<Resource> getMultipleResources(final String targetResourceName, final String category) {
+        if (category == null) {
+            return null;
+        }
+
         final ArrayList<Resource> resourcesToReturn = new ArrayList<>();
-        for (final String jarResourceName : JAR_RESOURCE_NAMES) {
+        for (final String jarResourceName : JAR_RESOURCE_NAMES.get(category)) {
             final SelfContainedJarFile selfContainedJarFile = Holder.INSTANCE.get(jarResourceName);
             final Resource resourceFound = selfContainedJarFile.getResource(targetResourceName);
             if (resourceFound != null) {
@@ -103,8 +115,10 @@ public final class EmbulkSelfContainedJarFiles {
 
         static {
             final HashSet<String> allJarResourceNames = new HashSet<>();
-            for (final String jarResourceName : JAR_RESOURCE_NAMES) {
-                allJarResourceNames.add(jarResourceName);
+            for (final Map.Entry<String, List<String>> entry : JAR_RESOURCE_NAMES.entrySet()) {
+                for (final String jarResourceName : entry.getValue()) {
+                    allJarResourceNames.add(jarResourceName);
+                }
             }
 
             final HashMap<String, SelfContainedJarFile> instanceBuilt = new HashMap<>();
@@ -128,5 +142,9 @@ public final class EmbulkSelfContainedJarFiles {
         return list;
     }
 
-    private static final ArrayList<String> JAR_RESOURCE_NAMES = new ArrayList<>();
+    // Category for embulk-core's own self-contained dependencies.
+    public static final String CORE = "";
+
+    // Note this is technically mutable -- so that it can be initialized lazily via StaticInitializer.
+    private static final HashMap<String, List<String>> JAR_RESOURCE_NAMES = new HashMap<>();
 }

--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkSelfContainedJarFiles.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkSelfContainedJarFiles.java
@@ -75,12 +75,17 @@ public final class EmbulkSelfContainedJarFiles {
 
     static Resource getSingleResource(final String targetResourceName, final String category) {
         if (category == null) {
-            return null;
+            throw new NullPointerException("EmbulkSelfContainedJarFiles.getSingleResources received null.");
+        }
+        final List<String> jarResourceNames = JAR_RESOURCE_NAMES.get(category);
+        if (jarResourceNames == null) {
+            throw new IllegalArgumentException(
+                    "EmbulkSelfContainedJarFiles.getSingleResources received unexpected category: " + category);
         }
 
         String foundJarResourceName = null;
         Resource resourceToReturn = null;
-        for (final String jarResourceName : JAR_RESOURCE_NAMES.get(category)) {
+        for (final String jarResourceName : jarResourceNames) {
             final SelfContainedJarFile selfContainedJarFile = Holder.INSTANCE.get(jarResourceName);
             final Resource resourceFound = selfContainedJarFile.getResource(targetResourceName);
             if (resourceFound != null) {
@@ -96,11 +101,16 @@ public final class EmbulkSelfContainedJarFiles {
 
     static Collection<Resource> getMultipleResources(final String targetResourceName, final String category) {
         if (category == null) {
-            return null;
+            throw new NullPointerException("EmbulkSelfContainedJarFiles.getMultipleResources received null.");
+        }
+        final List<String> jarResourceNames = JAR_RESOURCE_NAMES.get(category);
+        if (jarResourceNames == null) {
+            throw new IllegalArgumentException(
+                    "EmbulkSelfContainedJarFiles.getMultipleResources received unexpected category: " + category);
         }
 
         final ArrayList<Resource> resourcesToReturn = new ArrayList<>();
-        for (final String jarResourceName : JAR_RESOURCE_NAMES.get(category)) {
+        for (final String jarResourceName : jarResourceNames) {
             final SelfContainedJarFile selfContainedJarFile = Holder.INSTANCE.get(jarResourceName);
             final Resource resourceFound = selfContainedJarFile.getResource(targetResourceName);
             if (resourceFound != null) {

--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkSelfContainedJarFiles.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkSelfContainedJarFiles.java
@@ -143,7 +143,7 @@ public final class EmbulkSelfContainedJarFiles {
     }
 
     // Category for embulk-core's own self-contained dependencies.
-    public static final String CORE = "";
+    public static final String CORE = "$embulk-deps$";
 
     // Note this is technically mutable -- so that it can be initialized lazily via StaticInitializer.
     private static final HashMap<String, List<String>> JAR_RESOURCE_NAMES = new HashMap<>();


### PR DESCRIPTION
Types of self-contained JAR resource files have been once disabled in #1279, but now we have to reenable it for a different purpose.

Embulk executable binary is going to self-contain `embulk-standards` plugin JARs in upcoming changes. Types of self-contained JAR files need to be reenabled so that the self-contained plugin JARs are loaded through `PluginClassLoader`s, not `DependencyClassLoader`.

This is needed for #1360.