### PR TITLE
SerDe TimestampFormat with a Jackson Module

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/ModelManager.java
+++ b/embulk-core/src/main/java/org/embulk/config/ModelManager.java
@@ -21,6 +21,7 @@ public class ModelManager {
         objectMapper.registerModule(new SchemaConfigJacksonModule(this));
         objectMapper.registerModule(new PluginTypeJacksonModule());
         objectMapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
+        objectMapper.registerModule(new TimestampFormatJacksonModule());
         objectMapper.registerModule(new CharsetJacksonModule());
         objectMapper.registerModule(new LocalFileJacksonModule());
         objectMapper.registerModule(new ToStringJacksonModule());

--- a/embulk-core/src/main/java/org/embulk/config/TimestampFormatJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/config/TimestampFormatJacksonModule.java
@@ -1,0 +1,66 @@
+package org.embulk.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+
+final class TimestampFormatJacksonModule extends SimpleModule {
+    @SuppressWarnings("deprecation")  // For use of org.embulk.spi.time.TimestampFormat
+    public TimestampFormatJacksonModule() {
+        this.addSerializer(org.embulk.spi.time.TimestampFormat.class, new TimestampFormatSerializer());
+        this.addDeserializer(org.embulk.spi.time.TimestampFormat.class, new TimestampFormatDeserializer());
+    }
+
+    @SuppressWarnings("deprecation")  // For use of org.embulk.spi.time.TimestampFormat
+    private static class TimestampFormatSerializer extends JsonSerializer<org.embulk.spi.time.TimestampFormat> {
+        @Override
+        public void serialize(
+                final org.embulk.spi.time.TimestampFormat value,
+                final JsonGenerator jsonGenerator,
+                final SerializerProvider provider)
+                throws IOException {
+            jsonGenerator.writeString(value.getFormat());
+        }
+    }
+
+    @SuppressWarnings("deprecation")  // For use of org.embulk.spi.time.TimestampFormat
+    private static class TimestampFormatDeserializer extends JsonDeserializer<org.embulk.spi.time.TimestampFormat> {
+        @Override
+        public org.embulk.spi.time.TimestampFormat deserialize(
+                final JsonParser jsonParser,
+                final DeserializationContext context)
+                throws JsonMappingException {
+            final JsonNode node;
+            try {
+                node = OBJECT_MAPPER.readTree(jsonParser);
+            } catch (final JsonParseException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to parse JSON.", ex);
+            } catch (final JsonProcessingException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to process JSON in parsing.", ex);
+            } catch (final IOException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to read JSON in parsing.", ex);
+            }
+
+            return new org.embulk.spi.time.TimestampFormat(getString(node, jsonParser));
+        }
+
+        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    }
+
+    private static String getString(final JsonNode node, final JsonParser jsonParser) throws JsonMappingException {
+        if (node.isTextual()) {
+            return node.textValue();
+        }
+        throw JsonMappingException.from(jsonParser, "TimestampFormat must be a string.");
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java
@@ -1,18 +1,13 @@
 package org.embulk.spi.time;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-
 // org.embulk.spi.time.TimestampFormat is deprecated.
 // It won't be removed very soon at least until Embulk v0.10.
 @Deprecated
 public class TimestampFormat {
-    @JsonCreator
     public TimestampFormat(final String format) {
         this.format = format;
     }
 
-    @JsonValue
     public String getFormat() {
         return this.format;
     }


### PR DESCRIPTION
Several Embulk classes have had annotated with Jackson's annotations like `@JsonCreator`, `@JsonProperty`, and `@JsonValue`. To remove Jackson from `embulk-core`, those annotations need to be removed.

Instead of the annotations, the classes can still be serialized/deserialized by registering a Jackson Module to `ObjectMapper` with appropriate `JsonSerializer` and `JsonDeserializer` implemented. It works only for SerDe with `ModelManager`, though. (It won't work for arbitrary `ObjectMapper`, but we give it up. We haven't observed such a plugin so far.)

It is a replacement from annotations to a SerDe Module for `org.embulk.spi.time.TimestampFormat`.