### PR TITLE
Register Jackson Modules inside ModelManager

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -1,8 +1,5 @@
 package org.embulk;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -20,18 +17,10 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
-import org.embulk.config.CharsetJacksonModule;
-import org.embulk.config.ColumnJacksonModule;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigLoader;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.DataSource;
-import org.embulk.config.LocalFileJacksonModule;
-import org.embulk.config.SchemaJacksonModule;
-import org.embulk.config.TimestampJacksonModule;
-import org.embulk.config.ToStringJacksonModule;
-import org.embulk.config.ToStringMapJacksonModule;
-import org.embulk.config.TypeJacksonModule;
 import org.embulk.exec.BulkLoader;
 import org.embulk.exec.ExecModule;
 import org.embulk.exec.ExecutionResult;
@@ -547,18 +536,7 @@ public class EmbulkEmbed {
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     private static org.embulk.config.ModelManager createModelManager() {
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
-        mapper.registerModule(new CharsetJacksonModule());
-        mapper.registerModule(new LocalFileJacksonModule());
-        mapper.registerModule(new ToStringJacksonModule());
-        mapper.registerModule(new ToStringMapJacksonModule());
-        mapper.registerModule(new TypeJacksonModule());
-        mapper.registerModule(new ColumnJacksonModule());
-        mapper.registerModule(new SchemaJacksonModule());
-        mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
-        mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
-        return new org.embulk.config.ModelManager(mapper);
+        return new org.embulk.config.ModelManager();
     }
 
     // TODO: Remove them finally.

--- a/embulk-core/src/main/java/org/embulk/config/ModelManager.java
+++ b/embulk-core/src/main/java/org/embulk/config/ModelManager.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import javax.validation.Validation;
 import org.apache.bval.jsr303.ApacheValidationProvider;
 
@@ -13,8 +15,18 @@ public class ModelManager {
     private final ObjectMapper configObjectMapper;  // configObjectMapper uses different TaskDeserializer
     private final TaskValidator taskValidator;
 
-    public ModelManager(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+    public ModelManager() {
+        this.objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
+        objectMapper.registerModule(new CharsetJacksonModule());
+        objectMapper.registerModule(new LocalFileJacksonModule());
+        objectMapper.registerModule(new ToStringJacksonModule());
+        objectMapper.registerModule(new ToStringMapJacksonModule());
+        objectMapper.registerModule(new TypeJacksonModule());
+        objectMapper.registerModule(new ColumnJacksonModule());
+        objectMapper.registerModule(new SchemaJacksonModule());
+        objectMapper.registerModule(new GuavaModule());  // jackson-datatype-guava
+        objectMapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
         this.configObjectMapper = objectMapper.copy();
         this.taskValidator = new TaskValidator(
                 Validation.byProvider(ApacheValidationProvider.class).configure().buildValidatorFactory().getValidator());

--- a/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecModule.java
@@ -1,8 +1,5 @@
 package org.embulk.exec;
 
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.module.guice.ObjectMapperModule;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -11,14 +8,6 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.embulk.EmbulkSystemProperties;
-import org.embulk.config.CharsetJacksonModule;
-import org.embulk.config.ColumnJacksonModule;
-import org.embulk.config.LocalFileJacksonModule;
-import org.embulk.config.SchemaJacksonModule;
-import org.embulk.config.TimestampJacksonModule;
-import org.embulk.config.ToStringJacksonModule;
-import org.embulk.config.ToStringMapJacksonModule;
-import org.embulk.config.TypeJacksonModule;
 import org.embulk.deps.buffer.PooledBufferAllocator;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.TempFileSpaceAllocator;
@@ -44,21 +33,6 @@ public class ExecModule implements Module {
 
         binder.bind(BufferAllocator.class).toInstance(this.createBufferAllocatorFromSystemConfig());
         binder.bind(TempFileSpaceAllocator.class).toInstance(new SimpleTempFileSpaceAllocator());
-
-        // TODO: Remove the ObjectMapperModule Guice module.
-        // They should be no longer required once ModelManager is managed in ExecSessionInternal.
-        final ObjectMapperModule mapper = new ObjectMapperModule();
-        mapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
-        mapper.registerModule(new CharsetJacksonModule());
-        mapper.registerModule(new LocalFileJacksonModule());
-        mapper.registerModule(new ToStringJacksonModule());
-        mapper.registerModule(new ToStringMapJacksonModule());
-        mapper.registerModule(new TypeJacksonModule());
-        mapper.registerModule(new ColumnJacksonModule());
-        mapper.registerModule(new SchemaJacksonModule());
-        mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
-        mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
-        mapper.configure(binder);
     }
 
     private BufferAllocator createBufferAllocatorFromSystemConfig() {

--- a/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
+++ b/embulk-core/src/test/java/org/embulk/EmbulkTestRuntime.java
@@ -1,25 +1,14 @@
 package org.embulk;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import java.util.Properties;
 import java.util.Random;
 import org.embulk.EmbulkEmbed;
-import org.embulk.config.CharsetJacksonModule;
-import org.embulk.config.ColumnJacksonModule;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.DataSourceImpl;
-import org.embulk.config.LocalFileJacksonModule;
 import org.embulk.config.ModelManager;
-import org.embulk.config.SchemaJacksonModule;
-import org.embulk.config.TimestampJacksonModule;
-import org.embulk.config.ToStringJacksonModule;
-import org.embulk.config.ToStringMapJacksonModule;
-import org.embulk.config.TypeJacksonModule;
 import org.embulk.exec.ExecModule;
 import org.embulk.exec.ExtensionServiceLoaderModule;
 import org.embulk.exec.SystemConfigModule;
@@ -117,17 +106,6 @@ public class EmbulkTestRuntime extends GuiceBinder {
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     private static org.embulk.config.ModelManager createModelManager() {
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
-        mapper.registerModule(new CharsetJacksonModule());
-        mapper.registerModule(new LocalFileJacksonModule());
-        mapper.registerModule(new ToStringJacksonModule());
-        mapper.registerModule(new ToStringMapJacksonModule());
-        mapper.registerModule(new TypeJacksonModule());
-        mapper.registerModule(new ColumnJacksonModule());
-        mapper.registerModule(new SchemaJacksonModule());
-        mapper.registerModule(new GuavaModule());  // jackson-datatype-guava
-        mapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
-        return new org.embulk.config.ModelManager(mapper);
+        return new org.embulk.config.ModelManager();
     }
 }

--- a/embulk-core/src/test/java/org/embulk/config/TestConfigLoader.java
+++ b/embulk-core/src/test/java/org/embulk/config/TestConfigLoader.java
@@ -2,7 +2,6 @@ package org.embulk.config;
 
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,7 +15,7 @@ public class TestConfigLoader {
 
     @Before
     public void setup() throws Exception {
-        this.loader = new ConfigLoader(new ModelManager(new ObjectMapper()));
+        this.loader = new ConfigLoader(new ModelManager());
     }
 
     @Test

--- a/embulk-junit4/src/main/java/org/embulk/test/EmbulkTests.java
+++ b/embulk-junit4/src/main/java/org/embulk/test/EmbulkTests.java
@@ -6,7 +6,6 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assume.assumeThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 import java.io.File;
@@ -28,7 +27,7 @@ public class EmbulkTests {
         String path = System.getenv(envName);
         assumeThat(isNullOrEmpty(path), is(false));
         try {
-            return new ConfigLoader(new ModelManager(new ObjectMapper())).fromYamlFile(new File(path));
+            return new ConfigLoader(new ModelManager()).fromYamlFile(new File(path));
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }


### PR DESCRIPTION
As a preparation to move all Jackson Modules to `embulk-deps`, registering all Jackson Modules inside `org.embulk.config.ModelManager` to have references in a closed loop.