### PR TITLE
Set guess_sample_buffer_bytes and preview_sample_buffer_bytes from Embulk System Properties

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -79,7 +79,7 @@ public class EmbulkEmbed {
 
         this.bulkLoader = injector.getInstance(BulkLoader.class);
         this.guessExecutor = injector.getInstance(GuessExecutor.class);
-        this.previewExecutor = new PreviewExecutor();
+        this.previewExecutor = new PreviewExecutor(embulkSystemProperties);
     }
 
     public static class Bootstrap {

--- a/embulk-core/src/main/java/org/embulk/EmbulkSystemProperties.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkSystemProperties.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -61,6 +62,14 @@ public final class EmbulkSystemProperties extends Properties {
             return defaultValue;
         }
         return parseInteger(value);
+    }
+
+    public OptionalInt getPropertyAsOptionalInt(final String key) {
+        final String value = this.getProperty(key);
+        if (value == null) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(parseInteger(value));
     }
 
     @Override  // From Properties

--- a/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
@@ -149,7 +149,6 @@ public class GuessExecutor {
         guessPlugins.removeAll(task.getExcludeGuessPlugins());
         final int guessParserSampleBufferBytes =
                 task.getSampleBufferBytes().orElse(this.systemGuessSampleBufferBytes.orElse(DEAULT_SAMPLE_BUFFER_BYTES));
-        System.out.println(guessParserSampleBufferBytes);
 
         return guessParserConfig(sample, inputConfig, guessPlugins, guessParserSampleBufferBytes);
     }

--- a/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/PreviewExecutor.java
@@ -2,7 +2,9 @@ package org.embulk.exec;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalInt;
 import javax.validation.constraints.NotNull;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigSource;
