### PR TITLE
Cleanup build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,17 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
         withSourcesJar()
     }
 
+    javadoc {
+        options {
+            locale = 'en_US'
+            encoding = 'UTF-8'
+            if (project.name == "embulk-api" || project.name == "embulk-spi" ) {
+                overview = "src/main/html/overview.html"
+                links "https://docs.oracle.com/javase/8/docs/api/"
+                links "https://www.javadoc.io/doc/org.slf4j/slf4j-api/1.7.30/"
+            }
+        }
+    }
 
     tasks.withType(Test) {
         systemProperties System.properties.findAll { it.key.startsWith("org.embulk") }
@@ -94,13 +105,6 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
         maxWarnings = 0  // https://github.com/gradle/gradle/issues/881
     }
 
-    javadoc {
-        options {
-            locale = 'en_US'
-            encoding = 'UTF-8'
-        }
-    }
-
     jar {
         manifest {
             attributes 'Implementation-Title': project.name,
@@ -115,15 +119,6 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
         from rootProject.file("LICENSE")
     }
 
-    if (project.name == "embulk-api" || project.name == "embulk-spi" ) {
-        javadoc {
-            options {
-                overview = "src/main/html/overview.html"
-                links "https://docs.oracle.com/javase/8/docs/api/"
-                links "https://www.javadoc.io/doc/org.slf4j/slf4j-api/1.7.30/"
-            }
-        }
-    }
 
     // embulk-core:tests need to be released because some plugins use embulk-core:tests for their testing.
     // TODO: Merge them into embulk-junit4 in some manner.

--- a/build.gradle
+++ b/build.gradle
@@ -132,23 +132,7 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
                        'Specification-Version': project.version
         }
     }
-}
 
