### PR TITLE
Fix the mix-up of command line options -L and -I (Fix #1413)

### DIFF
--- a/embulk-deps/src/main/java/org/embulk/deps/cli/CommandLineImpl.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/cli/CommandLineImpl.java
@@ -338,15 +338,15 @@ final class CommandLineImpl extends org.embulk.cli.CommandLine {
             }
         } else if (LOAD.getOpt().equals(option.getOpt())) {  // -L
             final String oldValue = properties.getProperty("jruby_load_path");
-            final String newValue = option.getValue();
+            final String newValue = Paths.get(option.getValue()).resolve("lib").toString();
             if (oldValue == null || oldValue.isEmpty()) {
                 properties.setProperty("jruby_load_path", newValue);
             } else {
                 properties.setProperty("jruby_load_path", oldValue + java.io.File.pathSeparator + newValue);
             }
         } else if (LOAD_PATH.getOpt().equals(option.getOpt())) {  // -I
-            final String newValue = Paths.get(option.getValue()).resolve("lib").toString();
             final String oldValue = properties.getProperty("jruby_load_path");
+            final String newValue = option.getValue();
             if (oldValue == null || oldValue.isEmpty()) {
                 properties.setProperty("jruby_load_path", newValue);
             } else {

--- a/embulk-deps/src/test/java/org/embulk/deps/cli/TestCommandLineParserImpl.java
+++ b/embulk-deps/src/test/java/org/embulk/deps/cli/TestCommandLineParserImpl.java
@@ -24,10 +24,10 @@ public class TestCommandLineParserImpl {
                 "-Xjruby=file:///some/jruby.jar",
                 "-X", "bar=baz",
                 "run",
-                "-I", "test",
+                "-L", "test",
                 "-R", "bar",
                 "file3.yml",
-                "-L", "example");
+                "-I", "example");
 
         assertEquals(Command.RUN, commandLine.getCommand());
 


### PR DESCRIPTION
We have had a bug in command line parsing -- `-L` and `-I` have been mixed up. (#1413)