### PR TITLE
Embed standard non-guess plugins as self-contained JARs, and load them through PluginClassLoader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,6 +307,10 @@ dependencies {
         transitive = false
     }
 
+    subprojectNamesOfStandardPlugins.each { pluginName ->
+        embed(project(":${pluginName}"))
+    }
+
     // Logback and jansi are included only in the executable package. (jansi for logback colors to work on Windows.)
     implementation "ch.qos.logback:logback-classic:1.2.3"
     implementation "org.fusesource.jansi:jansi:1.18"
@@ -314,10 +318,6 @@ dependencies {
     embed(project(':embulk-deps')) {
         exclude group: 'org.apache.commons', module: 'commons-lang3'  // Included in embulk-core.
         exclude group: 'com.google.guava', module: 'guava'  // Included in embulk-core.
-    }
-
-    subprojectNamesOfStandardPlugins.each { pluginName ->
-        embed(project(":${pluginName}"))
     }
 
     // Only to install the msgpack gem in embulk/build/.

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,23 @@ def subprojectNamesReleasedInMavenCentral = [
     "embulk-spi",
 ]
 
+def subprojectNamesOfStandardPlugins = [
+    "embulk-decoder-bzip2",
+    "embulk-decoder-gzip",
+    "embulk-encoder-bzip2",
+    "embulk-encoder-gzip",
+    "embulk-filter-remove_columns",
+    "embulk-filter-rename",
+    "embulk-formatter-csv",
+    "embulk-input-config",
+    "embulk-input-file",
+    "embulk-output-file",
+    "embulk-output-null",
+    "embulk-output-stdout",
+    "embulk-parser-csv",
+    "embulk-parser-json",
+]
+
 def subprojectNamesReleasedInBintray = [
     "embulk-core",
     "embulk-deps",
@@ -284,7 +301,11 @@ configurations {
 
 dependencies {
     implementation project(':embulk-core')
-    implementation project(':embulk-standards')
+    implementation(project(':embulk-standards')) {  // embulk-standards is still here only for some Ruby-based standard guess.
+        // embulk-standards' transitive dependencies are now only subprojects, such as ":embulk-parser-csv".
+        // Those subprojects are now embedded as self-contained JAR resources. All transitive dependencies are not needed.
+        transitive = false
+    }
 
     // Logback and jansi are included only in the executable package. (jansi for logback colors to work on Windows.)
     implementation "ch.qos.logback:logback-classic:1.2.3"
@@ -295,23 +316,42 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'  // Included in embulk-core.
     }
 
+    subprojectNamesOfStandardPlugins.each { pluginName ->
+        embed(project(":${pluginName}"))
+    }
+
     // Only to install the msgpack gem in embulk/build/.
     jruby "org.jruby:jruby-complete:9.1.15.0"
 }
 
 def listEmbedDependencies = { rootModuleName, prefix ->
-    def list = []
+    def firstArtifact = []  // The artifact of rootModuleName -- the list should contain only one.
+    def followingArtifacts = []  // Artifacts depended from the artifact of rootModuleName.
+
     configurations.embed.resolvedConfiguration.firstLevelModuleDependencies.each { firstLevelDependency ->
         if (firstLevelDependency.moduleName == rootModuleName) {
             firstLevelDependency.allModuleArtifacts.each { requiredArtifact ->
-                list.add(prefix + requiredArtifact.file.name)
+                if (requiredArtifact.name == rootModuleName) {
+                    firstArtifact.add(prefix + requiredArtifact.file.name)
+                } else {
+                    followingArtifacts.add(prefix + requiredArtifact.file.name)
+                }
             }
         }
     }
-    if (list.isEmpty()) {
-        throw new GradleException('Failed to collect libraries to embed: no dependencies found')
+
+    if (firstArtifact.isEmpty()) {
+        if (followingArtifacts.isEmpty()) {
+            throw new GradleException('Failed to collect libraries to embed: no dependencies found')
+        } else {
+            throw new GradleException('Failed to collect libraries to embed: specified root module is not found')
+        }
+    } else if (firstArtifact.size() > 1) {
+        throw new GradleException('Failed to collect libraries to embed: multiple root modules are found')
     }
-    return String.join(' ', list)
+
+    // It guarantees that the artifact of rootModuleName comes first.
+    return String.join(' ', firstArtifact + followingArtifacts)
 }
 
 // Standard "jar" task to build a JAR with dependency JAR resources embedded.
@@ -320,7 +360,11 @@ jar {
               ":embulk-spi:jar",
               ":embulk-core:jar",
               ":embulk-deps:jar",
-              ":embulk-standards:jar"
+              ":embulk-standards:jar"  // embulk-standards is here only for some Ruby-based standard guess.
+
+    subprojectNamesOfStandardPlugins.each { pluginName ->
+        dependsOn ":${pluginName}:jar"
+    }
 
     // Expands all dependencies including "embulk-core" and "embulk-standards"
     from {
@@ -344,7 +388,12 @@ jar {
                    'Specification-Title': 'embulk',
                    'Specification-Version': project.version,
                    'Embulk-Resource-Class-Path': listEmbedDependencies('embulk-deps', '/lib/'),
-                   'Main-Class': 'org.embulk.cli.Main'
+                   "Main-Class": "org.embulk.cli.Main",
+                   "Embulk-Plugins": String.join(" ", subprojectNamesOfStandardPlugins)
+        def pluginAttributes = subprojectNamesOfStandardPlugins.collectEntries { pluginName ->
+            [ ("Embulk-Plugin-${pluginName}".toString()): listEmbedDependencies(pluginName, "/lib/") ]
+        }
+        attributes(pluginAttributes)
     }
 }
 

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -1,7 +1,5 @@
 package org.embulk.exec;
 
-import static org.embulk.plugin.InjectedPluginSource.registerPluginTo;
-
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
@@ -17,8 +15,6 @@ import org.embulk.EmbulkSystemProperties;
 import org.embulk.deps.buffer.PooledBufferAllocator;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.ColumnJacksonModule;
-import org.embulk.spi.ExecutorPlugin;
-import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.SchemaJacksonModule;
 import org.embulk.spi.TempFileSpaceAllocator;
 import org.embulk.spi.time.DateTimeZoneJacksonModule;
@@ -51,13 +47,6 @@ public class ExecModule implements Module {
         binder.bind(org.embulk.config.ModelManager.class).in(Scopes.SINGLETON);
         binder.bind(BufferAllocator.class).toInstance(this.createBufferAllocatorFromSystemConfig());
         binder.bind(TempFileSpaceAllocator.class).toInstance(new SimpleTempFileSpaceAllocator());
-
-        // GuessExecutor, PreviewExecutor
-        registerPluginTo(binder, ParserPlugin.class, "system_guess", GuessExecutor.GuessParserPlugin.class);
-        registerPluginTo(binder, ParserPlugin.class, "system_sampling", SamplingParserPlugin.class);
-
-        // LocalExecutorPlugin
-        registerPluginTo(binder, ExecutorPlugin.class, "local", LocalExecutorPlugin.class);
 
         // SerDe
         final ObjectMapperModule mapper = new ObjectMapperModule();

--- a/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/LocalExecutorPlugin.java
@@ -1,7 +1,6 @@
 package org.embulk.exec;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -39,7 +38,6 @@ public class LocalExecutorPlugin implements ExecutorPlugin {
     private int defaultMaxThreads;
     private int defaultMinThreads;
 
-    @Inject
     public LocalExecutorPlugin(final EmbulkSystemProperties embulkSystemProperties) {
         int cores = Runtime.getRuntime().availableProcessors();
         this.defaultMaxThreads = embulkSystemProperties.getPropertyAsInteger("max_threads", cores * 2);

--- a/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
@@ -4,7 +4,6 @@ import static java.util.Locale.ENGLISH;
 import static org.embulk.spi.util.Inputs.each;
 
 import com.google.common.base.Preconditions;
-import com.google.inject.Inject;
 import java.text.NumberFormat;
 import java.util.List;
 import org.embulk.config.Config;
@@ -136,7 +135,6 @@ public class SamplingParserPlugin implements ParserPlugin {
         public int getSampleBufferBytes();
     }
 
-    @Inject
     public SamplingParserPlugin() {
         this.minSampleBufferBytes = 40;  // empty gzip file is 33 bytes. // TODO get sample size from system config
     }

--- a/embulk-core/src/main/java/org/embulk/plugin/InjectedPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/InjectedPluginSource.java
@@ -24,6 +24,7 @@ import org.embulk.spi.OutputPlugin;
  *     InjectedPluginSource.registerPluginTo(InputPluginclass, "my", MyInputPlugin.class);
  * }
  *
+ * InjectedPluginSource is still here only for testing. It will be removed very soon.
  */
 public class InjectedPluginSource implements PluginSource {
     private final Injector injector;

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
@@ -5,7 +5,6 @@ import com.google.common.collect.Iterators;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,16 +16,18 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.embulk.deps.SelfContainedJarAwareURLClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PluginClassLoader extends URLClassLoader {
+public class PluginClassLoader extends SelfContainedJarAwareURLClassLoader {
     private PluginClassLoader(
             final ClassLoader parentClassLoader,
             final Collection<URL> jarUrls,
+            final String selfContainedPluginName,
             final Collection<String> parentFirstPackages,
             final Collection<String> parentFirstResources) {
-        super(jarUrls.toArray(new URL[0]), parentClassLoader);
+        super(jarUrls.toArray(new URL[0]), parentClassLoader, selfContainedPluginName);
 
         this.hasJep320LoggedWithStackTrace = false;
 
@@ -53,6 +54,20 @@ public class PluginClassLoader extends URLClassLoader {
         return new PluginClassLoader(
                 parentClassLoader,
                 jarUrls,
+                null,
+                parentFirstPackages,
+                parentFirstResources);
+    }
+
+    public static PluginClassLoader forSelfContainedPlugin(
+            final ClassLoader parentClassLoader,
+            final String selfContainedPluginName,
+            final Collection<String> parentFirstPackages,
+            final Collection<String> parentFirstResources) {
+        return new PluginClassLoader(
+                parentClassLoader,
+                new ArrayList<>(),
+                selfContainedPluginName,
                 parentFirstPackages,
                 parentFirstResources);
     }

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactory.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactory.java
@@ -6,5 +6,7 @@ import java.util.Collection;
 public interface PluginClassLoaderFactory {
     PluginClassLoader create(Collection<URL> flatJarUrls, ClassLoader parentClassLoader);
 
+    PluginClassLoader forSelfContainedPlugin(String selfContainedPluginName, ClassLoader parentClassLoader);
+
     void clear();
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactoryImpl.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactoryImpl.java
@@ -31,6 +31,17 @@ public class PluginClassLoaderFactoryImpl implements PluginClassLoaderFactory {
     }
 
     @Override
+    public PluginClassLoader forSelfContainedPlugin(final String selfContainedPluginName, final ClassLoader parentClassLoader) {
+        final PluginClassLoader created = PluginClassLoader.forSelfContainedPlugin(
+                parentClassLoader,
+                selfContainedPluginName,
+                this.parentFirstPackages,
+                this.parentFirstResources);
+        this.createdPluginClassLoaders.add(created);
+        return created;
+    }
+
+    @Override
     public void clear() {
         // "close()" is intentionally not called for them considering: https://bugs.openjdk.java.net/browse/JDK-8246714
         /*

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginSource.java
@@ -8,7 +8,7 @@ public interface PluginSource {
     <T> T newPlugin(Class<T> iface, PluginType type) throws PluginSourceNotMatchException;
 
     public enum Type {
-        DEFAULT("default"),  // DEFAULT includes InjectedPluginSource and JRubyPluginSource.
+        DEFAULT("default"),  // DEFAULT includes SelfContainedPluginSource and JRubyPluginSource.
         MAVEN("maven"),
         ;
 

--- a/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginSource.java
@@ -1,0 +1,305 @@
+package org.embulk.plugin;
+
+import com.google.inject.Injector;
+import org.embulk.EmbulkSystemProperties;
+import org.embulk.deps.EmbulkSelfContainedJarFiles;
+import org.embulk.plugin.PluginClassLoaderFactory;
+import org.embulk.plugin.PluginSource;
+import org.embulk.plugin.PluginSourceNotMatchException;
+import org.embulk.plugin.PluginType;
+import org.embulk.plugin.jar.InvalidJarPluginException;
+import org.embulk.plugin.jar.JarPluginLoader;
+import org.embulk.spi.DecoderPlugin;
+import org.embulk.spi.EncoderPlugin;
+import org.embulk.spi.ExecutorPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileInputRunner;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FileOutputRunner;
+import org.embulk.spi.FilterPlugin;
+import org.embulk.spi.FormatterPlugin;
+import org.embulk.spi.GuessPlugin;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.ParserPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>It replaces {@code InjectedPluginSource} for embulk-standards plugins embedded in an Embulk executable binary.
+ */
+public class SelfContainedPluginSource implements PluginSource {
+    public SelfContainedPluginSource(
+            final Injector injector,
+            final EmbulkSystemProperties embulkSystemProperties,
+            final PluginClassLoaderFactory pluginClassLoaderFactory) {
+        this.injector = injector;
+        this.embulkSystemProperties = embulkSystemProperties;
+        this.pluginClassLoaderFactory = pluginClassLoaderFactory;
+    }
+
+    @Override
+    public <T> T newPlugin(final Class<T> pluginInterface, final PluginType pluginType) throws PluginSourceNotMatchException {
+        final String category;
+        if (InputPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "input";
+        } else if (OutputPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "output";
+        } else if (ParserPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "parser";
+        } else if (FormatterPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "formatter";
+        } else if (DecoderPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "decoder";
+        } else if (EncoderPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "encoder";
+        } else if (FilterPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "filter";
+        } else if (GuessPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "guess";
+        } else if (ExecutorPlugin.class.isAssignableFrom(pluginInterface)) {
+            category = "executor";
+        } else {
+            // unsupported plugin category
+            throw new PluginSourceNotMatchException("Plugin interface " + pluginInterface + " is not supported.");
+        }
+
+        if (pluginType.getSourceType() != PluginSource.Type.DEFAULT) {
+            throw new PluginSourceNotMatchException();
+        }
+
+        this.rejectTraditionalStandardPluginsFromEmbulkSystemProperties(category, pluginType.getName());
+
+        final String selfContainedPluginName = "embulk-" + category + "-" + pluginType.getName();
+        if (!EmbulkSelfContainedJarFiles.has(selfContainedPluginName)) {
+            throw new PluginSourceNotMatchException();
+        }
+
+        final Class<?> pluginMainClass;
+        try (final JarPluginLoader loader = JarPluginLoader.loadSelfContained(selfContainedPluginName, this.pluginClassLoaderFactory)) {
+            pluginMainClass = loader.getPluginMainClass();
+        } catch (final InvalidJarPluginException ex) {
+            throw new PluginSourceNotMatchException(ex);
+        }
+
+        final Object pluginMainObject;
+        try {
+            // Unlike JRubyPluginSource,
+            // SelfContainedPluginSource does not have "registration" before creating an instance of the plugin class.
+            // FileInputPlugin and FileOutputPlugin are wrapped with FileInputRunner and FileOutputRunner here.
+            if (FileInputPlugin.class.isAssignableFrom(pluginMainClass)) {
+                final FileInputPlugin fileInputPluginMainObject;
+                try {
+                    fileInputPluginMainObject = (FileInputPlugin) this.injector.getInstance(pluginMainClass);
+                } catch (final ClassCastException ex) {
+                    throw new PluginSourceNotMatchException(
+                            "[FATAL/INTERNAL] Plugin class \"" + pluginMainClass.getName() + "\" is not file-input.",
+                            ex);
+                }
+                pluginMainObject = new FileInputRunner(fileInputPluginMainObject);
+            } else if (FileOutputPlugin.class.isAssignableFrom(pluginMainClass)) {
+                final FileOutputPlugin fileOutputPluginMainObject;
+                try {
+                    fileOutputPluginMainObject = (FileOutputPlugin) this.injector.getInstance(pluginMainClass);
+                } catch (final ClassCastException ex) {
+                    throw new PluginSourceNotMatchException(
+                            "[FATAL/INTERNAL] Plugin class \"" + pluginMainClass.getName() + "\" is not file-output.",
+                            ex);
+                }
+                pluginMainObject = new FileOutputRunner(fileOutputPluginMainObject);
+            } else {
+                if (!pluginInterface.isAssignableFrom(pluginMainClass)) {
+                    throw new PluginSourceNotMatchException(
+                            "Plugin class \"" + pluginMainClass.getName() + "\" is not a valid " + category + " plugin.");
+                }
+                pluginMainObject = this.injector.getInstance(pluginMainClass);
+            }
+        } catch (final ExceptionInInitializerError ex) {
+            throw new PluginSourceNotMatchException(
+                    "Plugin class \"" + pluginMainClass.getName()
+                            + "\" is not instantiatable due to exception in initialization.",
+                    ex);
+        } catch (final SecurityException ex) {
+            throw new PluginSourceNotMatchException(
+                    "Plugin class \"" + pluginMainClass.getName()
+                            + "\" is not instantiatable due to security manager.",
+                    ex);
+        }
+
+        try {
+            return pluginInterface.cast(pluginMainObject);
+        } catch (final ClassCastException ex) {
+            throw new PluginSourceNotMatchException(
+                    "[FATAL/INTERNAL] Plugin class \"" + pluginMainClass.getName() + "\" is not " + category + " actually.",
+                    ex);
+        }
+    }
+
+    private void rejectTraditionalStandardPluginsFromEmbulkSystemProperties(
+            final String category, final String type) throws PluginSourceNotMatchException {
+        switch (category) {
+            case "input":
+                switch (type) {
+                    case "config":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.input.config.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard config input plugin by the Embulk system property "
+                                    + "\"standards.input.config.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    case "file":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.input.file.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard local file input plugin by the Embulk system property "
+                                    + "\"standards.input.file.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case "parser":
+                switch (type) {
+                    case "csv":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.parser.csv.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard CSV parser plugin by the Embulk system property "
+                                    + "\"standards.parser.csv.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    case "json":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.parser.json.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard JSON parser plugin by the Embulk system property "
+                                    + "\"standards.parser.json.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case "decoder":
+                switch (type) {
+                    case "gzip":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.decoder.gzip.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard gzip decoder plugin by the Embulk system property "
+                                    + "\"standards.decoder.gzip.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    case "bzip2":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.decoder.bzip2.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard bzip2 decoder plugin by the Embulk system property "
+                                    + "\"standards.decoder.bzip2.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case "output":
+                switch (type) {
+                    case "file":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.output.file.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard local file output plugin by the Embulk system property "
+                                    + "\"standards.output.file.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    case "null":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.output.null.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard null output plugin by the Embulk system property "
+                                    + "\"standards.output.null.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    case "stdout":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.output.stdout.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard stdout output plugin by the Embulk system property "
+                                    + "\"standards.output.stdout.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case "formatter":
+                switch (type) {
+                    case "csv":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.formatter.csv.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard CSV formatter plugin by the Embulk system property "
+                                    + "\"standards.formatter.csv.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case "encoder":
+                switch (type) {
+                    case "gzip":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.encoder.gzip.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard gzip encoder plugin by the Embulk system property "
+                                    + "\"standards.encoder.gzip.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    case "bzip2":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.encoder.bzip2.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard bzip2 encoder plugin by the Embulk system property "
+                                    + "\"standards.encoder.bzip2.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case "filter":
+                switch (type) {
+                    case "rename":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.filter.rename.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard rename filter plugin by the Embulk system property "
+                                    + "\"standards.filter.rename.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    case "remove_columns":
+                        if (this.embulkSystemProperties.getPropertyAsBoolean("standards.filter.remove_columns.disabled", false)) {
+                            logger.warn(
+                                    "Disabling the standard remove columns plugin by the Embulk system property "
+                                    + "\"standards.filter.remove_columns.disabled\" is deprecated.");
+                            throw new PluginSourceNotMatchException();
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(SelfContainedPluginSource.class);
+
+    private final Injector injector;
+    private final EmbulkSystemProperties embulkSystemProperties;
+    private final PluginClassLoaderFactory pluginClassLoaderFactory;
+}

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
@@ -111,7 +111,7 @@ public class MavenPluginSource implements PluginSource {
 
         final Object pluginMainObject;
         try {
-            // Unlike InjectedPluginSource and JRubyPluginSource,
+            // Unlike JRubyPluginSource,
             // MavenPluginSource does not have "registration" before creating an instance of the plugin class.
             // FileInputPlugin and FileOutputPlugin are wrapped with FileInputRunner and FileOutputRunner here.
             if (FileInputPlugin.class.isAssignableFrom(pluginMainClass)) {

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSessionInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSessionInternal.java
@@ -25,6 +25,7 @@ import org.embulk.plugin.PluginClassLoaderFactory;
 import org.embulk.plugin.PluginClassLoaderFactoryImpl;
 import org.embulk.plugin.PluginManager;
 import org.embulk.plugin.PluginType;
+import org.embulk.plugin.SelfContainedPluginSource;
 import org.embulk.plugin.maven.MavenPluginSource;
 import org.embulk.spi.time.Instants;
 import org.embulk.spi.time.TimestampFormatter;
@@ -171,8 +172,10 @@ public class ExecSessionInternal extends ExecSession {
                 (parentFirstPackages != null) ? parentFirstPackages : Collections.unmodifiableSet(new HashSet<>()),
                 (parentFirstResources != null) ? parentFirstResources : Collections.unmodifiableSet(new HashSet<>()));
         this.pluginManager = PluginManager.with(
+                embulkSystemProperties,
                 new InjectedPluginSource(injector),
                 new MavenPluginSource(injector, embulkSystemProperties, pluginClassLoaderFactory),
+                new SelfContainedPluginSource(injector, embulkSystemProperties, pluginClassLoaderFactory),
                 new JRubyPluginSource(injector.getInstance(ScriptingContainerDelegate.class), pluginClassLoaderFactory));
 
         this.bufferAllocator = injector.getInstance(BufferAllocator.class);

--- a/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
+++ b/embulk-standards/src/main/java/org/embulk/standards/StandardPluginModule.java
@@ -1,20 +1,12 @@
 package org.embulk.standards;
 
 import static org.embulk.exec.GuessExecutor.registerDefaultGuessPluginTo;
-import static org.embulk.plugin.InjectedPluginSource.registerPluginTo;
 
 import com.google.common.base.Preconditions;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import org.embulk.EmbulkSystemProperties;
 import org.embulk.plugin.DefaultPluginType;
-import org.embulk.spi.DecoderPlugin;
-import org.embulk.spi.EncoderPlugin;
-import org.embulk.spi.FilterPlugin;
-import org.embulk.spi.FormatterPlugin;
-import org.embulk.spi.InputPlugin;
-import org.embulk.spi.OutputPlugin;
-import org.embulk.spi.ParserPlugin;
 
 public class StandardPluginModule implements Module {
     public StandardPluginModule(final EmbulkSystemProperties embulkSystemProperties) {
@@ -24,62 +16,6 @@ public class StandardPluginModule implements Module {
     @Override
     public void configure(Binder binder) {
         Preconditions.checkNotNull(binder, "binder is null.");
-
-        // input plugins
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.input.config.disabled", false)) {
-            registerPluginTo(binder, InputPlugin.class, "config", ConfigInputPlugin.class);
-        }
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.input.file.disabled", false)) {
-            registerPluginTo(binder, InputPlugin.class, "file", LocalFileInputPlugin.class);
-        }
-
-        // parser plugins
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.parser.csv.disabled", false)) {
-            registerPluginTo(binder, ParserPlugin.class, "csv", CsvParserPlugin.class);
-        }
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.parser.json.disabled", false)) {
-            registerPluginTo(binder, ParserPlugin.class, "json", JsonParserPlugin.class);
-        }
-
-        // file decoder plugins
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.decoder.gzip.disabled", false)) {
-            registerPluginTo(binder, DecoderPlugin.class, "gzip", GzipFileDecoderPlugin.class);
-        }
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.decoder.bzip2.disabled", false)) {
-            registerPluginTo(binder, DecoderPlugin.class, "bzip2", Bzip2FileDecoderPlugin.class);
-        }
-
-        // output plugins
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.output.file.disabled", false)) {
-            registerPluginTo(binder, OutputPlugin.class, "file", LocalFileOutputPlugin.class);
-        }
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.output.null.disabled", false)) {
-            registerPluginTo(binder, OutputPlugin.class, "null", NullOutputPlugin.class);
-        }
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.output.stdout.disabled", false)) {
-            registerPluginTo(binder, OutputPlugin.class, "stdout", StdoutOutputPlugin.class);
-        }
-
-        // formatter plugins
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.formatter.csv.disabled", false)) {
-            registerPluginTo(binder, FormatterPlugin.class, "csv", CsvFormatterPlugin.class);
-        }
-
-        // file encoder plugins
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.encoder.gzip.disabled", false)) {
-            registerPluginTo(binder, EncoderPlugin.class, "gzip", GzipFileEncoderPlugin.class);
-        }
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.encoder.bzip2.disabled", false)) {
-            registerPluginTo(binder, EncoderPlugin.class, "bzip2", Bzip2FileEncoderPlugin.class);
-        }
-
-        // filter plugins
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.filter.rename.disabled", false)) {
-            registerPluginTo(binder, FilterPlugin.class, "rename", RenameFilterPlugin.class);
-        }
-        if (!embulkSystemProperties.getPropertyAsBoolean("standards.filter.remove_columns.disabled", false)) {
-            registerPluginTo(binder, FilterPlugin.class, "remove_columns", RemoveColumnsFilterPlugin.class);
-        }
 
         // default guess plugins
         if (!embulkSystemProperties.getPropertyAsBoolean("standards.decoder.gzip.disabled", false)) {

--- a/embulk-standards/src/test/java/org/embulk/standards/StandardPluginTestExtension.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/StandardPluginTestExtension.java
@@ -1,0 +1,13 @@
+package org.embulk.standards;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
+import java.util.List;
+import org.embulk.EmbulkSystemProperties;
+import org.embulk.spi.Extension;
+
+public class StandardPluginTestExtension implements Extension {
+    public List<Module> getModules(final EmbulkSystemProperties embulkSystemProperties) {
+        return ImmutableList.<Module>of(new StandardPluginTestModule());
+    }
+}

--- a/embulk-standards/src/test/java/org/embulk/standards/StandardPluginTestModule.java
+++ b/embulk-standards/src/test/java/org/embulk/standards/StandardPluginTestModule.java
@@ -1,0 +1,24 @@
+package org.embulk.standards;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import org.embulk.plugin.InjectedPluginSource;
+import org.embulk.spi.FilterPlugin;
+import org.embulk.spi.FormatterPlugin;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.ParserPlugin;
+
+public class StandardPluginTestModule implements Module {
+    public StandardPluginTestModule() {
+    }
+
+    @Override
+    public void configure(final Binder binder) {
+        InjectedPluginSource.registerPluginTo(binder, FormatterPlugin.class, "csv", CsvFormatterPlugin.class);
+        InjectedPluginSource.registerPluginTo(binder, InputPlugin.class, "file", LocalFileInputPlugin.class);
+        InjectedPluginSource.registerPluginTo(binder, OutputPlugin.class, "file", LocalFileOutputPlugin.class);
+        InjectedPluginSource.registerPluginTo(binder, ParserPlugin.class, "csv", CsvParserPlugin.class);
+        InjectedPluginSource.registerPluginTo(binder, FilterPlugin.class, "remove_columns", RemoveColumnsFilterPlugin.class);
+    }
+}

--- a/embulk-standards/src/test/resources/META-INF/services/org.embulk.spi.Extension
+++ b/embulk-standards/src/test/resources/META-INF/services/org.embulk.spi.Extension
@@ -1,0 +1,1 @@
+org.embulk.standards.StandardPluginTestExtension


### PR DESCRIPTION
After #1358 and #1359, this PR starts loading (non-guess) `embulk-standards` plugins as self-contained JAR files through `PluginClassLoader`.

They have been loaded on the top-level class loader so far, registered through `StandardPluginModule` and `StandardPluginExtension`.