### PR TITLE
Dump actual diffs in "decoders" and "parser" in embulk-guess-csv_verify

### DIFF
--- a/embulk-guess-csv_verify/build.gradle
+++ b/embulk-guess-csv_verify/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 group = "${rootProject.group}"
 version = "${rootProject.version}"
-description = "Verification-purpose Embulk CSV guess plugin to compare the old Ruby-based one and the new Java-based one (not for your production use)"
+description = "Verification-purpose Embulk CSV guess plugin to compare the old Ruby-based one and the new Java-based one (not for your production use; note that 'decoders' and 'parser' sections in your configuration can be logged even if they contain confidential information)"
 
 dependencies {
     compile project(":embulk-guess-csv")


### PR DESCRIPTION
`embulk-guess-csv-verify` (#1415) originally dumped only different key names, without actual diffs, in order to avoid logging confidential information (e.g. AWS access token) unintentionally.

But, actual diffs are really helpful to investigate. This PR is to dump actual diffs of `decoders` and `parser` sections because those sections should not have any confidential information.