### PR TITLE
SerDe org.embulk.spi.unit.ByteSize with a Jackson Module

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/ByteSizeJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/config/ByteSizeJacksonModule.java
@@ -1,0 +1,69 @@
+package org.embulk.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+
+final class ByteSizeJacksonModule extends SimpleModule {
+    @SuppressWarnings("deprecation")  // For use of org.embulk.spi.unit.ByteSize
+    public ByteSizeJacksonModule() {
+        this.addSerializer(org.embulk.spi.unit.ByteSize.class, new ByteSizeSerializer());
+        this.addDeserializer(org.embulk.spi.unit.ByteSize.class, new ByteSizeDeserializer());
+    }
+
+    @SuppressWarnings("deprecation")  // For use of org.embulk.spi.unit.ByteSize
+    private static class ByteSizeSerializer extends JsonSerializer<org.embulk.spi.unit.ByteSize> {
+        @Override
+        public void serialize(
+                final org.embulk.spi.unit.ByteSize value,
+                final JsonGenerator jsonGenerator,
+                final SerializerProvider provider)
+                throws IOException {
+            jsonGenerator.writeString(value.toString());
+        }
+    }
+
+    @SuppressWarnings("deprecation")  // For use of org.embulk.spi.unit.ByteSize
+    private static class ByteSizeDeserializer extends JsonDeserializer<org.embulk.spi.unit.ByteSize> {
+        @Override
+        public org.embulk.spi.unit.ByteSize deserialize(
+                final JsonParser jsonParser,
+                final DeserializationContext context)
+                throws JsonMappingException {
+            final JsonNode node;
+            try {
+                node = OBJECT_MAPPER.readTree(jsonParser);
+            } catch (final JsonParseException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to parse JSON.", ex);
+            } catch (final JsonProcessingException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to process JSON in parsing.", ex);
+            } catch (final IOException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to read JSON in parsing.", ex);
+            }
+
+            return getByteSize(node, jsonParser);
+        }
+
+        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    }
+
+    @SuppressWarnings("deprecation")  // For use of org.embulk.spi.unit.ByteSize
+    private static org.embulk.spi.unit.ByteSize getByteSize(final JsonNode node, final JsonParser jsonParser) throws JsonMappingException {
+        if (node.isTextual()) {
+            return org.embulk.spi.unit.ByteSize.parseByteSize(node.asText());
+        } else if (node.isIntegralNumber()) {
+            return new org.embulk.spi.unit.ByteSize(node.asLong());
+        }
+        throw JsonMappingException.from(jsonParser, "ByteSize must be a string or an integer.");
+    }
+}

--- a/embulk-core/src/main/java/org/embulk/config/ModelManager.java
+++ b/embulk-core/src/main/java/org/embulk/config/ModelManager.java
@@ -22,6 +22,7 @@ public class ModelManager {
         objectMapper.registerModule(new PluginTypeJacksonModule());
         objectMapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
         objectMapper.registerModule(new TimestampFormatJacksonModule());
+        objectMapper.registerModule(new ByteSizeJacksonModule());
         objectMapper.registerModule(new CharsetJacksonModule());
         objectMapper.registerModule(new LocalFileJacksonModule());
         objectMapper.registerModule(new ToStringJacksonModule());

--- a/embulk-core/src/main/java/org/embulk/spi/unit/ByteSize.java
+++ b/embulk-core/src/main/java/org/embulk/spi/unit/ByteSize.java
@@ -1,7 +1,5 @@
 package org.embulk.spi.unit;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Preconditions;
 import java.util.Locale;
 import java.util.Objects;
@@ -28,7 +26,6 @@ public class ByteSize implements Comparable<ByteSize> {
         this.displayUnit = unit;
     }
 
-    @JsonCreator
     public ByteSize(long bytes) {
         logger.warn("org.embulk.spi.unit.ByteSize is deprecated. Used at:", new Throwable());
         Preconditions.checkArgument(bytes >= 0, "size is negative");
@@ -55,7 +52,6 @@ public class ByteSize implements Comparable<ByteSize> {
         return bytes / (double) unit.getFactor();
     }
 
-    @JsonCreator
     public static ByteSize parseByteSize(String size) {
         Preconditions.checkNotNull(size, "size is null");
         Preconditions.checkArgument(!size.isEmpty(), "size is empty");
@@ -82,7 +78,6 @@ public class ByteSize implements Comparable<ByteSize> {
         throw new IllegalArgumentException("Unknown unit '" + unitString + "'");
     }
 
-    @JsonValue
     @Override
     public String toString() {
         double value = getValue(displayUnit);


### PR DESCRIPTION
Several Embulk classes have had annotated with Jackson's annotations like `@JsonCreator`, `@JsonProperty`, and `@JsonValue`. To remove Jackson from `embulk-core`, those annotations need to be removed.

Instead of the annotations, the classes can still be serialized/deserialized by registering a Jackson Module to `ObjectMapper` with appropriate `JsonSerializer` and `JsonDeserializer` implemented. It works only for SerDe with `ModelManager`, though. (It won't work for arbitrary `ObjectMapper`, but we give it up. We haven't observed such a plugin so far.)

It is a replacement from annotations to a SerDe Module for `org.embulk.spi.unit.ByteSize`.