### PR TITLE
Declare Buffer's constructor compatible with v0.9's

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/Buffer.java
+++ b/embulk-api/src/main/java/org/embulk/spi/Buffer.java
@@ -38,6 +38,11 @@ public abstract class Buffer {
     protected Buffer() {
     }
 
+    @Deprecated  // Declared only for embulk-util-file can refer this.
+    protected Buffer(final byte[] wrap, final int offset, final int capacity) {
+        this();
+    }
+
     /**
      * Returns the internal {@code byte} array of this {@link Buffer}.
      *


### PR DESCRIPTION
#1409 needs a fix in `embulk-util-file` to construct its `EmptyBuffer`.

`embulk-util-file:0.1.1`'s `EmptyBuffer` expects a constructor `Buffer()` without arguments.
* https://github.com/embulk/embulk-util-file/blob/v0.1.1/src/main/java/org/embulk/util/file/EmptyBuffer.java

But it's only in Embulk v0.10's `Buffer`.
* https://github.com/embulk/embulk/blob/v0.10.27/embulk-api/src/main/java/org/embulk/spi/Buffer.java

Embulk v0.9.23 did not have `Buffer()`, but `Buffer(byte[], int, int)`.
* https://github.com/embulk/embulk/blob/v0.9.23/embulk-core/src/main/java/org/embulk/spi/Buffer.java

It's the reason why `embulk-util-file` cannot initialize `EmptyBuffer` with Embulk v0.9.23 in #1409. This is one of the fixes for the problem. The other fix will be in `embulk-util-file`.