### PR TITLE
SerDe org.embulk.spi.ColumnConfig and org.embulk.spi.SchemaConfig with Jackson Modules

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/ColumnConfigJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/config/ColumnConfigJacksonModule.java
@@ -1,0 +1,97 @@
+package org.embulk.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import org.embulk.config.ConfigException;
+import org.embulk.spi.ColumnConfig;
+import org.embulk.spi.type.Type;
+
+public final class ColumnConfigJacksonModule extends SimpleModule {
+    @SuppressWarnings("deprecation")  // For use of ModelManager
+    public ColumnConfigJacksonModule(final ModelManager model) {
+        this.addSerializer(ColumnConfig.class, new ColumnConfigSerializer(model));
+        this.addDeserializer(ColumnConfig.class, new ColumnConfigDeserializer(model));
+    }
+
+    private static class ColumnConfigSerializer extends JsonSerializer<ColumnConfig> {
+        @SuppressWarnings("deprecation")  // For use of ModelManager
+        ColumnConfigSerializer(final ModelManager model) {
+            this.model = model;
+        }
+
+        @Override
+        public void serialize(
+                final ColumnConfig value,
+                final JsonGenerator jsonGenerator,
+                final SerializerProvider provider)
+                throws IOException {
+            final ConfigSource option = value.getOption();
+            final ObjectNode object = model.writeObjectAsObjectNode(option);
+            object.put("name", value.getName());
+            object.put("type", value.getType().getName());
+            jsonGenerator.writeTree(object);
+        }
+
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
+        private final ModelManager model;
+    }
+
+    private static class ColumnConfigDeserializer extends JsonDeserializer<ColumnConfig> {
+        @SuppressWarnings("deprecation")  // For use of ModelManager
+        ColumnConfigDeserializer(final ModelManager model) {
+            this.model = model;
+        }
+
+        @Override
+        public ColumnConfig deserialize(
+                final JsonParser jsonParser,
+                final DeserializationContext context)
+                throws JsonMappingException {
+            final JsonNode node;
+            try {
+                node = OBJECT_MAPPER.readTree(jsonParser);
+            } catch (final JsonParseException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to parse JSON.", ex);
+            } catch (final JsonProcessingException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to process JSON in parsing.", ex);
+            } catch (final IOException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to read JSON in parsing.", ex);
+            }
+
+            if (!node.isObject()) {
+                throw new JsonMappingException("Expected object to deserialize ColumnConfig", jsonParser.getCurrentLocation());
+            }
+
+            try {
+                final ConfigSource config = (ConfigSource) new DataSourceImpl(model, (ObjectNode) node);
+
+                final String name = config.get(String.class, "name");
+                final Type type = config.get(Type.class, "type");
+                final ConfigSource option = config.deepCopy();
+                option.remove("name");
+                option.remove("type");
+
+                return new ColumnConfig(name, type, option);
+            } catch (final ConfigException ex) {
+                throw JsonMappingException.from(jsonParser, "Invalid object to deserialize ColumnConfig", ex);
+            }
+        }
+
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
+        private final ModelManager model;
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+}

--- a/embulk-core/src/main/java/org/embulk/config/ModelManager.java
+++ b/embulk-core/src/main/java/org/embulk/config/ModelManager.java
@@ -17,6 +17,8 @@ public class ModelManager {
 
     public ModelManager() {
         this.objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new ColumnConfigJacksonModule(this));
+        objectMapper.registerModule(new SchemaConfigJacksonModule(this));
         objectMapper.registerModule(new PluginTypeJacksonModule());
         objectMapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
         objectMapper.registerModule(new CharsetJacksonModule());

--- a/embulk-core/src/main/java/org/embulk/config/SchemaConfigJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/config/SchemaConfigJacksonModule.java
@@ -1,0 +1,95 @@
+package org.embulk.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import org.embulk.spi.ColumnConfig;
+import org.embulk.spi.SchemaConfig;
+
+public final class SchemaConfigJacksonModule extends SimpleModule {
+    @SuppressWarnings("deprecation")  // For use of ModelManager
+    public SchemaConfigJacksonModule(final ModelManager model) {
+        this.addSerializer(SchemaConfig.class, new SchemaConfigSerializer(model));
+        this.addDeserializer(SchemaConfig.class, new SchemaConfigDeserializer(model));
+    }
+
+    private static class SchemaConfigSerializer extends JsonSerializer<SchemaConfig> {
+        @SuppressWarnings("deprecation")  // For use of ModelManager
+        SchemaConfigSerializer(final ModelManager model) {
+            this.model = model;
+        }
+
+        @Override
+        public void serialize(
+                final SchemaConfig value,
+                final JsonGenerator jsonGenerator,
+                final SerializerProvider provider)
+                throws IOException {
+            final ArrayNode array = OBJECT_MAPPER.createArrayNode();
+
+            for (final ColumnConfig columnConfig : value.getColumns()) {
+                final ConfigSource option = columnConfig.getOption();
+                final ObjectNode object = this.model.writeObjectAsObjectNode(option);
+                object.put("name", columnConfig.getName());
+                object.put("type", columnConfig.getType().getName());
+                array.add(object);
+            }
+            jsonGenerator.writeTree(array);
+        }
+
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
+        private final ModelManager model;
+    }
+
+    private static class SchemaConfigDeserializer extends JsonDeserializer<SchemaConfig> {
+        @SuppressWarnings("deprecation")  // For use of ModelManager
+        SchemaConfigDeserializer(final ModelManager model) {
+            this.model = model;
+        }
+
+        @Override
+        public SchemaConfig deserialize(
+                final JsonParser jsonParser,
+                final DeserializationContext context)
+                throws JsonMappingException {
+            final JsonNode node;
+            try {
+                node = OBJECT_MAPPER.readTree(jsonParser);
+            } catch (final JsonParseException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to parse JSON.", ex);
+            } catch (final JsonProcessingException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to process JSON in parsing.", ex);
+            } catch (final IOException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to read JSON in parsing.", ex);
+            }
+
+            if (!node.isArray()) {
+                throw new JsonMappingException("Expected array to deserialize SchemaConfig", jsonParser.getCurrentLocation());
+            }
+            final ArrayList<ColumnConfig> columnConfigs = new ArrayList<>();
+            for (final JsonNode columnConfigNode : (ArrayNode) node) {
+                columnConfigs.add(model.readObject(ColumnConfig.class, columnConfigNode.traverse()));
+            }
+            return new SchemaConfig(Collections.unmodifiableList(columnConfigs));
+        }
+
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
+        private final ModelManager model;
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+}

--- a/embulk-core/src/main/java/org/embulk/spi/ColumnConfig.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ColumnConfig.java
@@ -1,7 +1,5 @@
 package org.embulk.spi;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Objects;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.type.TimestampType;
@@ -28,7 +26,6 @@ public class ColumnConfig {
         this.option = option;
     }
 
-    @JsonCreator
     public ColumnConfig(ConfigSource conf) {
         this.name = conf.get(String.class, "name");
         this.type = conf.get(Type.class, "type");
@@ -49,7 +46,6 @@ public class ColumnConfig {
         return option;
     }
 
-    @JsonValue
     public ConfigSource getConfigSource() {
         ConfigSource conf = option.deepCopy();
         conf.set("name", name);

--- a/embulk-core/src/main/java/org/embulk/spi/SchemaConfig.java
+++ b/embulk-core/src/main/java/org/embulk/spi/SchemaConfig.java
@@ -1,7 +1,5 @@
 package org.embulk.spi;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
@@ -10,12 +8,10 @@ import org.embulk.spi.type.Type;
 public class SchemaConfig {
     private final List<ColumnConfig> columns;
 
-    @JsonCreator
     public SchemaConfig(List<ColumnConfig> columns) {
         this.columns = columns;
     }
 
-    @JsonValue
     public List<ColumnConfig> getColumns() {
         return columns;
     }

--- a/embulk-core/src/test/java/org/embulk/spi/TestSchemaConfig.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestSchemaConfig.java
@@ -1,0 +1,209 @@
+package org.embulk.spi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.ModelManager;
+import org.embulk.spi.type.Types;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestSchemaConfig {
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    @Test
+    public void testColumnConfigSerDe1() throws IOException {
+        final ObjectNode node = MAPPER.createObjectNode();
+        node.put("name", "foo");
+        node.put("type", "boolean");
+
+        final ModelManager model = ExecInternal.getModelManager();
+        final ColumnConfig config = model.readObject(ColumnConfig.class, node.traverse());
+        assertEquals("foo", config.getName());
+        assertEquals(Types.BOOLEAN, config.getType());
+        assertTrue(config.getOption().isEmpty());
+
+        assertEquals("{\"name\":\"foo\",\"type\":\"boolean\"}", model.writeObject(config));
+    }
+
+    @Test
+    public void testColumnConfigSerDe2() throws IOException {
+        final ObjectNode node = MAPPER.createObjectNode();
+        node.put("name", "barbar");
+        node.put("type", "double");
+        node.put("format", "%z");
+
+        final ModelManager model = ExecInternal.getModelManager();
+        final ColumnConfig config = model.readObject(ColumnConfig.class, node.traverse());
+        assertEquals("barbar", config.getName());
+        assertEquals(Types.DOUBLE, config.getType());
+        final ConfigSource option = config.getOption();
+        assertEquals(1, option.getAttributeNames().size());
+        assertEquals("%z", option.get(String.class, "format"));
+
+        assertEquals("{\"format\":\"%z\",\"name\":\"barbar\",\"type\":\"double\"}", model.writeObject(config));
+    }
+
+    @Test
+    public void testColumnConfigSerDe3() throws IOException {
+        final ObjectNode node = MAPPER.createObjectNode();
+        node.put("name", "bazqux");
+        node.put("type", "json");
+        node.put("format", "%H");
+        node.put("dummy", "hoge");
+
+        final ModelManager model = ExecInternal.getModelManager();
+        final ColumnConfig config = model.readObject(ColumnConfig.class, node.traverse());
+        assertEquals("bazqux", config.getName());
+        assertEquals(Types.JSON, config.getType());
+        final ConfigSource option = config.getOption();
+        assertEquals(2, option.getAttributeNames().size());
+        assertEquals("%H", option.get(String.class, "format"));
+        assertEquals("hoge", option.get(String.class, "dummy"));
+
+        assertEquals("{\"format\":\"%H\",\"dummy\":\"hoge\",\"name\":\"bazqux\",\"type\":\"json\"}", model.writeObject(config));
+    }
+
+    @Test
+    public void testColumnConfigDeserizalizeToFail1() throws IOException {
+        final ObjectNode node = MAPPER.createObjectNode();
+        node.put("name", "foo");
+
+        final ModelManager model = ExecInternal.getModelManager();
+        try {
+            model.readObject(ColumnConfig.class, node.traverse());
+        } catch (final RuntimeException ex) {
+            assertTrue(ex.getCause() instanceof JsonMappingException);
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void testColumnConfigDeserizalizeToFail2() throws IOException {
+        final ObjectNode node = MAPPER.createObjectNode();
+        node.put("type", "string");
+
+        final ModelManager model = ExecInternal.getModelManager();
+        try {
+            model.readObject(ColumnConfig.class, node.traverse());
+        } catch (final RuntimeException ex) {
+            assertTrue(ex.getCause() instanceof JsonMappingException);
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void testColumnConfigDeserizalizeToFail3() throws IOException {
+        final ObjectNode node = MAPPER.createObjectNode();
+        node.put("name", "foo");
+        node.put("type", "invalid_type");
+
+        final ModelManager model = ExecInternal.getModelManager();
+        try {
+            model.readObject(ColumnConfig.class, node.traverse());
+        } catch (final RuntimeException ex) {
+            assertTrue(ex.getCause() instanceof JsonMappingException);
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void testSchemaConfigSerDe0() throws IOException {
+        final ArrayNode array = MAPPER.createArrayNode();
+
+        final ModelManager model = ExecInternal.getModelManager();
+        final SchemaConfig schema = model.readObject(SchemaConfig.class, array.traverse());
+        assertEquals(0, schema.size());
+
+        assertEquals("[]", model.writeObject(schema));
+    }
+
+    @Test
+    public void testSchemaConfigSerDe1() throws IOException {
+        final ObjectNode node1 = MAPPER.createObjectNode();
+        node1.put("name", "foo1");
+        node1.put("type", "string");
+        final ObjectNode node2 = MAPPER.createObjectNode();
+        node2.put("name", "bar2");
+        node2.put("type", "timestamp");
+        node2.put("format", "%H%M%S");
+        final ObjectNode node3 = MAPPER.createObjectNode();
+        node3.put("name", "baz3");
+        node3.put("type", "long");
+        node3.put("dummy", "something");
+        final ArrayNode array = MAPPER.createArrayNode();
+        array.add(node1);
+        array.add(node2);
+        array.add(node3);
+
+        final ModelManager model = ExecInternal.getModelManager();
+        final SchemaConfig schema = model.readObject(SchemaConfig.class, array.traverse());
+        assertEquals(3, schema.size());
+
+        final ColumnConfig column1 = schema.getColumn(0);
+        assertEquals("foo1", column1.getName());
+        assertEquals(Types.STRING, column1.getType());
+        assertTrue(column1.getOption().isEmpty());
+
+        final ColumnConfig column2 = schema.getColumn(1);
+        assertEquals("bar2", column2.getName());
+        assertEquals(Types.TIMESTAMP, column2.getType());
+        final ConfigSource option2 = column2.getOption();
+        assertEquals(1, option2.getAttributeNames().size());
+        assertEquals("%H%M%S", option2.get(String.class, "format"));
+
+        final ColumnConfig column3 = schema.getColumn(2);
+        assertEquals("baz3", column3.getName());
+        assertEquals(Types.LONG, column3.getType());
+        final ConfigSource option3 = column3.getOption();
+        assertEquals(1, option3.getAttributeNames().size());
+        assertEquals("something", option3.get(String.class, "dummy"));
+
+        assertEquals(
+                "[{\"name\":\"foo1\",\"type\":\"string\"},{\"format\":\"%H%M%S\",\"name\":\"bar2\",\"type\":\"timestamp\"},"
+                + "{\"dummy\":\"something\",\"name\":\"baz3\",\"type\":\"long\"}]",
+                model.writeObject(schema));
+    }
+
+    @Test
+    public void testSchemaConfigDeserializeToFail() throws IOException {
+        final ObjectNode node1 = MAPPER.createObjectNode();
+        node1.put("name", "foo1");
+        node1.put("type", "string");
+        final ObjectNode node2 = MAPPER.createObjectNode();
+        node2.put("name", "bar2");
+        node2.put("type", "timestamp");
+        node2.put("format", "%H%M%S");
+        final ObjectNode node3 = MAPPER.createObjectNode();
+        node3.put("name", "baz3");
+        node3.put("type", "invalid_type");
+        node3.put("dummy", "something");
+        final ArrayNode array = MAPPER.createArrayNode();
+        array.add(node1);
+        array.add(node2);
+        array.add(node3);
+
+        final ModelManager model = ExecInternal.getModelManager();
+        try {
+            model.readObject(SchemaConfig.class, array.traverse());
+        } catch (final RuntimeException ex) {
+            assertTrue(ex.getCause() instanceof JsonMappingException);
+            return;
+        }
+        fail();
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+}


### PR DESCRIPTION
Several Embulk classes have had annotated with Jackson's annotations like `@JsonCreator`, `@JsonProperty`, and `@JsonValue`. To remove Jackson from `embulk-core`, those annotations need to be removed.

Instead of the annotations, the classes can still be serialized/deserialized by registering a Jackson Module to `ObjectMapper` with appropriate `JsonSerializer` and `JsonDeserializer` implemented. It works only for SerDe with `ModelManager`, though. (It won't work for arbitrary `ObjectMapper`, but we give it up. We haven't observed such a plugin so far.)

It is a replacement from annotations to a SerDe Module for `org.embulk.spi.ColumnConfig/SchemaConfig`.