### PR TITLE
Release everything into Maven Central, instead of JCenter/Bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,26 @@ Modify `jrubyVersion` in `build.gradle` to update JRuby of Embulk.
 
 ### Release
 
-You need to add your bintray account information to ~/.gradle/gradle.properties
+#### Prerequisite: Sonatype OSSRH
+
+You need an account in [Sonatype OSSRH](https://central.sonatype.org/pages/ossrh-guide.html), and configure it in your `~/.gradle/gradle.properties`.
 
 ```
-bintray_user=(bintray user name)
-bintray_api_key=(bintray api key)
+ossrhUsername=(your Sonatype OSSRH username)
+ossrhPassword=(your Sonatype OSSRH password)
 ```
+
+#### Prerequisite: PGP signatures
+
+You need your [PGP signatures to release artifacts into Maven Central](https://central.sonatype.org/pages/working-with-pgp-signatures.html), and [configure Gradle to use your key to sign](https://docs.gradle.org/current/userguide/signing_plugin.html).
+
+```
+signing.keyId=(the last 8 symbols of your keyId)
+signing.password=(the passphrase used to protect your private key)
+signing.secretKeyRingFile=(the absolute path to the secret key ring file containing your private key)
+```
+
+#### Release
 
 Modify `version` in `build.gradle` at a detached commit to bump Embulk version up.
 
@@ -149,7 +163,3 @@ git tag -a vX.Y.Z
 ./gradlew clean && ./gradlew release
 git push -u origin vX.Y.Z
 ```
-
-See also:
-* [Bintray](https://bintray.com)
-* [How to acquire bintray API Keys](https://bintray.com/docs/usermanual/interacting/interacting_editingyouruserprofile.html#anchorAPIKEY)

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id "java-library"
     id "maven-publish"
     id "jacoco"
-    id "com.jfrog.bintray" version "1.8.4" apply false
     id "org.ajoberstar.grgit" version "4.0.1"
     id "org.embulk.embulk-plugins" version "0.4.2" apply false
 }
@@ -43,9 +42,12 @@ ext {
     summary = 'Embulk, a plugin-based parallel bulk data loader'
 }
 
-def subprojectNamesReleasedInMavenCentral = [
+def subprojectNamesOfCoreArtifacts = [
     "embulk-api",
     "embulk-spi",
+    "embulk-core",
+    "embulk-deps",
+    "embulk-junit4",
 ]
 
 def subprojectNamesOfStandardPlugins = [
@@ -70,25 +72,13 @@ def subprojectNamesOfStandardPlugins = [
     "embulk-parser-json",
 ]
 
-def subprojectNamesReleasedInBintray = [
-    "embulk-core",
-    "embulk-deps",
-    "embulk-junit4",
-]
-
-// NOTE: "subprojectNamesReleased" represents subprojects that are released by tasks defined in the top-level build.gradle.
-// A subproject in "subprojectNamesOfStandardPlugins" is released by its own task defined in its own build.gradle.
-// This is prepration for splitting each standard plugin as a separate repository.
-def subprojectNamesReleased = subprojectNamesReleasedInMavenCentral + subprojectNamesReleasedInBintray
-
-configure(subprojects.findAll { subprojectNamesReleased.contains(it.name) }) {
+configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name) }) {
     apply plugin: "java-library"
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'maven-publish'
     // TODO: Enable SpotBugs instead of FindBugs which was used in Embulk until v0.9.17.
 
-    // The version needs to be declared here, not in each build.gradle, so that "bintray" can get the value.
     version = "${rootProject.version}"
     project.ext.setProperty("revision", revision)
 
@@ -144,8 +134,9 @@ configure(subprojects.findAll { subprojectNamesReleased.contains(it.name) }) {
     }
 }
 
-configure(subprojects.findAll { subprojectNamesReleasedInBintray.contains(it.name) }) {
-    apply plugin: "com.jfrog.bintray"
+project(":embulk-core") {
+    // embulk-core:tests need to be released because some plugins use embulk-core:tests for their testing.
+    // TODO: Merge them into embulk-junit4 in some manner.
 
     task testsJar(type: Jar, dependsOn: classes) {
         classifier = 'tests'
@@ -155,63 +146,22 @@ configure(subprojects.findAll { subprojectNamesReleasedInBintray.contains(it.nam
     artifacts {
         archives testsJar
     }
-
-    publishing {
-        publications {
-            maven(MavenPublication) {
-                if (project.version.endsWith("-SNAPSHOT")) {
-                    version = "${project.version}-${revision}"
-                }
-
-                from components.java
-                // javadocJar and sourcesJar are added by java.withJavadocJar() and java.withSourcesJar() above.
-                // See: https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaPluginExtension.html
-                artifact testsJar
-            }
-        }
-    }
-
-    bintray {  // Defines "bintrayUpload" properties for Java subprojects.
-        // NOTE: Define Gradle properties "bintray_user" and "bintray_api_key" to upload the releases to Bintray.
-        // ~/.gradle/gradle.properties would help defining.
-        user = project.hasProperty('bintray_user') ? bintray_user : ''
-        key = project.hasProperty('bintray_api_key') ? bintray_api_key : ''
-
-        publications = ["maven"]
-
-        dryRun = false
-        publish = true
-
-        pkg {
-            userOrg = 'embulk'
-            repo = 'maven'
-            name = 'embulk'
-            desc = 'Embulk, a plugin-based parallel bulk data loader'
-            websiteUrl = "https://www.embulk.org/"
-            issueTrackerUrl = 'https://github.com/embulk/embulk/issues'
-            vcsUrl = 'https://github.com/embulk/embulk.git'
-            licenses = ['Apache-2.0']
-            labels = [ "embulk" ]
-            publicDownloadNumbers = true
-            version {
-                name = project.version
-            }
-        }
-    }
 }
 
-configure(subprojects.findAll { subprojectNamesReleasedInMavenCentral.contains(it.name) }) {
+configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name) }) {
     apply plugin: "signing"
 
     jar {
         from rootProject.file("LICENSE")
     }
 
-    javadoc {
-        options {
-            overview = "src/main/html/overview.html"
-            links "https://docs.oracle.com/javase/8/docs/api/"
-            links "https://www.javadoc.io/doc/org.slf4j/slf4j-api/1.7.12/"
+    if (project.name == "embulk-api" || project.name == "embulk-spi" ) {
+        javadoc {
+            options {
+                overview = "src/main/html/overview.html"
+                links "https://docs.oracle.com/javase/8/docs/api/"
+                links "https://www.javadoc.io/doc/org.slf4j/slf4j-api/1.7.30/"
+            }
         }
     }
 
@@ -224,6 +174,12 @@ configure(subprojects.findAll { subprojectNamesReleasedInMavenCentral.contains(i
                 from components.java
                 // javadocJar and sourcesJar are added by java.withJavadocJar() and java.withSourcesJar() above.
                 // See: https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaPluginExtension.html
+
+                // embulk-core:tests need to be released because some plugins use embulk-core:tests for their testing.
+                // TODO: Merge them into embulk-junit4 in some manner.
+                if (project.name == "embulk-core") {
+                    artifact testsJar
+                }
 
                 pom {  // https://central.sonatype.org/pages/requirements.html
                     name = "${project.name}"
@@ -286,8 +242,8 @@ configure(subprojects.findAll { subprojectNamesReleasedInMavenCentral.contains(i
                     url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
                 }
                 credentials {
-                    username = project.hasProperty("sonatype_username") ? sonatype_username : ""
-                    password = project.hasProperty("sonatype_password") ? sonatype_password : ""
+                    username = project.hasProperty("ossrhUsername") ? ossrhUsername : ""
+                    password = project.hasProperty("ossrhPassword") ? ossrhPassword : ""
                 }
             }
         }
@@ -444,13 +400,9 @@ task releaseCheck {
 task release {
     dependsOn "releaseCheck"
     dependsOn "executableJar"
-    subprojectNamesReleasedInMavenCentral.each { subprojectName ->
+    subprojectNamesOfCoreArtifacts.each { subprojectName ->
         dependsOn ":${subprojectName}:publishMavenPublicationToMavenCentralRepository"
         tasks.findByPath(":${subprojectName}:publishMavenPublicationToMavenCentralRepository").mustRunAfter(":releaseCheck")
-    }
-    subprojectNamesReleasedInBintray.each { subprojectName ->
-        dependsOn ":${subprojectName}:bintrayUpload"
-        tasks.findByPath(":${subprojectName}:bintrayUpload").mustRunAfter(":releaseCheck")
     }
     subprojectNamesOfStandardPlugins.each { subprojectName ->
         dependsOn ":${subprojectName}:publishMavenPublicationToMavenCentralRepository"


### PR DESCRIPTION
JFrog will be sunsetting Bintray and JCenter. New package versions submittion will close on March 31st, 2021. Serving packages from JCenter will terminate on February 1st, 2022.
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

Embulk has been migrating its distribution repository to Maven Central gradually, but it has not completed yet. `embulk-api` and `embulk-spi` have been released into Maven Central from their beginning, v0.10.2 and v0.10.7, respectively.

Along with standard plugins, which start to be released into Maven Central from this version v0.10.28, it's time to drop JCenter/Bintray, adn start releasing `embulk-core`, `embulk-deps`, and `embulk-junit4` into Maven Central!