### PR TITLE
Fail explicitly with embulk.gem mismatching with the running Embulk

### DIFF
--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyInitializer.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyInitializer.java
@@ -129,6 +129,10 @@ final class JRubyInitializer {
             }
 
             if (this.isEmbulkSpecific) {
+                // Loading 'embulk/version' triggers a version check with embulk.gem v0.10.25 or later.
+                // (Even in Embulk v0.10.24 or earlier, 'embulk/version' is loaded soon below from 'embulk/logger'.)
+                jruby.runScriptlet("require 'embulk/version'");
+
                 // Embulk's base Ruby code is loaded at last.
                 jruby.runScriptlet("require 'embulk/logger'");
                 jruby.runScriptlet("require 'embulk/java/bootstrap'");

--- a/embulk-ruby/build.gradle
+++ b/embulk-ruby/build.gradle
@@ -16,6 +16,7 @@ ext.ruby_version = buildRubyStyleVersionFromJavaStyleVersion(version)
 
 configurations {
     jruby
+    rubyTest
 }
 
 repositories {
@@ -24,6 +25,8 @@ repositories {
 
 dependencies {
     jruby "org.jruby:jruby-complete:9.1.15.0"
+    rubyTest project(":embulk-core")
+    rubyTest project(":embulk-standards")
 }
 
 task gemContents(type: Copy) {
@@ -40,6 +43,14 @@ task gemContents(type: Copy) {
     }
     from("${projectDir}/embulk.gemspec.template") {
         rename "embulk.gemspec.template", "embulk.gemspec"
+        expand([
+            java_version: project.version,
+            ruby_version: project.ruby_version,
+        ])
+    }
+    from("${projectDir}/gem_version.rb.template") {
+        into "lib/embulk"
+        rename "gem_version.rb.template", "gem_version.rb"
         expand([
             java_version: project.version,
             ruby_version: project.ruby_version,
@@ -70,9 +81,7 @@ task rubyTest(type: JavaExec, dependsOn: [
         ":embulk-deps:assemble",
         ]) {
     workingDir = file("${projectDir}/build/gemContents")
-    classpath = configurations.jruby +
-                project(":embulk-core").sourceSets.main.runtimeClasspath +
-                project(":embulk-standards").sourceSets.main.runtimeClasspath
+    classpath = configurations.jruby + configurations.rubyTest
     main = "org.jruby.Main"
     args = ["-Ilib", "-Itest", "--debug", "./test/vanilla/run-test.rb"]
     systemProperty "deps_classpath", project(":embulk-deps").sourceSets.main.runtimeClasspath.files.join(File.pathSeparator)

--- a/embulk-ruby/gem_version.rb.template
+++ b/embulk-ruby/gem_version.rb.template
@@ -1,0 +1,3 @@
+module Embulk
+  GEM_VERSION_EMBEDDED = "${ruby_version}"
+end

--- a/embulk-ruby/lib/embulk/logger.rb
+++ b/embulk-ruby/lib/embulk/logger.rb
@@ -1,5 +1,6 @@
-
 module Embulk
+  require 'embulk/version'  # 'embulk/version' is loaded in the very beginning.
+
   # this file is required before loading embulk-core.jar
 
   require 'logger'

--- a/embulk-ruby/lib/embulk/version.rb
+++ b/embulk-ruby/lib/embulk/version.rb
@@ -1,5 +1,50 @@
 module Embulk
+  CORE_VERSION = Java::org.embulk.EmbulkVersion::VERSION
+
   # Converts the original Java-style version string to Ruby-style.
   # E.g., "0.9.0-SNAPSHOT" (in Java) is converted to "0.9.0.snapshot" in Ruby.
-  VERSION = ::String.new(Java::org.embulk.EmbulkVersion::VERSION).tr('-', '.').downcase
+  CORE_VERSION_IN_RUBY_GEM_STYLE = ::String.new(CORE_VERSION).tr('-', '.').downcase
+  private_constant :CORE_VERSION_IN_RUBY_GEM_STYLE
+
+  begin
+    require 'embulk/gem_version'
+  rescue LoadError => e
+    raise LoadError, "[Internal Error] This embulk.gem is not properly built with embulk/gem_version.rb to declare its own version."
+  end
+
+  begin
+    GEM_VERSION = GEM_VERSION_EMBEDDED
+  rescue NameError => e
+    raise LoadError, "[Internal Error] This embulk.gem does not contain its own version defined properly."
+  end
+
+  if GEM_VERSION != CORE_VERSION_IN_RUBY_GEM_STYLE
+    # "embulk/logger" cannot be used because embulk/version.rb is loaded even before embulk/logger.rb.
+    STDERR.puts "*******************************************************************************************"
+    STDERR.puts "Running Embulk version (#{CORE_VERSION}) does not match the installed embulk.gem version (#{GEM_VERSION})."
+    STDERR.puts ""
+    STDERR.puts "If you use Embulk v0.9.* or v0.10.[0-23] without Bundler:"
+    STDERR.puts "   Uninstall embulk.gem from your GEM_HOME/GEM_PATH."
+    STDERR.puts "   An embulk.gem equivalent should be embedded in your Embulk's core JAR."
+    STDERR.puts ""
+    STDERR.puts "If you use Embulk v0.9.* or v0.10.[0-23] with Bundler:"
+    STDERR.puts "   Try updating your Gemfile as below:"
+    STDERR.puts "     gem 'embulk', '< 0.10'"
+    STDERR.puts "   Bundler will find the embulk.gem equivalent embedded in your Embulk's core JAR."
+    STDERR.puts ""
+    STDERR.puts "If you use Embulk v0.10.25 or later:"
+    STDERR.puts "   Use exactly the same version of embulk.gem."
+    STDERR.puts "   In case you use Bundler, your Gemfile should declare like:"
+    STDERR.puts "     gem 'embulk', '#{CORE_VERSION_IN_RUBY_GEM_STYLE}'"
+    STDERR.puts ""
+    STDERR.puts "If you use Embulk v0.10.24:"
+    STDERR.puts "   Update to v0.10.25 or later."
+    STDERR.puts ""
+    STDERR.puts "If you use Embulk v0.8.* or earlier:"
+    STDERR.puts "   Update to the latest v0.9.*. v0.8 or earlier are deprecated."
+    STDERR.puts "*******************************************************************************************"
+    raise LoadError, "Running Embulk version (#{CORE_VERSION}) does not match the installed embulk.gem version (#{GEM_VERSION})."
+  end
+
+  VERSION = GEM_VERSION
 end


### PR DESCRIPTION
It turned out that existing v0.9.* users with Bundler (`mkbundle`) may fall into a weird situation that `embulk.gem` 0.10.24 is installed by Bundler, caused by releasing `embulk.gem` 0.10.24 in rubygems.org. 

Most Bundler users should have had the following declaration in their `Gemfile` (by our recommendation when we started v0.9):
```
gem 'embulk'
```

It installs the latest `embulk.gem`, then `embulk.gem` 0.10.24 is installed.

However, we cannot get back. Then, we're going to introduce a version check in `embulk.gem` v0.10.25+ between the Embulk core (Java) and `embulk.gem` (Ruby). The check fails if the running Embulk version does not match the loaded `embulk.gem` version, and suggests how the user should do based on their use-case.

In case the user uses v0.9.* with Bundler, it suggests to update their `Gemfile` as below, and it should work:
```
gem 'embulk', '< 0.10'
```

----

We found the case thanks to @hiroyuki-sato.
https://gist.github.com/hiroyuki-sato/e3f277a05656888ef3e4810de799a946