### PR TITLE
Manage ModelManager out of Guice

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
@@ -436,16 +436,14 @@ public class EmbulkRunner {
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     private String dumpDataSourceInYaml(final DataSource modelObject) {
-        final org.embulk.config.ModelManager modelManager = this.embed.getModelManager();
-        final Object object = modelManager.readObject(Object.class, modelManager.writeObject(modelObject));
+        final Object object = this.embed.dumpObjectFromDataSource(modelObject);
         final YamlProcessor yamlProc = YamlProcessor.create(false);
         return yamlProc.dump(object);
     }
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     private String dumpResumeStateInYaml(final ResumeState modelObject) {
-        final org.embulk.config.ModelManager modelManager = this.embed.getModelManager();
-        final Object object = modelManager.readObject(Object.class, modelManager.writeObject(modelObject));
+        final Object object = this.embed.dumpObjectFromResumeState(modelObject);
         final YamlProcessor yamlProc = YamlProcessor.create(false);
         return yamlProc.dump(object);
     }

--- a/embulk-core/src/main/java/org/embulk/config/ConfigLoader.java
+++ b/embulk-core/src/main/java/org/embulk/config/ConfigLoader.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
-import com.google.inject.Inject;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -20,7 +19,6 @@ public class ConfigLoader {
     @Deprecated  // https://github.com/embulk/embulk/issues/1304
     private final ModelManager model;
 
-    @Inject
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     public ConfigLoader(ModelManager model) {
         this.model = model;

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -42,11 +42,11 @@ public class ExecModule implements Module {
         // TODO: Remove this ILoggerFactory binding.
         binder.bind(ILoggerFactory.class).toProvider(LoggerProvider.class).in(Scopes.SINGLETON);
 
-        binder.bind(org.embulk.config.ModelManager.class).in(Scopes.SINGLETON);
         binder.bind(BufferAllocator.class).toInstance(this.createBufferAllocatorFromSystemConfig());
         binder.bind(TempFileSpaceAllocator.class).toInstance(new SimpleTempFileSpaceAllocator());
 
-        // SerDe
+        // TODO: Remove the ObjectMapperModule Guice module.
+        // They should be no longer required once ModelManager is managed in ExecSessionInternal.
         final ObjectMapperModule mapper = new ObjectMapperModule();
         mapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
         mapper.registerModule(new CharsetJacksonModule());

--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyInitializer.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyInitializer.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import org.embulk.EmbulkSystemProperties;
 import org.embulk.spi.BufferAllocator;
+import org.embulk.spi.ExecInternal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -281,7 +282,7 @@ final class JRubyInitializer {
             final ScriptingContainerDelegate jruby,
             final Object injected,
             final Injector injector) {
-        jruby.callMethod(injected, "const_set", "ModelManager", injector.getInstance(org.embulk.config.ModelManager.class));
+        jruby.callMethod(injected, "const_set", "ModelManager", ExecInternal.getModelManager());
     }
 
     private final boolean isEmbulkSpecific;

--- a/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
+++ b/embulk-core/src/main/java/org/embulk/jruby/JRubyScriptingModule.java
@@ -46,11 +46,9 @@ public class JRubyScriptingModule implements Module {
         }
 
         @Override  // from |com.google.inject.spi.HasDependencies|
-        @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
         public Set<Dependency<?>> getDependencies() {
             // get() depends on other modules
             final HashSet<Dependency<?>> built = new HashSet<>();
-            built.add(Dependency.get(Key.get(org.embulk.config.ModelManager.class)));
             built.add(Dependency.get(Key.get(BufferAllocator.class)));
             return Collections.unmodifiableSet(built);
         }

--- a/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
+++ b/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
@@ -1,5 +1,8 @@
 package org.embulk;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -16,11 +19,19 @@ import org.embulk.jruby.JRubyScriptingModule;
 import org.embulk.plugin.PluginClassLoaderFactory;
 import org.embulk.plugin.PluginClassLoaderFactoryImpl;
 import org.embulk.spi.BufferAllocator;
+import org.embulk.spi.ColumnJacksonModule;
 import org.embulk.spi.ExecAction;
 import org.embulk.spi.ExecInternal;
 import org.embulk.spi.ExecSessionInternal;
 import org.embulk.spi.MockFormatterPlugin;
 import org.embulk.spi.MockParserPlugin;
+import org.embulk.spi.SchemaJacksonModule;
+import org.embulk.spi.time.TimestampJacksonModule;
+import org.embulk.spi.type.TypeJacksonModule;
+import org.embulk.spi.unit.LocalFileJacksonModule;
+import org.embulk.spi.unit.ToStringJacksonModule;
+import org.embulk.spi.unit.ToStringMapJacksonModule;
+import org.embulk.spi.util.CharsetJacksonModule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
@@ -42,9 +53,11 @@ public class EmbulkTestRuntime extends GuiceBinder {
     public EmbulkTestRuntime() {
         super(new TestRuntimeModule());
         Injector injector = getInjector();
-        ConfigSource execConfig = new DataSourceImpl(injector.getInstance(ModelManager.class));
+        final ModelManager model = createModelManager(injector);
+        ConfigSource execConfig = new DataSourceImpl(model);
         this.exec = ExecSessionInternal.builderInternal(injector)
                 .fromExecConfig(execConfig)
+                .setModelManager(model)
                 .registerParserPlugin("mock", MockParserPlugin.class)
                 .registerFormatterPlugin("mock", MockFormatterPlugin.class)
                 .build();
@@ -58,8 +71,9 @@ public class EmbulkTestRuntime extends GuiceBinder {
         return getInstance(BufferAllocator.class);
     }
 
+    @SuppressWarnings("deprecation")
     public ModelManager getModelManager() {
-        return getInstance(ModelManager.class);
+        return this.exec.getModelManager();
     }
 
     public Random getRandom() {
@@ -99,5 +113,21 @@ public class EmbulkTestRuntime extends GuiceBinder {
         public RuntimeExecutionException(Throwable cause) {
             super(cause);
         }
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
+    private static org.embulk.config.ModelManager createModelManager(final Injector injector) {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
+        mapper.registerModule(new CharsetJacksonModule());
+        mapper.registerModule(new LocalFileJacksonModule());
+        mapper.registerModule(new ToStringJacksonModule());
+        mapper.registerModule(new ToStringMapJacksonModule());
+        mapper.registerModule(new TypeJacksonModule());
+        mapper.registerModule(new ColumnJacksonModule());
+        mapper.registerModule(new SchemaJacksonModule());
+        mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
+        mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
+        return new org.embulk.config.ModelManager(injector, mapper);
     }
 }


### PR DESCRIPTION
This is one of the steps to hide Jackson from plugins behind `embulk-deps`.

`ModelManager` is a wrapper of Jackson `ObjectMapper` for `org.embulk.config.*`, and it has been strongly coupled with Guice and many contents included in the Guice Injector. The first step of `ModelManager` is to separate it from Guice.