### PR TITLE
Test embulk.gem's version check

### DIFF
--- a/embulk-ruby/test/vanilla/test_version.rb
+++ b/embulk-ruby/test/vanilla/test_version.rb
@@ -1,0 +1,10 @@
+require 'embulk/version'
+
+class VersionTest < ::Test::Unit::TestCase
+  def test_version
+    STDERR.puts ""
+    STDERR.puts "CORE_VERSION: #{Java::org.embulk.EmbulkVersion::VERSION}"
+    STDERR.puts "GEM_VERSION: #{::Embulk::VERSION}"
+    assert_equal(::String.new(Java::org.embulk.EmbulkVersion::VERSION).tr('-', '.').downcase, ::Embulk::VERSION)
+  end
+end


### PR DESCRIPTION
It tests "embulk.gem's version check" mechanism introduced in #1370 in `embulk-ruby`'s Ruby test code.