### PR TITLE
Duplicate ByteBuffer before loading an inner class/resource from self-contained JARs

### DIFF
--- a/embulk-core/src/main/java/org/embulk/deps/SelfContainedJarFile.java
+++ b/embulk-core/src/main/java/org/embulk/deps/SelfContainedJarFile.java
@@ -116,8 +116,7 @@ final class SelfContainedJarFile {
     }
 
     ByteBuffer getInnerResourcesBinary() {
-        // TODO: Call asReadOnlyBuffer or duplicate?
-        return this.innerResourcesBinary;
+        return this.innerResourcesBinary.asReadOnlyBuffer();
     }
 
     /**


### PR DESCRIPTION
This is a fix for #1408.

#1408 seems starting when loading the same resource in a self-contained JAR from mulitiple class loaders. It started happening when Embulk started to load self-contained plugin JARs in v0.10.26 by #1360.

It looks to be caused by the same `ByteBuffer` used multiple times. This PR fixes it by duplicating the `ByteBuffer` with `ByteBuffer#asReadOnlyBuffer`.
* https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html#asReadOnlyBuffer--