@@ -52,11 +54,13 @@ public class PreviewExecutor {
 
     public interface PreviewExecutorTask extends Task {
         @Config("preview_sample_buffer_bytes")
-        @ConfigDefault("32768") // 32 * 1024
-        public int getSampleBufferBytes();
+        @ConfigDefault("null")
+        public OptionalInt getSampleBufferBytes();
     }
 
-    public PreviewExecutor() {}
+    public PreviewExecutor(final EmbulkSystemProperties embulkSystemProperties) {
+        this.embulkSystemProperties = embulkSystemProperties;
+    }
 
     public PreviewResult preview(ExecSessionInternal exec, final ConfigSource config) {
         try {
@@ -92,17 +96,22 @@ public class PreviewExecutor {
             Buffer sample = SamplingParserPlugin.runFileInputSampling(
                     (FileInputRunner) inputPlugin,
                     config.getNested("in"),
-                    createSampleBufferConfigFromExecConfig(task.getExecConfig()));
-            FileInputRunner previewRunner = new FileInputRunner(new BufferFileInputPlugin(sample));
+                    createSampleBufferConfigFromExecConfig(task.getExecConfig(), this.embulkSystemProperties));
+            FileInputRunner previewRunner = new FileInputRunner(new BufferFileInputPlugin(sample), this.embulkSystemProperties);
             return doPreview(task, previewRunner, filterPlugins);
         } else {
             return doPreview(task, inputPlugin, filterPlugins);
         }
     }
 
-    private static ConfigSource createSampleBufferConfigFromExecConfig(ConfigSource execConfig) {
+    private static ConfigSource createSampleBufferConfigFromExecConfig(
+            final ConfigSource execConfig, final EmbulkSystemProperties embulkSystemProperties) {
         final PreviewExecutorTask execTask = loadPreviewExecutorTask(execConfig);
-        return Exec.newConfigSource().set("sample_buffer_bytes", execTask.getSampleBufferBytes());
+        final OptionalInt systemPreviewSampleBufferBytes =
+                embulkSystemProperties.getPropertyAsOptionalInt("preview_sample_buffer_bytes");
+        return Exec.newConfigSource().set(
+                "sample_buffer_bytes",
+                execTask.getSampleBufferBytes().orElse(systemPreviewSampleBufferBytes.orElse(DEAULT_SAMPLE_BUFFER_BYTES)));
     }
 
     @SuppressWarnings("checkstyle:OverloadMethodsDeclarationOrder")
@@ -205,4 +214,8 @@ public class PreviewExecutor {
     }
 
     private static final Logger logger = LoggerFactory.getLogger(PreviewExecutor.class);
+
+    private static final int DEAULT_SAMPLE_BUFFER_BYTES = 32768;  // 32 * 1024
+
+    private final EmbulkSystemProperties embulkSystemProperties;
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/BuiltinPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/BuiltinPluginSource.java
@@ -3,6 +3,7 @@ package org.embulk.plugin;
 import com.google.inject.Injector;  // Only for instantiating a plugin.
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.spi.DecoderPlugin;
 import org.embulk.spi.EncoderPlugin;
 import org.embulk.spi.ExecutorPlugin;
@@ -20,6 +21,7 @@ import org.embulk.spi.ParserPlugin;
 public class BuiltinPluginSource implements PluginSource {
     private BuiltinPluginSource(
             final Injector injector,
+            final EmbulkSystemProperties embulkSystemProperties,
             final Map<String, Class<? extends DecoderPlugin>> decoderPlugins,
             final Map<String, Class<? extends EncoderPlugin>> encoderPlugins,
             final Map<String, Class<? extends ExecutorPlugin>> executorPlugins,
@@ -32,6 +34,7 @@ public class BuiltinPluginSource implements PluginSource {
             final Map<String, Class<? extends OutputPlugin>> outputPlugins,
             final Map<String, Class<? extends ParserPlugin>> parserPlugins) {
         this.injector = injector;
+        this.embulkSystemProperties = embulkSystemProperties;
         this.decoderPlugins = decoderPlugins;
         this.encoderPlugins = encoderPlugins;
         this.executorPlugins = executorPlugins;
@@ -146,9 +149,15 @@ public class BuiltinPluginSource implements PluginSource {
             return this;
         }
 
+        public Builder setEmbulkSystemProperties(final EmbulkSystemProperties embulkSystemProperties) {
+            this.embulkSystemProperties = embulkSystemProperties;
+            return this;
+        }
+
         public BuiltinPluginSource build() {
             return new BuiltinPluginSource(
                     this.injector,
+                    this.embulkSystemProperties,
                     this.decoderPlugins,
                     this.encoderPlugins,
                     this.executorPlugins,
@@ -174,6 +183,8 @@ public class BuiltinPluginSource implements PluginSource {
         private final LinkedHashMap<String, Class<? extends InputPlugin>> inputPlugins;
         private final LinkedHashMap<String, Class<? extends OutputPlugin>> outputPlugins;
         private final LinkedHashMap<String, Class<? extends ParserPlugin>> parserPlugins;
+
+        private EmbulkSystemProperties embulkSystemProperties;
     }
 
     public static Builder builder(final Injector injector) {
@@ -195,7 +206,8 @@ public class BuiltinPluginSource implements PluginSource {
             }
             final Class<? extends FileInputPlugin> fileInputPluginImpl = this.fileInputPlugins.get(name);
             if (fileInputPluginImpl != null) {
-                return pluginInterface.cast(new FileInputRunner((FileInputPlugin) this.injector.getInstance(fileInputPluginImpl)));
+                return pluginInterface.cast(new FileInputRunner(
+                        (FileInputPlugin) this.injector.getInstance(fileInputPluginImpl), this.embulkSystemProperties));
             }
         } else if (OutputPlugin.class.isAssignableFrom(pluginInterface)) {
             // Duplications between Output Plugins and File Output Plugins are rejected when registered above.
@@ -235,6 +247,7 @@ public class BuiltinPluginSource implements PluginSource {
     }
 
     private final Injector injector;
+    private final EmbulkSystemProperties embulkSystemProperties;
     private final Map<String, Class<? extends DecoderPlugin>> decoderPlugins;
     private final Map<String, Class<? extends EncoderPlugin>> encoderPlugins;
     private final Map<String, Class<? extends ExecutorPlugin>> executorPlugins;

--- a/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginSource.java
@@ -96,7 +96,7 @@ public class SelfContainedPluginSource implements PluginSource {
                             "[FATAL/INTERNAL] Plugin class \"" + pluginMainClass.getName() + "\" is not file-input.",
                             ex);
                 }
-                pluginMainObject = new FileInputRunner(fileInputPluginMainObject);
+                pluginMainObject = new FileInputRunner(fileInputPluginMainObject, this.embulkSystemProperties);
             } else if (FileOutputPlugin.class.isAssignableFrom(pluginMainClass)) {
                 final FileOutputPlugin fileOutputPluginMainObject;
                 try {

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
@@ -125,7 +125,7 @@ public class MavenPluginSource implements PluginSource {
                             "[FATAL/INTERNAL] Plugin class \"" + pluginMainClass.getName() + "\" is not file-input.",
                             ex);
                 }
-                pluginMainObject = new FileInputRunner(fileInputPluginMainObject);
+                pluginMainObject = new FileInputRunner(fileInputPluginMainObject, this.embulkSystemProperties);
             } else if (FileOutputPlugin.class.isAssignableFrom(pluginMainClass)) {
                 final FileOutputPlugin fileOutputPluginMainObject;
                 try {

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSessionInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSessionInternal.java
@@ -151,6 +151,7 @@ public class ExecSessionInternal extends ExecSession {
 
         public Builder setEmbulkSystemProperties(final EmbulkSystemProperties embulkSystemProperties) {
             this.embulkSystemProperties = embulkSystemProperties;
+            this.builtinPluginSourceBuilder.setEmbulkSystemProperties(embulkSystemProperties);
             return this;
         }
 

--- a/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
@@ -4,6 +4,7 @@ import static org.embulk.exec.GuessExecutor.createSampleBufferConfigFromExecConf
 
 import java.util.ArrayList;
 import java.util.List;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -19,9 +20,11 @@ import org.embulk.spi.util.DecodersInternal;
 
 public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugin {
     private final FileInputPlugin fileInputPlugin;
+    private final EmbulkSystemProperties embulkSystemProperties;
 
-    public FileInputRunner(FileInputPlugin fileInputPlugin) {
+    public FileInputRunner(final FileInputPlugin fileInputPlugin, final EmbulkSystemProperties embulkSystemProperties) {
         this.fileInputPlugin = fileInputPlugin;
+        this.embulkSystemProperties = embulkSystemProperties;
     }
 
     private interface RunnerTask extends Task {
@@ -75,7 +78,8 @@ public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugi
     }
 
     public ConfigDiff guess(ConfigSource execConfig, ConfigSource inputConfig) {
-        final ConfigSource sampleBufferConfig = createSampleBufferConfigFromExecConfig(execConfig);
+        final ConfigSource sampleBufferConfig = createSampleBufferConfigFromExecConfig(
+                execConfig, this.embulkSystemProperties);
         final Buffer sample = SamplingParserPlugin.runFileInputSampling(this, inputConfig, sampleBufferConfig);
         // SamplingParserPlugin.runFileInputSampling throws NoSampleException if there're
         // no files or all files are smaller than minSampleSize (40 bytes).

--- a/embulk-core/src/test/java/org/embulk/spi/TestFileInputRunner.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestFileInputRunner.java
@@ -9,7 +9,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Properties;
 import java.util.Queue;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
@@ -94,7 +96,7 @@ public class TestFileInputRunner {
                 runtime.getBufferAllocator().allocate() };
         MockFileInputPlugin fileInputPlugin = new MockFileInputPlugin(
                 new LinkedList<Buffer>(Arrays.asList(buffers)));
-        final FileInputRunner runner = new FileInputRunner(fileInputPlugin);
+        final FileInputRunner runner = new FileInputRunner(fileInputPlugin, EmbulkSystemProperties.of(new Properties()));
 
         ConfigSource config = Exec.newConfigSource().set(
                 "parser",
@@ -143,7 +145,7 @@ public class TestFileInputRunner {
                 runtime.getBufferAllocator().allocate() };
         MockFileInputPlugin fileInputPlugin = new MockFileInputPlugin(
                 new LinkedList<Buffer>(Arrays.asList(buffers)));
-        final FileInputRunner runner = new FileInputRunner(fileInputPlugin);
+        final FileInputRunner runner = new FileInputRunner(fileInputPlugin, EmbulkSystemProperties.of(new Properties()));
 
         ConfigSource config = Exec.newConfigSource().set(
                 "parser",


### PR DESCRIPTION
`guess_sample_buffer_bytes` and `preview_sample_buffer_bytes` are 32KB by default, and they could be too small as of the age of 2020s.

But, a decision to increase the default values is not easy. For instance, if users are reading just a local file, incrasing the default value does ot have any serious impact. But for another example, some users read files from S3. AWS charges for a size of S3 read. Updating the default value can affect such users silently.

As a better workaround than setting `exec: guess_sample_buffer_bytes: 32768` in every Embulk configuration, this change is to make it available to set their default values from Embulk System Properties, which could be configured from auto-loaded `.embulk/embulk.properties` (since v0.10.21).