### PR TITLE
SerDe org.embulk.plugin.PluginType with a Jackson Module

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/ModelManager.java
+++ b/embulk-core/src/main/java/org/embulk/config/ModelManager.java
@@ -17,6 +17,7 @@ public class ModelManager {
 
     public ModelManager() {
         this.objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new PluginTypeJacksonModule());
         objectMapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
         objectMapper.registerModule(new CharsetJacksonModule());
         objectMapper.registerModule(new LocalFileJacksonModule());

--- a/embulk-core/src/main/java/org/embulk/config/PluginTypeJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/config/PluginTypeJacksonModule.java
@@ -1,0 +1,145 @@
+package org.embulk.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ContainerNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import org.embulk.plugin.DefaultPluginType;
+import org.embulk.plugin.MavenPluginType;
+import org.embulk.plugin.PluginSource;
+import org.embulk.plugin.PluginType;
+
+final class PluginTypeJacksonModule extends SimpleModule {
+    public PluginTypeJacksonModule() {
+        this.addSerializer(DefaultPluginType.class, new DefaultPluginTypeSerializer());
+        this.addSerializer(MavenPluginType.class, new MavenPluginTypeSerializer());
+        this.addDeserializer(PluginType.class, new PluginTypeDeserializer());
+    }
+
+    private static class DefaultPluginTypeSerializer extends JsonSerializer<DefaultPluginType> {
+        @Override
+        public void serialize(
+                final DefaultPluginType value, final JsonGenerator jsonGenerator, final SerializerProvider provider)
+                throws IOException {
+            jsonGenerator.writeString(value.getName());
+        }
+    }
+
+    private static class MavenPluginTypeSerializer extends JsonSerializer<MavenPluginType> {
+        @Override
+        public void serialize(
+                final MavenPluginType value, final JsonGenerator jsonGenerator, final SerializerProvider provider)
+                throws IOException {
+            final ObjectNode object = OBJECT_MAPPER.createObjectNode();
+            object.put("source", value.getSourceName());
+            object.put("name", value.getName());
+            if (value.getGroup() != null) {
+                object.put("group", value.getGroup());
+            }
+            if (value.getClassifier() != null) {
+                object.put("classifier", value.getClassifier());
+            }
+            if (value.getVersion() != null) {
+                object.put("version", value.getVersion());
+            }
+            jsonGenerator.writeTree(object);
+        }
+
+        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    }
+
+    private static class PluginTypeDeserializer extends JsonDeserializer<PluginType> {
+        @Override
+        public PluginType deserialize(
+                final JsonParser jsonParser,
+                final DeserializationContext context)
+                throws JsonMappingException {
+            final JsonNode typeJson;
+            try {
+                typeJson = OBJECT_MAPPER.readTree(jsonParser);
+            } catch (final JsonParseException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to parse JSON.", ex);
+            } catch (final JsonProcessingException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to process JSON in parsing.", ex);
+            } catch (final IOException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to read JSON in parsing.", ex);
+            }
+
+            if (typeJson.isTextual()) {
+                return createFromString(((TextNode) typeJson).textValue());
+            } else if (typeJson.isObject()) {
+                final HashMap<String, String> stringMap = new HashMap<String, String>();
+                final ObjectNode typeObject = (ObjectNode) typeJson;
+                final Iterator<Map.Entry<String, JsonNode>> fieldIterator = typeObject.fields();
+                while (fieldIterator.hasNext()) {
+                    final Map.Entry<String, JsonNode> field = fieldIterator.next();
+                    final JsonNode fieldValue = field.getValue();
+                    if (fieldValue instanceof ContainerNode) {
+                        throw new IllegalArgumentException("\"type\" must be a string or a 1-depth mapping.");
+                    }
+                    stringMap.put(field.getKey(), fieldValue.textValue());
+                }
+                return createFromStringMap(stringMap);
+            } else {
+                throw new IllegalArgumentException("\"type\" must be a string or a 1-depth mapping.");
+            }
+        }
+
+        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    }
+
+    private static PluginType createFromString(String name) {
+        if (name == null) {
+            throw new NullPointerException("name must not be null");
+        }
+        return DefaultPluginType.create(name);
+    }
+
+    private static PluginType createFromStringMap(Map<String, String> stringMap) {
+        final PluginSource.Type sourceType;
+        if (stringMap.containsKey("source")) {
+            sourceType = PluginSource.Type.of(stringMap.get("source"));
+        } else {
+            sourceType = PluginSource.Type.DEFAULT;
+        }
+
+        switch (sourceType) {
+            case DEFAULT: {
+                final String name = stringMap.get("name");
+                return createFromString(name);
+            }
+            case MAVEN: {
+                final String name = stringMap.get("name");
+                final String group = stringMap.get("group");
+                final String classifier = stringMap.get("classifier");
+                final String version = stringMap.get("version");
+                return MavenPluginType.create(name, group, classifier, version);
+            }
+            default:
+                throw new IllegalArgumentException("\"source\" must be one of: [\"default\", \"maven\"]");
+        }
+    }
+
+    static PluginType createFromStringForTesting(final String name) {
+        return createFromString(name);
+    }
+
+    static PluginType createFromStringMapForTesting(final Map<String, String> stringMap) {
+        return createFromStringMap(stringMap);
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/plugin/DefaultPluginType.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/DefaultPluginType.java
@@ -1,6 +1,5 @@
 package org.embulk.plugin;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Objects;
 
 public final class DefaultPluginType extends PluginType {
@@ -15,7 +14,6 @@ public final class DefaultPluginType extends PluginType {
         return new DefaultPluginType(name);
     }
 
-    @JsonValue
     public final String getJsonValue() {
         return this.getName();
     }

--- a/embulk-core/src/main/java/org/embulk/plugin/MavenPluginType.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/MavenPluginType.java
@@ -1,7 +1,5 @@
 package org.embulk.plugin;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -67,22 +65,18 @@ public final class MavenPluginType extends PluginType {
         return new MavenPluginType(parts[2], parts[1], null, parts[3]);
     }
 
-    @JsonValue
     public final Map<String, String> getJsonValue() {
         return this.fullMap;
     }
 
-    @JsonProperty("group")
     public final String getGroup() {
         return this.group;
     }
 
-    @JsonProperty("classifier")
     public final String getClassifier() {
         return this.classifier;
     }
 
-    @JsonProperty("version")
     public final String getVersion() {
         return this.version;
     }
@@ -110,7 +104,6 @@ public final class MavenPluginType extends PluginType {
                 && this.getVersion().equals(other.getVersion()));
     }
 
-    @JsonValue
     @Override
     public String toString() {
         return this.fullName;

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginType.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginType.java
@@ -1,16 +1,5 @@
 package org.embulk.plugin;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ContainerNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-import com.google.common.annotations.VisibleForTesting;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
 public abstract class PluginType {
     public static final PluginType LOCAL = DefaultPluginType.create("local");
 
@@ -24,80 +13,14 @@ public abstract class PluginType {
         this.name = name;
     }
 
-    @JsonCreator
-    private static PluginType create(final JsonNode typeJson) {
-        if (typeJson.isTextual()) {
-            return createFromString(((TextNode) typeJson).textValue());
-        } else if (typeJson.isObject()) {
-            final HashMap<String, String> stringMap = new HashMap<String, String>();
-            final ObjectNode typeObject = (ObjectNode) typeJson;
-            final Iterator<Map.Entry<String, JsonNode>> fieldIterator = typeObject.fields();
-            while (fieldIterator.hasNext()) {
-                final Map.Entry<String, JsonNode> field = fieldIterator.next();
-                final JsonNode fieldValue = field.getValue();
-                if (fieldValue instanceof ContainerNode) {
-                    throw new IllegalArgumentException("\"type\" must be a string or a 1-depth mapping.");
-                }
-                stringMap.put(field.getKey(), fieldValue.textValue());
-            }
-            return createFromStringMap(stringMap);
-        } else {
-            throw new IllegalArgumentException("\"type\" must be a string or a 1-depth mapping.");
-        }
-    }
-
-    private static PluginType createFromString(String name) {
-        if (name == null) {
-            throw new NullPointerException("name must not be null");
-        }
-        return DefaultPluginType.create(name);
-    }
-
-    private static PluginType createFromStringMap(Map<String, String> stringMap) {
-        final PluginSource.Type sourceType;
-        if (stringMap.containsKey("source")) {
-            sourceType = PluginSource.Type.of(stringMap.get("source"));
-        } else {
-            sourceType = PluginSource.Type.DEFAULT;
-        }
-
-        switch (sourceType) {
-            case DEFAULT: {
-                final String name = stringMap.get("name");
-                return createFromString(name);
-            }
-            case MAVEN: {
-                final String name = stringMap.get("name");
-                final String group = stringMap.get("group");
-                final String classifier = stringMap.get("classifier");
-                final String version = stringMap.get("version");
-                return MavenPluginType.create(name, group, classifier, version);
-            }
-            default:
-                throw new IllegalArgumentException("\"source\" must be one of: [\"default\", \"maven\"]");
-        }
-    }
-
-    @VisibleForTesting
-    static PluginType createFromStringForTesting(final String name) {
-        return createFromString(name);
-    }
-
-    @VisibleForTesting
-    static PluginType createFromStringMapForTesting(final Map<String, String> stringMap) {
-        return createFromStringMap(stringMap);
-    }
-
     public final PluginSource.Type getSourceType() {
         return sourceType;
     }
 
-    @JsonProperty("source")
     public final String getSourceName() {
         return sourceType.toString();
     }
 
-    @JsonProperty("name")
     public final String getName() {
         return name;
     }

--- a/embulk-core/src/test/java/org/embulk/config/TestPluginType.java
+++ b/embulk-core/src/test/java/org/embulk/config/TestPluginType.java
@@ -1,4 +1,4 @@
-package org.embulk.plugin;
+package org.embulk.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -9,18 +9,23 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 import java.util.Properties;
 import org.embulk.EmbulkSystemProperties;
+import org.embulk.plugin.DefaultPluginType;
+import org.embulk.plugin.MavenPluginType;
+import org.embulk.plugin.PluginSource;
+import org.embulk.plugin.PluginSourceNotMatchException;
+import org.embulk.plugin.PluginType;
 import org.junit.Test;
 
 public class TestPluginType {
     @Test
     public void testEquals() {
-        PluginType type = PluginType.createFromStringForTesting("a");
+        PluginType type = PluginTypeJacksonModule.createFromStringForTesting("a");
         assertTrue(type instanceof DefaultPluginType);
         assertEquals(PluginSource.Type.DEFAULT, type.getSourceType());
         assertTrue(type.equals(type));
 
-        assertTrue(type.equals(PluginType.createFromStringForTesting("a")));
-        assertFalse(type.equals(PluginType.createFromStringForTesting("b")));
+        assertTrue(type.equals(PluginTypeJacksonModule.createFromStringForTesting("a")));
+        assertFalse(type.equals(PluginTypeJacksonModule.createFromStringForTesting("b")));
     }
 
     @Test
@@ -29,13 +34,13 @@ public class TestPluginType {
         mapping.put("source", "default");
         mapping.put("name", "c");
 
-        PluginType type = PluginType.createFromStringMapForTesting(mapping);
+        PluginType type = PluginTypeJacksonModule.createFromStringMapForTesting(mapping);
         assertTrue(type instanceof DefaultPluginType);
         assertEquals(PluginSource.Type.DEFAULT, type.getSourceType());
         assertTrue(type.equals(type));
 
-        assertTrue(type.equals(PluginType.createFromStringForTesting("c")));
-        assertFalse(type.equals(PluginType.createFromStringForTesting("d")));
+        assertTrue(type.equals(PluginTypeJacksonModule.createFromStringForTesting("c")));
+        assertFalse(type.equals(PluginTypeJacksonModule.createFromStringForTesting("d")));
     }
 
     @Test
@@ -46,7 +51,7 @@ public class TestPluginType {
         mapping.put("group", "org.embulk.foobar");
         mapping.put("version", "0.1.2");
 
-        PluginType type = PluginType.createFromStringMapForTesting(mapping);
+        PluginType type = PluginTypeJacksonModule.createFromStringMapForTesting(mapping);
         assertTrue(type instanceof MavenPluginType);
         assertEquals(PluginSource.Type.MAVEN, type.getSourceType());
         MavenPluginType mavenType = (MavenPluginType) type;
@@ -67,7 +72,7 @@ public class TestPluginType {
         mapping.put("version", "0.1.2");
         mapping.put("classifier", "bar");
 
-        PluginType type = PluginType.createFromStringMapForTesting(mapping);
+        PluginType type = PluginTypeJacksonModule.createFromStringMapForTesting(mapping);
         assertTrue(type instanceof MavenPluginType);
         assertEquals(PluginSource.Type.MAVEN, type.getSourceType());
         MavenPluginType mavenType = (MavenPluginType) type;
@@ -81,7 +86,7 @@ public class TestPluginType {
 
     @Test
     public void testMavenFail1() {
-        final DefaultPluginType type = (DefaultPluginType) PluginType.createFromStringForTesting("qux");
+        final DefaultPluginType type = (DefaultPluginType) PluginTypeJacksonModule.createFromStringForTesting("qux");
 
         try {
             MavenPluginType.createFromDefaultPluginType("input", type, EmbulkSystemProperties.of(new Properties()));
@@ -94,7 +99,7 @@ public class TestPluginType {
 
     @Test
     public void testMavenFail2() {
-        final DefaultPluginType type = (DefaultPluginType) PluginType.createFromStringForTesting("foo");
+        final DefaultPluginType type = (DefaultPluginType) PluginTypeJacksonModule.createFromStringForTesting("foo");
 
         try {
             final Properties properties = new Properties();
@@ -110,7 +115,7 @@ public class TestPluginType {
 
     @Test
     public void testMavenFail3() {
-        final DefaultPluginType type = (DefaultPluginType) PluginType.createFromStringForTesting("test");
+        final DefaultPluginType type = (DefaultPluginType) PluginTypeJacksonModule.createFromStringForTesting("test");
 
         try {
             final Properties properties = new Properties();
@@ -126,7 +131,7 @@ public class TestPluginType {
 
     @Test
     public void testMaven() throws PluginSourceNotMatchException {
-        final DefaultPluginType type = (DefaultPluginType) PluginType.createFromStringForTesting("some");
+        final DefaultPluginType type = (DefaultPluginType) PluginTypeJacksonModule.createFromStringForTesting("some");
 
         final Properties properties1 = new Properties();
         properties1.setProperty("plugins.input.some", "maven:org.embulk.baz:some:0.2.3");

--- a/embulk-core/src/test/java/org/embulk/config/TestPluginTypeSerDe.java
+++ b/embulk-core/src/test/java/org/embulk/config/TestPluginTypeSerDe.java
@@ -1,12 +1,14 @@
-package org.embulk.plugin;
+package org.embulk.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import org.embulk.EmbulkTestRuntime;
+import org.embulk.plugin.DefaultPluginType;
+import org.embulk.plugin.MavenPluginType;
+import org.embulk.plugin.PluginSource;
+import org.embulk.plugin.PluginType;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -51,14 +53,9 @@ public class TestPluginTypeSerDe {
         assertEquals(mavenPluginType.getVersion(), "0.1.2");
         assertNull(mavenPluginType.getClassifier());
 
-        // Serializing MavenPluginType has been failing unintentionally.
-        try {
-            testRuntime.getModelManager().writeObject(pluginType);
-        } catch (final RuntimeException ex) {
-            assertTrue(ex.getCause() instanceof JsonMappingException);
-            return;
-        }
-        fail();
+        assertEquals(
+                "{\"source\":\"maven\",\"name\":\"foo\",\"group\":\"org.embulk.bar\",\"version\":\"0.1.2\"}",
+                testRuntime.getModelManager().writeObject(pluginType));
     }
 
     @Test
@@ -74,13 +71,8 @@ public class TestPluginTypeSerDe {
         assertEquals(mavenPluginType.getVersion(), "0.1.2");
         assertEquals(mavenPluginType.getClassifier(), "foo");
 
-        // Serializing MavenPluginType has been failing unintentionally.
-        try {
-            testRuntime.getModelManager().writeObject(pluginType);
-        } catch (final RuntimeException ex) {
-            assertTrue(ex.getCause() instanceof JsonMappingException);
-            return;
-        }
-        fail();
+        assertEquals(
+                "{\"source\":\"maven\",\"name\":\"foo\",\"group\":\"org.embulk.bar\",\"classifier\":\"foo\",\"version\":\"0.1.2\"}",
+                testRuntime.getModelManager().writeObject(pluginType));
     }
 }

--- a/embulk-core/src/test/java/org/embulk/plugin/TestPluginTypeSerDe.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/TestPluginTypeSerDe.java
@@ -3,7 +3,9 @@ package org.embulk.plugin;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import org.embulk.EmbulkTestRuntime;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,6 +22,8 @@ public class TestPluginTypeSerDe {
         assertTrue(pluginType instanceof DefaultPluginType);
         assertEquals(PluginSource.Type.DEFAULT, pluginType.getSourceType());
         assertEquals("file", pluginType.getName());
+
+        assertEquals("\"file\"", testRuntime.getModelManager().writeObject(pluginType));
     }
 
     @Test
@@ -30,6 +34,8 @@ public class TestPluginTypeSerDe {
         assertTrue(pluginType instanceof DefaultPluginType);
         assertEquals(PluginSource.Type.DEFAULT, pluginType.getSourceType());
         assertEquals("dummy", pluginType.getName());
+
+        assertEquals("\"dummy\"", testRuntime.getModelManager().writeObject(pluginType));
     }
 
     @Test
@@ -44,6 +50,15 @@ public class TestPluginTypeSerDe {
         assertEquals(mavenPluginType.getGroup(), "org.embulk.bar");
         assertEquals(mavenPluginType.getVersion(), "0.1.2");
         assertNull(mavenPluginType.getClassifier());
+
+        // Serializing MavenPluginType has been failing unintentionally.
+        try {
+            testRuntime.getModelManager().writeObject(pluginType);
+        } catch (final RuntimeException ex) {
+            assertTrue(ex.getCause() instanceof JsonMappingException);
+            return;
+        }
+        fail();
     }
 
     @Test
@@ -58,5 +73,14 @@ public class TestPluginTypeSerDe {
         assertEquals(mavenPluginType.getGroup(), "org.embulk.bar");
         assertEquals(mavenPluginType.getVersion(), "0.1.2");
         assertEquals(mavenPluginType.getClassifier(), "foo");
+
+        // Serializing MavenPluginType has been failing unintentionally.
+        try {
+            testRuntime.getModelManager().writeObject(pluginType);
+        } catch (final RuntimeException ex) {
+            assertTrue(ex.getCause() instanceof JsonMappingException);
+            return;
+        }
+        fail();
     }
 }


### PR DESCRIPTION
Several Embulk classes have had annotated with Jackson's annotations like `@JsonCreator`, `@JsonProperty`, and `@JsonValue`. To remove Jackson from `embulk-core`, those annotations need to be removed.

Instead of the annotations, the classes can still be serialized/deserialized by registering a Jackson Module to `ObjectMapper` with appropriate `JsonSerializer` and `JsonDeserializer` implemented. It works only for SerDe with `ModelManager`, though. (It won't work for arbitrary `ObjectMapper`, but we give it up. We haven't observed such a plugin so far.)

It is a replacement from annotations to a SerDe Module for `org.embulk.plugin.PluginType`.