### PR TITLE
SerDe org.embulk.spi.ProcessTask with a Jackson Module

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/ModelManager.java
+++ b/embulk-core/src/main/java/org/embulk/config/ModelManager.java
@@ -20,6 +20,7 @@ public class ModelManager {
         objectMapper.registerModule(new ColumnConfigJacksonModule(this));
         objectMapper.registerModule(new SchemaConfigJacksonModule(this));
         objectMapper.registerModule(new PluginTypeJacksonModule());
+        objectMapper.registerModule(new ProcessTaskJacksonModule(this));
         objectMapper.registerModule(new ResumeStateJacksonModule(this));
         objectMapper.registerModule(new TimestampJacksonModule());  // Deprecated. TBD to remove or not.
         objectMapper.registerModule(new TimestampFormatJacksonModule());

--- a/embulk-core/src/main/java/org/embulk/config/ProcessTaskJacksonModule.java
+++ b/embulk-core/src/main/java/org/embulk/config/ProcessTaskJacksonModule.java
@@ -1,0 +1,166 @@
+package org.embulk.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import org.embulk.plugin.PluginType;
+import org.embulk.spi.ProcessTask;
+import org.embulk.spi.Schema;
+
+final class ProcessTaskJacksonModule extends SimpleModule {
+    @SuppressWarnings("deprecation")  // For use of ModelManager
+    public ProcessTaskJacksonModule(final ModelManager model) {
+        this.addSerializer(ProcessTask.class, new ProcessTaskSerializer(model));
+        this.addDeserializer(ProcessTask.class, new ProcessTaskDeserializer(model));
+    }
+
+    private static class ProcessTaskSerializer extends JsonSerializer<ProcessTask> {
+        @SuppressWarnings("deprecation")  // For use of ModelManager
+        ProcessTaskSerializer(final ModelManager model) {
+            this.model = model;
+        }
+
+        @Override
+        public void serialize(
+                final ProcessTask value,
+                final JsonGenerator jsonGenerator,
+                final SerializerProvider provider)
+                throws IOException {
+            final ObjectNode object = OBJECT_MAPPER.createObjectNode();
+            object.put("inputType", this.model.writeObjectAsObjectNode(value.getInputPluginType()));
+            object.put("outputType", this.model.writeObjectAsObjectNode(value.getOutputPluginType()));
+            object.put("filterTypes", this.model.writeObjectAsObjectNode(value.getFilterPluginTypes()));
+            object.put("inputTask", this.model.writeObjectAsObjectNode(value.getInputTaskSource()));
+            object.put("outputTask", this.model.writeObjectAsObjectNode(value.getOutputTaskSource()));
+            object.put("filterTasks", this.model.writeObjectAsObjectNode(value.getFilterTaskSources()));
+            object.put("schemas", this.model.writeObjectAsObjectNode(value.getFilterSchemas()));
+            object.put("executorSchema", this.model.writeObjectAsObjectNode(value.getExecutorSchema()));
+            object.put("executorTask", this.model.writeObjectAsObjectNode(value.getExecutorTaskSource()));
+            jsonGenerator.writeTree(object);
+        }
+
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
+        private final ModelManager model;
+    }
+
+    private static class ProcessTaskDeserializer extends JsonDeserializer<ProcessTask> {
+        @SuppressWarnings("deprecation")  // For use of ModelManager
+        ProcessTaskDeserializer(final ModelManager model) {
+            this.model = model;
+        }
+
+        @Override
+        public ProcessTask deserialize(
+                final JsonParser jsonParser,
+                final DeserializationContext context)
+                throws JsonMappingException {
+            final JsonNode node;
+            try {
+                node = OBJECT_MAPPER.readTree(jsonParser);
+            } catch (final JsonParseException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to parse JSON.", ex);
+            } catch (final JsonProcessingException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to process JSON in parsing.", ex);
+            } catch (final IOException ex) {
+                throw JsonMappingException.from(jsonParser, "Failed to read JSON in parsing.", ex);
+            }
+
+            if (!node.isObject()) {
+                throw new JsonMappingException("Expected object to deserialize ProcessTask", jsonParser.getCurrentLocation());
+            }
+
+            final ObjectNode object = (ObjectNode) node;
+
+            try {
+                final PluginType inputPluginType =
+                        this.model.readObject(PluginType.class, object.get("inputType").traverse());
+                final PluginType outputPluginType =
+                        this.model.readObject(PluginType.class, object.get("outputType").traverse());
+
+                final JsonNode filterPluginTypesNode = object.get("filterTypes");
+                if (!filterPluginTypesNode.isArray()) {
+                    throw new JsonMappingException(
+                            "An array is expected for ProcessTask's filterTypes", jsonParser.getCurrentLocation());
+                }
+                final ArrayList<PluginType> filterPluginTypes = new ArrayList<>();
+                for (final JsonNode filterPluginTypeNode : (ArrayNode) filterPluginTypesNode) {
+                    if (filterPluginTypeNode == null || filterPluginTypeNode.isNull()) {
+                        filterPluginTypes.add(null);
+                    } else {
+                        filterPluginTypes.add(this.model.readObject(PluginType.class, filterPluginTypeNode.traverse()));
+                    }
+                }
+
+                final TaskSource inputTaskSource =
+                        this.model.readObject(TaskSource.class, object.get("inputTask").traverse());
+                final TaskSource outputTaskSource =
+                        this.model.readObject(TaskSource.class, object.get("outputTask").traverse());
+
+                final JsonNode filterTaskSourcesNode = object.get("filterTasks");
+                if (!filterTaskSourcesNode.isArray()) {
+                    throw new JsonMappingException(
+                            "An array is expected for ProcessTask's filterTasks", jsonParser.getCurrentLocation());
+                }
+                final ArrayList<TaskSource> filterTaskSources = new ArrayList<>();
+                for (final JsonNode filterTaskSourceNode : (ArrayNode) filterTaskSourcesNode) {
+                    if (filterTaskSourceNode == null || filterTaskSourceNode.isNull()) {
+                        filterTaskSources.add(null);
+                    } else {
+                        filterTaskSources.add(this.model.readObject(TaskSource.class, filterTaskSourceNode.traverse()));
+                    }
+                }
+
+                final JsonNode schemasNode = object.get("schemas");
+                if (!schemasNode.isArray()) {
+                    throw new JsonMappingException(
+                            "An array is expected for ProcessTask's schemas", jsonParser.getCurrentLocation());
+                }
+                final ArrayList<Schema> schemas = new ArrayList<>();
+                for (final JsonNode schemaNode : (ArrayNode) schemasNode) {
+                    if (schemaNode == null || schemaNode.isNull()) {
+                        schemas.add(null);
+                    } else {
+                        schemas.add(this.model.readObject(Schema.class, schemaNode.traverse()));
+                    }
+                }
+
+                final Schema executorSchema =
+                        this.model.readObject(Schema.class, object.get("executorSchema").traverse());
+                final TaskSource executorTaskSource =
+                        this.model.readObject(TaskSource.class, object.get("executorTask").traverse());
+
+                return new ProcessTask(
+                        inputPluginType,
+                        outputPluginType,
+                        Collections.unmodifiableList(filterPluginTypes),
+                        inputTaskSource,
+                        outputTaskSource,
+                        Collections.unmodifiableList(filterTaskSources),
+                        Collections.unmodifiableList(schemas),
+                        executorSchema,
+                        executorTaskSource);
+            } catch (final ConfigException ex) {
+                throw JsonMappingException.from(jsonParser, "Invalid object to deserialize ProcessTask", ex);
+            }
+        }
+
+        @Deprecated  // https://github.com/embulk/embulk/issues/1304
+        private final ModelManager model;
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+}

--- a/embulk-core/src/main/java/org/embulk/spi/ProcessTask.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ProcessTask.java
@@ -1,8 +1,5 @@
 package org.embulk.spi;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import org.embulk.config.TaskSource;
 import org.embulk.plugin.PluginType;
@@ -19,17 +16,16 @@ public class ProcessTask {
     private final Schema executorSchema;
     private TaskSource executorTaskSource;
 
-    @JsonCreator
     public ProcessTask(
-            @JsonProperty("inputType") PluginType inputPluginType,
-            @JsonProperty("outputType") PluginType outputPluginType,
-            @JsonProperty("filterTypes") List<PluginType> filterPluginTypes,
-            @JsonProperty("inputTask") TaskSource inputTaskSource,
-            @JsonProperty("outputTask") TaskSource outputTaskSource,
-            @JsonProperty("filterTasks") List<TaskSource> filterTaskSources,
-            @JsonProperty("schemas") List<Schema> schemas,
-            @JsonProperty("executorSchema") Schema executorSchema,
-            @JsonProperty("executorTask") TaskSource executorTaskSource) {
+            final PluginType inputPluginType,
+            final PluginType outputPluginType,
+            final List<PluginType> filterPluginTypes,
+            final TaskSource inputTaskSource,
+            final TaskSource outputTaskSource,
+            final List<TaskSource> filterTaskSources,
+            final List<Schema> schemas,
+            final Schema executorSchema,
+            final TaskSource executorTaskSource) {
         this.inputPluginType = inputPluginType;
         this.outputPluginType = outputPluginType;
         this.filterPluginTypes = filterPluginTypes;
@@ -41,62 +37,50 @@ public class ProcessTask {
         this.executorTaskSource = executorTaskSource;
     }
 
-    @JsonProperty("inputType")
     public PluginType getInputPluginType() {
         return inputPluginType;
     }
 
-    @JsonProperty("outputType")
     public PluginType getOutputPluginType() {
         return outputPluginType;
     }
 
-    @JsonProperty("filterTypes")
     public List<PluginType> getFilterPluginTypes() {
         return filterPluginTypes;
     }
 
-    @JsonProperty("inputTask")
     public TaskSource getInputTaskSource() {
         return inputTaskSource;
     }
 
-    @JsonProperty("outputTask")
     public TaskSource getOutputTaskSource() {
         return outputTaskSource;
     }
 
-    @JsonProperty("filterTasks")
     public List<TaskSource> getFilterTaskSources() {
         return filterTaskSources;
     }
 
-    @JsonProperty("schemas")
     public List<Schema> getFilterSchemas() {
         return schemas;
     }
 
-    @JsonProperty("executorSchema")
     public Schema getExecutorSchema() {
         return executorSchema;
     }
 
-    @JsonIgnore
     public Schema getInputSchema() {
         return ExecutorsInternal.getInputSchema(schemas);
     }
 
-    @JsonIgnore
     public Schema getOutputSchema() {
         return ExecutorsInternal.getOutputSchema(schemas);
     }
 
-    @JsonIgnore
     public void setExecutorTaskSource(TaskSource executorTaskSource) {
         this.executorTaskSource = executorTaskSource;
     }
 
-    @JsonProperty("executorTask")
     public TaskSource getExecutorTaskSource() {
         return executorTaskSource;
     }


### PR DESCRIPTION
Several Embulk classes have had annotated with Jackson's annotations like `@JsonCreator`, `@JsonProperty`, and `@JsonValue`. To remove Jackson from `embulk-core`, those annotations need to be removed.

Instead of the annotations, the classes can still be serialized/deserialized by registering a Jackson Module to `ObjectMapper` with appropriate `JsonSerializer` and `JsonDeserializer` implemented. It works only for SerDe with `ModelManager`, though. (It won't work for arbitrary `ObjectMapper`, but we give it up. We haven't observed such a plugin so far.)

It is a replacement from annotations to a SerDe Module for `org.embulk.spi.ProcessTask`.