### PR TITLE
Stop handling @ConfigInject

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -93,7 +93,7 @@ public class EmbulkEmbed {
         this.guessExecutor = injector.getInstance(GuessExecutor.class);
         this.previewExecutor = new PreviewExecutor();
 
-        this.modelManager = createModelManager(injector);
+        this.modelManager = createModelManager();
     }
 
     public static class Bootstrap {
@@ -546,7 +546,7 @@ public class EmbulkEmbed {
     }
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
-    private static org.embulk.config.ModelManager createModelManager(final Injector injector) {
+    private static org.embulk.config.ModelManager createModelManager() {
         final ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
         mapper.registerModule(new CharsetJacksonModule());
@@ -558,7 +558,7 @@ public class EmbulkEmbed {
         mapper.registerModule(new SchemaJacksonModule());
         mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
         mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
-        return new org.embulk.config.ModelManager(injector, mapper);
+        return new org.embulk.config.ModelManager(mapper);
     }
 
     // TODO: Remove them finally.

--- a/embulk-core/src/main/java/org/embulk/config/ConfigInject.java
+++ b/embulk-core/src/main/java/org/embulk/config/ConfigInject.java
@@ -6,6 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@Deprecated  // https://github.com/embulk/embulk/issues/1404
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/embulk-core/src/main/java/org/embulk/config/ModelManager.java
+++ b/embulk-core/src/main/java/org/embulk/config/ModelManager.java
@@ -4,21 +4,16 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.inject.Inject;
-import com.google.inject.Injector;
 import javax.validation.Validation;
 import org.apache.bval.jsr303.ApacheValidationProvider;
 
 @Deprecated  // https://github.com/embulk/embulk/issues/1304
 public class ModelManager {
-    private final Injector injector;
     private final ObjectMapper objectMapper;
     private final ObjectMapper configObjectMapper;  // configObjectMapper uses different TaskDeserializer
     private final TaskValidator taskValidator;
 
-    @Inject
-    public ModelManager(Injector injector, ObjectMapper objectMapper) {
-        this.injector = injector;
+    public ModelManager(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
         this.configObjectMapper = objectMapper.copy();
         this.taskValidator = new TaskValidator(
@@ -121,11 +116,5 @@ public class ModelManager {
             }
             throw new RuntimeException(ex);
         }
-    }
-
-    // visible for TaskSerDe.set
-    // TODO create annotation calss and get its instance at the 2nd argument
-    <T> T getInjectedInstance(Class<T> type) {
-        return injector.getInstance(type);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/config/TaskInvocationHandler.java
+++ b/embulk-core/src/main/java/org/embulk/config/TaskInvocationHandler.java
@@ -9,7 +9,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 class TaskInvocationHandler implements InvocationHandler {
     @Deprecated  // https://github.com/embulk/embulk/issues/1304
@@ -17,14 +16,12 @@ class TaskInvocationHandler implements InvocationHandler {
 
     private final Class<?> iface;
     private final Map<String, Object> objects;
-    private final Set<String> injectedFields;
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
-    public TaskInvocationHandler(ModelManager model, Class<?> iface, Map<String, Object> objects, Set<String> injectedFields) {
+    public TaskInvocationHandler(ModelManager model, Class<?> iface, Map<String, Object> objects) {
         this.model = model;
         this.iface = iface;
         this.objects = objects;
-        this.injectedFields = injectedFields;
     }
 
     /**
@@ -51,11 +48,6 @@ class TaskInvocationHandler implements InvocationHandler {
         return objects;
     }
 
-    // visible for ModelManager.AccessorSerializer
-    Set<String> getInjectedFields() {
-        return injectedFields;
-    }
-
     protected Object invokeGetter(Method method, String fieldName) {
         return objects.get(fieldName);
     }
@@ -69,11 +61,7 @@ class TaskInvocationHandler implements InvocationHandler {
     }
 
     private Map<String, Object> getSerializableFields() {
-        Map<String, Object> data = new HashMap<String, Object>(objects);
-        for (String injected : injectedFields) {
-            data.remove(injected);
-        }
-        return data;
+        return new HashMap<String, Object>(objects);
     }
 
     protected TaskSource invokeDump() {

--- a/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
+++ b/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
@@ -53,7 +53,7 @@ public class EmbulkTestRuntime extends GuiceBinder {
     public EmbulkTestRuntime() {
         super(new TestRuntimeModule());
         Injector injector = getInjector();
-        final ModelManager model = createModelManager(injector);
+        final ModelManager model = createModelManager();
         ConfigSource execConfig = new DataSourceImpl(model);
         this.exec = ExecSessionInternal.builderInternal(injector)
                 .fromExecConfig(execConfig)
@@ -116,7 +116,7 @@ public class EmbulkTestRuntime extends GuiceBinder {
     }
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
-    private static org.embulk.config.ModelManager createModelManager(final Injector injector) {
+    private static org.embulk.config.ModelManager createModelManager() {
         final ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
         mapper.registerModule(new CharsetJacksonModule());
@@ -128,6 +128,6 @@ public class EmbulkTestRuntime extends GuiceBinder {
         mapper.registerModule(new SchemaJacksonModule());
         mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
         mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
-        return new org.embulk.config.ModelManager(injector, mapper);
+        return new org.embulk.config.ModelManager(mapper);
     }
 }

--- a/embulk-core/src/test/java/org/embulk/config/TestConfigLoader.java
+++ b/embulk-core/src/test/java/org/embulk/config/TestConfigLoader.java
@@ -16,7 +16,7 @@ public class TestConfigLoader {
 
     @Before
     public void setup() throws Exception {
-        this.loader = new ConfigLoader(new ModelManager(null, new ObjectMapper()));
+        this.loader = new ConfigLoader(new ModelManager(new ObjectMapper()));
     }
 
     @Test

--- a/embulk-junit4/src/main/java/org/embulk/test/EmbulkTests.java
+++ b/embulk-junit4/src/main/java/org/embulk/test/EmbulkTests.java
@@ -28,7 +28,7 @@ public class EmbulkTests {
         String path = System.getenv(envName);
         assumeThat(isNullOrEmpty(path), is(false));
         try {
-            return new ConfigLoader(new ModelManager(null, new ObjectMapper())).fromYamlFile(new File(path));
+            return new ConfigLoader(new ModelManager(new ObjectMapper())).fromYamlFile(new File(path));
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }


### PR DESCRIPTION
`@ConfigInject` has been like `@Config` in plugin `Task`, but assigned a value from the Guice injector, not from the config. As explained in https://dev.embulk.org/topics/catchup-with-v0.10.html, it is removed.

Typical use-cases were `BufferAllocator` and `ScriptingContainer` (JRuby) like below.

```
interface PluginTask extends Task {
    @Config("someConfig")
    String getSomeConfig();

    @ConfigInject
    BufferAllocator getBufferAllocator();

    @ConfigInject
    ScriptingContainer getJRuby();
}
```

`BufferAllocator` can be now retrieved by `Exec.getBufferAllocator()`. JRuby `ScriptingContainer` is no longer available for plugins.