### PR TITLE
SerDe org.embulk.exec.ResumeState with a Jackson Module

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/ModelManager.java
+++ b/embulk-core/src/main/java/org/embulk/config/ModelManager.java
@@ -20,6 +20,7 @@ public class ModelManager {
         objectMapper.registerModule(new ColumnConfigJacksonModule(this));
         objectMapper.registerModule(new SchemaConfigJacksonModule(this));
         objectMapper.registerModule(new PluginTypeJacksonModule());
+        objectMapper.registerModule(new ResumeStateJacksonModule(this));
         objectMapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
         objectMapper.registerModule(new TimestampFormatJacksonModule());
         objectMapper.registerModule(new ByteSizeJacksonModule());

--- a/embulk-core/src/main/java/org/embulk/config/ResumeStateJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/config/ResumeStateJacksonModule.java
@@ -1,0 +1,144 @@
+package org.embulk.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Optional;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import org.embulk.exec.ResumeState;
+import org.embulk.spi.Schema;
+
+final class ResumeStateJacksonModule extends SimpleModule {
+    @SuppressWarnings("deprecation")  // For use of ModelManager
+    public ResumeStateJacksonModule(final ModelManager model) {
+        this.addSerializer(ResumeState.class, new ResumeStateSerializer(model));
+        this.addDeserializer(ResumeState.class, new ResumeStateDeserializer(model));
+    }
+
+    private static class ResumeStateSerializer extends JsonSerializer<ResumeState> {
+        @SuppressWarnings("deprecation")  // For use of ModelManager
+        ResumeStateSerializer(final ModelManager model) {
+            this.model = model;
+        }
+
+        @Override
+        public void serialize(
+                final ResumeState value,
+                final JsonGenerator jsonGenerator,
+                final SerializerProvider provider)
+                throws IOException {
+            final ObjectNode object = OBJECT_MAPPER.createObjectNode();
+            object.put("exec_task", this.model.writeObjectAsObjectNode(value.getExecSessionConfigSource()));
+            object.put("in_task", this.model.writeObjectAsObjectNode(value.getInputTaskSource()));
+            object.put("out_task", this.model.writeObjectAsObjectNode(value.getOutputTaskSource()));
+            object.put("in_schema", this.model.writeObjectAsObjectNode(value.getInputSchema()));
+            object.put("out_schema", this.model.writeObjectAsObjectNode(value.getOutputSchema()));
+            object.put("in_reports", this.model.writeObjectAsObjectNode(value.getInputTaskReports()));
+            object.put("out_reports", this.model.writeObjectAsObjectNode(value.getOutputTaskReports()));
+            jsonGenerator.writeTree(object);
+        }
+
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
+        private final ModelManager model;
+    }
+
+    private static class ResumeStateDeserializer extends JsonDeserializer<ResumeState> {
+        @SuppressWarnings("deprecation")  // For use of ModelManager
+        ResumeStateDeserializer(final ModelManager model) {
+            this.model = model;
+        }
+
+        @Override
+        public ResumeState deserialize(
+                final JsonParser jsonParser,
+                final DeserializationContext context)
+                throws JsonMappingException {
+            final JsonNode node;
+            try {
+                node = OBJECT_MAPPER.readTree(jsonParser);
+            } catch (final JsonParseException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to parse JSON.", ex);
+            } catch (final JsonProcessingException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to process JSON in parsing.", ex);
+            } catch (final IOException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to read JSON in parsing.", ex);
+            }
+
+            if (!node.isObject()) {
+                throw new JsonMappingException("Expected object to deserialize ResumeState", jsonParser.getCurrentLocation());
+            }
+
+            final ObjectNode object = (ObjectNode) node;
+
+            try {
+                final ConfigSource execSessionConfigSource =
+                        this.model.readObject(ConfigSource.class, object.get("exec_task").traverse());
+                final TaskSource inputTaskSource =
+                        this.model.readObject(TaskSource.class, object.get("in_task").traverse());
+                final TaskSource outputTaskSource =
+                        this.model.readObject(TaskSource.class, object.get("out_task").traverse());
+                final Schema inputSchema =
+                        this.model.readObject(Schema.class, object.get("in_schema").traverse());
+                final Schema outputSchema =
+                        this.model.readObject(Schema.class, object.get("out_schema").traverse());
+
+                final JsonNode inputTaskReportsNode = object.get("in_reports");
+                if (!inputTaskReportsNode.isArray()) {
+                    throw new JsonMappingException(
+                            "An array is expected for ResumeState's in_reports", jsonParser.getCurrentLocation());
+                }
+                final ArrayList<Optional<TaskReport>> inputTaskReports = new ArrayList<>();
+                for (final JsonNode inputTaskReportNode : (ArrayNode) inputTaskReportsNode) {
+                    if (inputTaskReportNode == null || inputTaskReportNode.isNull()) {
+                        inputTaskReports.add(Optional.<TaskReport>absent());
+                    } else {
+                        inputTaskReports.add(Optional.of(this.model.readObject(TaskReport.class, inputTaskReportNode.traverse())));
+                    }
+                }
+
+                final JsonNode outputTaskReportsNode = object.get("out_reports");
+                if (!outputTaskReportsNode.isArray()) {
+                    throw new JsonMappingException(
+                            "An array is expected for ResumeState's out_reports", jsonParser.getCurrentLocation());
+                }
+                final ArrayList<Optional<TaskReport>> outputTaskReports = new ArrayList<>();
+                for (final JsonNode outputTaskReportNode : (ArrayNode) outputTaskReportsNode) {
+                    if (outputTaskReportNode == null || outputTaskReportNode.isNull()) {
+                        outputTaskReports.add(Optional.<TaskReport>absent());
+                    } else {
+                        outputTaskReports.add(Optional.of(this.model.readObject(TaskReport.class, outputTaskReportNode.traverse())));
+                    }
+                }
+
+                return new ResumeState(
+                        execSessionConfigSource,
+                        inputTaskSource,
+                        outputTaskSource,
+                        inputSchema,
+                        outputSchema,
+                        Collections.unmodifiableList(inputTaskReports),
+                        Collections.unmodifiableList(outputTaskReports));
+            } catch (final ConfigException ex) {
+                throw JsonMappingException.from(jsonParser, "Invalid object to deserialize ResumeState", ex);
+            }
+        }
+
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
+        private final ModelManager model;
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+}

--- a/embulk-core/src/main/java/org/embulk/exec/ResumeState.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ResumeState.java
@@ -1,7 +1,5 @@
 package org.embulk.exec;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import java.util.List;
 import org.embulk.config.ConfigSource;
@@ -18,15 +16,14 @@ public class ResumeState {
     private final List<Optional<TaskReport>> inputTaskReports;
     private final List<Optional<TaskReport>> outputTaskReports;
 
-    @JsonCreator
     public ResumeState(
-            @JsonProperty("exec_task") ConfigSource execSessionConfigSource,
-            @JsonProperty("in_task") TaskSource inputTaskSource,
-            @JsonProperty("out_task") TaskSource outputTaskSource,
-            @JsonProperty("in_schema") Schema inputSchema,
-            @JsonProperty("out_schema") Schema outputSchema,
-            @JsonProperty("in_reports") List<Optional<TaskReport>> inputTaskReports,
-            @JsonProperty("out_reports") List<Optional<TaskReport>> outputTaskReports) {
+            final ConfigSource execSessionConfigSource,
+            final TaskSource inputTaskSource,
+            final TaskSource outputTaskSource,
+            final Schema inputSchema,
+            final Schema outputSchema,
+            final List<Optional<TaskReport>> inputTaskReports,
+            final List<Optional<TaskReport>> outputTaskReports) {
         this.execSessionConfigSource = execSessionConfigSource;
         this.inputTaskSource = inputTaskSource;
         this.outputTaskSource = outputTaskSource;
@@ -36,37 +33,30 @@ public class ResumeState {
         this.outputTaskReports = outputTaskReports;
     }
 
-    @JsonProperty("exec_task")
     public ConfigSource getExecSessionConfigSource() {
         return execSessionConfigSource;
     }
 
-    @JsonProperty("in_task")
     public TaskSource getInputTaskSource() {
         return inputTaskSource;
     }
 
-    @JsonProperty("out_task")
     public TaskSource getOutputTaskSource() {
         return outputTaskSource;
     }
 
-    @JsonProperty("in_schema")
     public Schema getInputSchema() {
         return inputSchema;
     }
 
-    @JsonProperty("out_schema")
     public Schema getOutputSchema() {
         return outputSchema;
     }
 
-    @JsonProperty("in_reports")
     public List<Optional<TaskReport>> getInputTaskReports() {
         return inputTaskReports;
     }
 
-    @JsonProperty("out_reports")
     public List<Optional<TaskReport>> getOutputTaskReports() {
         return outputTaskReports;
     }


### PR DESCRIPTION
Several Embulk classes have had annotated with Jackson's annotations like `@JsonCreator`, `@JsonProperty`, and `@JsonValue`. To remove Jackson from `embulk-core`, those annotations need to be removed.

Instead of the annotations, the classes can still be serialized/deserialized by registering a Jackson Module to `ObjectMapper` with appropriate `JsonSerializer` and `JsonDeserializer` implemented. It works only for SerDe with `ModelManager`, though. (It won't work for arbitrary `ObjectMapper`, but we give it up. We haven't observed such a plugin so far.)

It is a replacement from annotations to a SerDe Module for `org.embulk.exec.ResumeState`.