-project(":embulk-core") {
-    // embulk-core:tests need to be released because some plugins use embulk-core:tests for their testing.
-    // TODO: Merge them into embulk-junit4 in some manner.
-
-    task testsJar(type: Jar, dependsOn: classes) {
-        classifier = 'tests'
-        from sourceSets.test.output
-    }
-
-    artifacts {
-        archives testsJar
-    }
-}
-
-configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name) }) {
     apply plugin: "signing"
 
     jar {
@@ -162,6 +146,19 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
                 links "https://docs.oracle.com/javase/8/docs/api/"
                 links "https://www.javadoc.io/doc/org.slf4j/slf4j-api/1.7.30/"
             }
+        }
+    }
+
+    // embulk-core:tests need to be released because some plugins use embulk-core:tests for their testing.
+    // TODO: Merge them into embulk-junit4 in some manner.
+    if (project.name == "embulk-core") {
+        task testsJar(type: Jar, dependsOn: classes) {
+            classifier = 'tests'
+            from sourceSets.test.output
+        }
+
+        artifacts {
+            archives testsJar
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,6 @@ plugins {
 }
 
 allprojects {  // Applies all projects including the root project as well.
-    apply plugin: 'java'
-
     group = 'org.embulk'
 
     sourceCompatibility = 1.8
@@ -52,6 +50,7 @@ def subprojectNamesOfStandardPlugins = [
 ]
 
 configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name) }) {
+    apply plugin: "java"
     apply plugin: "java-library"
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,9 @@ plugins {
     id "org.embulk.embulk-plugins" version "0.4.2" apply false
 }
 
+repositories {
+    mavenCentral()
+}
 
 group = "org.embulk"
 version = "0.10.28-SNAPSHOT"
@@ -222,10 +225,6 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
     signing {
         sign publishing.publications.maven
     }
-}
-
-repositories {
-    mavenCentral()
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'maven-publish'
-    // TODO: Enable SpotBugs instead of FindBugs which was used in Embulk until v0.9.17.
 
     group = rootProject.group
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,11 +50,11 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
     apply plugin: "signing"
 
     group = rootProject.group
+    version = rootProject.version
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 
-    version = "${rootProject.version}"
     tasks.withType(JavaCompile) {
         options.encoding = "UTF-8"
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id "org.embulk.embulk-plugins" version "0.4.2" apply false
 }
 
-allprojects {  // Applies all projects including the root project as well.
-    [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
-
-}
 
 group = "org.embulk"
 version = "0.10.28-SNAPSHOT"
@@ -58,15 +54,16 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
     targetCompatibility = 1.8
 
     version = "${rootProject.version}"
+    tasks.withType(JavaCompile) {
+        options.encoding = "UTF-8"
+        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+    }
 
     java {
         withJavadocJar()
         withSourcesJar()
     }
 
-    tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
-    }
 
     tasks.withType(Test) {
         systemProperties System.properties.findAll { it.key.startsWith("org.embulk") }

--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,6 @@ allprojects {  // Applies all projects including the root project as well.
 
 version = "0.10.28-SNAPSHOT"
 
-description = 'Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control.'
-
-ext {
-    summary = 'Embulk, a plugin-based parallel bulk data loader'
-}
-
 def subprojectNamesOfCoreArtifacts = [
     "embulk-api",
     "embulk-spi",

--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,6 @@ allprojects {  // Applies all projects including the root project as well.
 
     [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
-    test {
-        maxHeapSize = '1536m'
-        forkEvery = 1  // test processes are forked by each test class (default is 0)
-    }
 }
 
 version = "0.10.28-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -7,17 +7,6 @@ plugins {
     id "org.embulk.embulk-plugins" version "0.4.2" apply false
 }
 
-def getRevision = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        workingDir "${rootDir}"
-        commandLine "git", "rev-parse", "HEAD"
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
-}
-def revision = getRevision()
-
 allprojects {  // Applies all projects including the root project as well.
     apply plugin: 'java'
 
@@ -80,7 +69,6 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
     // TODO: Enable SpotBugs instead of FindBugs which was used in Embulk until v0.9.17.
 
     version = "${rootProject.version}"
-    project.ext.setProperty("revision", revision)
 
     java {
         withJavadocJar()

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,6 @@ plugins {
 
 allprojects {  // Applies all projects including the root project as well.
     group = 'org.embulk'
-
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
-
     [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 }
@@ -56,6 +52,9 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
     apply plugin: 'jacoco'
     apply plugin: 'maven-publish'
     // TODO: Enable SpotBugs instead of FindBugs which was used in Embulk until v0.9.17.
+
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     version = "${rootProject.version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'maven-publish'
+    apply plugin: "signing"
 
     group = rootProject.group
 
@@ -106,8 +107,6 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
                        'Specification-Version': project.version
         }
     }
-
-    apply plugin: "signing"
 
     jar {
         from rootProject.file("LICENSE")

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,11 @@ plugins {
 }
 
 allprojects {  // Applies all projects including the root project as well.
-    group = 'org.embulk'
     [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 }
 
+group = "org.embulk"
 version = "0.10.28-SNAPSHOT"
 
 def subprojectNamesOfCoreArtifacts = [
@@ -52,6 +52,8 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
     apply plugin: 'jacoco'
     apply plugin: 'maven-publish'
     // TODO: Enable SpotBugs instead of FindBugs which was used in Embulk until v0.9.17.
+
+    group = rootProject.group
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -1,8 +1,4 @@
-// TODO: Have more details in description and summary.
-description = 'Embulk core'
-ext {
-    summary = 'Embulk core'
-}
+description = "The core classes of Embulk, a pluggable multi-source/destination bulk data loader."
 
 configurations {
     compileClasspath.resolutionStrategy.activateDependencyLocking()

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -1,12 +1,12 @@
 description = "The core classes of Embulk, a pluggable multi-source/destination bulk data loader."
 
+repositories {
+    mavenCentral()
+}
+
 configurations {
     compileClasspath.resolutionStrategy.activateDependencyLocking()
     runtimeClasspath.resolutionStrategy.activateDependencyLocking()
-}
-
-repositories {
-    mavenCentral()
 }
 
 // determine which dependencies have updates: $ gradle dependencyUpdates

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -44,7 +44,11 @@ dependencies {
     testImplementation project(":embulk-deps")
 }
 
-test.dependsOn([":test-helpers:deploy"])
+test {
+    dependsOn ":test-helpers:deploy"
+    maxHeapSize = "1536m"
+    forkEvery = 1  // test processes are forked by each test class (default is 0)
+}
 
 import java.util.zip.ZipFile
 task updateResources(dependsOn: 'prepareDependencyJars') {

--- a/embulk-deps/build.gradle
+++ b/embulk-deps/build.gradle
@@ -1,7 +1,4 @@
-description = "Embulk core's hidden dependencies."
-ext {
-    summary = "Embulk core's hidden dependencies."
-}
+description = "Dependencies of Embulk to be loaded behind an inner class loader."
 
 repositories {
     mavenCentral()

--- a/embulk-guess-csv/build.gradle
+++ b/embulk-guess-csv/build.gradle
@@ -139,6 +139,8 @@ signing {
 }
 
 test {
+    maxHeapSize = "1536m"
+    forkEvery = 1  // test processes are forked by each test class (default is 0)
     testLogging {
         outputs.upToDateWhen { false }
         showStandardStreams = true

--- a/embulk-guess-csv_all_strings/build.gradle
+++ b/embulk-guess-csv_all_strings/build.gradle
@@ -137,6 +137,8 @@ signing {
 }
 
 test {
+    maxHeapSize = "1536m"
+    forkEvery = 1  // test processes are forked by each test class (default is 0)
     testLogging {
         outputs.upToDateWhen { false }
         showStandardStreams = true

--- a/embulk-junit4/build.gradle
+++ b/embulk-junit4/build.gradle
@@ -1,4 +1,4 @@
-description = "A test helper for Embulk plugins with JUnit 4"
+description = "A test helper for Embulk plugins with JUnit 4."
 
 repositories {
     mavenCentral()

--- a/embulk-parser-csv/build.gradle
+++ b/embulk-parser-csv/build.gradle
@@ -171,6 +171,8 @@ signing {
 }
 
 test {
+    maxHeapSize = "1536m"
+    forkEvery = 1  // test processes are forked by each test class (default is 0)
     testLogging {
         outputs.upToDateWhen { false }
         showStandardStreams = true

--- a/embulk-parser-json/build.gradle
+++ b/embulk-parser-json/build.gradle
@@ -153,6 +153,8 @@ signing {
 }
 
 test {
+    maxHeapSize = "1536m"
+    forkEvery = 1  // test processes are forked by each test class (default is 0)
     testLogging {
         outputs.upToDateWhen { false }
         showStandardStreams = true

--- a/embulk-ruby/build.gradle
+++ b/embulk-ruby/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "java"
+
 String buildRubyStyleVersionFromJavaStyleVersion(String javaStyleVersion) {
     if (javaStyleVersion.contains("-")) {
         List<String> versionTokens = javaStyleVersion.tokenize("-");

--- a/embulk-ruby/build.gradle
+++ b/embulk-ruby/build.gradle
@@ -13,6 +13,7 @@ String buildRubyStyleVersionFromJavaStyleVersion(String javaStyleVersion) {
     }
 }
 
+group = rootProject.group
 version = rootProject.version
 ext.ruby_version = buildRubyStyleVersionFromJavaStyleVersion(version)
 

--- a/test-helpers/build.gradle
+++ b/test-helpers/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: "java"
 
+group = rootProject.group
+
 task deploy(dependsOn: ["deployJarsForEmbulkTestMavenPlugin"])
 
 /*

--- a/test-helpers/build.gradle
+++ b/test-helpers/build.gradle
@@ -1,6 +1,4 @@
-plugins {
-    id 'java'
-}
+apply plugin: "java"
 
 task deploy(dependsOn: ["deployJarsForEmbulkTestMavenPlugin"])
 


### PR DESCRIPTION
The build scripts (`build.gradle`) in the repository have been chaotic. It was partially because of the `bintray` Gradle plugin, but we now dropped JCenter/Bintray (#1401). It's time to cleanup `build.gradle` in the repository!

To be easier to review/trace, and not to make mistakes, this pull request consists of several Git commits for step-by-step changes.