### PR TITLE
Move ConfigLoader behind the embulk-deps DependencyClassLoader

### DIFF
--- a/embulk-core/src/main/java/org/embulk/config/ConfigLoader.java
+++ b/embulk-core/src/main/java/org/embulk/config/ConfigLoader.java
@@ -1,145 +1,57 @@
 package org.embulk.config;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
-import org.embulk.deps.config.YamlProcessor;
+import org.embulk.deps.config.ConfigLoaderDelegate;
 
 public class ConfigLoader {
-    @Deprecated  // https://github.com/embulk/embulk/issues/1304
-    private final ModelManager model;
-
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
     public ConfigLoader(ModelManager model) {
-        this.model = model;
+        this.delegate = ConfigLoaderDelegate.of(model);
     }
 
     public ConfigSource newConfigSource() {
-        return new DataSourceImpl(model);
+        return this.delegate.newConfigSource();
     }
 
-    public ConfigSource fromJsonString(String string) {
-        JsonNode node;
-        try {
-            node = new ObjectMapper().readTree(string);
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
-        }
-        validateJsonNode(node);
-        return new DataSourceImpl(model, (ObjectNode) node);
+    public ConfigSource fromJsonString(final String string) {
+        return this.delegate.fromJsonString(string);
     }
 
-    public ConfigSource fromJsonFile(File file) throws IOException {
-        try (FileInputStream is = new FileInputStream(file)) {
-            return fromJson(is);
-        }
+    public ConfigSource fromJsonFile(final File file) throws IOException {
+        return this.delegate.fromJsonFile(file);
     }
 
-    public ConfigSource fromJson(InputStream stream) throws IOException {
-        JsonNode node = new ObjectMapper().readTree(stream);
-        validateJsonNode(node);
-        return new DataSourceImpl(model, (ObjectNode) node);
+    public ConfigSource fromJson(final InputStream stream) throws IOException {
+        return this.delegate.fromJson(stream);
     }
 
-    public ConfigSource fromYamlString(String string) {
-        YamlProcessor yamlProc = YamlProcessor.create(true);
-        JsonNode node = objectToJson(yamlProc.load(string));
-        validateJsonNode(node);
-        return new DataSourceImpl(model, (ObjectNode) node);
+    public ConfigSource fromYamlString(final String string) {
+        return this.delegate.fromYamlString(string);
     }
 
-    public ConfigSource fromYamlFile(File file) throws IOException {
-        try (FileInputStream stream = new FileInputStream(file)) {
-            return fromYaml(stream);
-        }
+    public ConfigSource fromYamlFile(final File file) throws IOException {
+        return this.delegate.fromYamlFile(file);
     }
 
-    public ConfigSource fromYaml(InputStream stream) throws IOException {
-        YamlProcessor yamlProc = YamlProcessor.create(true);
-        JsonNode node = objectToJson(yamlProc.load(stream));
-        validateJsonNode(node);
-        return new DataSourceImpl(model, (ObjectNode) node);
+    public ConfigSource fromYaml(final InputStream stream) throws IOException {
+        return this.delegate.fromYaml(stream);
     }
 
-    private static void validateJsonNode(JsonNode node) {
-        if (!node.isObject()) {
-            throw new RuntimeJsonMappingException("Expected object to load ConfigSource but got " + node);
-        }
+    // The method is removed: public ConfigSource fromJson(JsonParser parser) throws IOException
+
+    public ConfigSource fromPropertiesYamlLiteral(final Properties props, final String keyPrefix) {
+        return this.delegate.fromPropertiesYamlLiteral(props, keyPrefix);
     }
 
-    // To be removed by v0.10. Not used from Embulk core.
-    @Deprecated  // https://github.com/embulk/embulk/issues/934
-    @SuppressWarnings("checkstyle:OverloadMethodsDeclarationOrder")
-    public ConfigSource fromJson(JsonParser parser) throws IOException {
-        // TODO check parsed.isObject()
-        ObjectNode source = (ObjectNode) new ObjectMapper().readTree(parser);
-        return new DataSourceImpl(model, source);
+    public ConfigSource fromPropertiesYamlLiteral(final Map<String, String> props, final String keyPrefix) {
+        return this.delegate.fromPropertiesYamlLiteral(props, keyPrefix);
     }
 
-    public ConfigSource fromPropertiesYamlLiteral(Properties props, String keyPrefix) {
-        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-        for (String propName : props.stringPropertyNames()) {
-            builder.put(propName, props.getProperty(propName));
-        }
-        return fromPropertiesYamlLiteral(builder.build(), keyPrefix);
-    }
+    // The method is removed: public ConfigSource fromPropertiesAsIs(final Properties properties)
 
-    public ConfigSource fromPropertiesYamlLiteral(Map<String, String> props, String keyPrefix) {
-        ObjectNode source = new ObjectNode(JsonNodeFactory.instance);
-        DataSource ds = new DataSourceImpl(model, source);
-        YamlProcessor yamlProc = YamlProcessor.create(true);
-        for (Map.Entry<String, String> pair : props.entrySet()) {
-            if (!pair.getKey().startsWith(keyPrefix)) {
-                continue;
-            }
-            String keyName = pair.getKey().substring(keyPrefix.length());
-            Object parsedValue = yamlProc.load(pair.getValue());
-            JsonNode node = objectToJson(parsedValue);
-
-            // handle "." as a map acccessor. for example:
-            // in.parser.type=csv => {"in": {"parser": {"type": "csv"}}}
-            // TODO handle "[]" as array index
-            String[] fragments = keyName.split("\\.");
-            DataSource key = ds;
-            for (int i = 0; i < fragments.length - 1; i++) {
-                key = key.getNestedOrSetEmpty(fragments[i]);  // TODO exception handling
-            }
-            key.set(fragments[fragments.length - 1], node);
-        }
-        return new DataSourceImpl(model, source);
-    }
-
-    /**
-     * Creates ConfigSource from java.util.Properties as-is.
-     *
-     * <p>Users and plugins MUST NOT call this directly. No any compatibility is guaranteed.
-     */
-    @Deprecated
-    public ConfigSource fromPropertiesAsIs(final Properties properties) {
-        final ObjectNode sourceNode = new ObjectNode(JsonNodeFactory.instance);
-        final DataSource dataSource = new DataSourceImpl(model, sourceNode);
-        for (final String key : properties.stringPropertyNames()) {
-            dataSource.set(key, properties.getProperty(key));
-        }
-        return new DataSourceImpl(model, sourceNode);
-    }
-
-    private JsonNode objectToJson(Object object) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            return objectMapper.readTree(objectMapper.writeValueAsString(object));
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
-        }
-    }
+    private final ConfigLoaderDelegate delegate;
 }

--- a/embulk-core/src/main/java/org/embulk/deps/config/ConfigLoaderDelegate.java
+++ b/embulk-core/src/main/java/org/embulk/deps/config/ConfigLoaderDelegate.java
@@ -1,0 +1,74 @@
+package org.embulk.deps.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Properties;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.ModelManager;
+import org.embulk.deps.EmbulkDependencyClassLoaders;
+
+public abstract class ConfigLoaderDelegate {
+    public static ConfigLoaderDelegate of(final ModelManager model) {
+        try {
+            return CONSTRUCTOR.newInstance(model);
+        } catch (final IllegalAccessException | IllegalArgumentException | InstantiationException ex) {
+            throw new LinkageError("Dependencies for Jackson are not loaded correctly: " + CLASS_NAME, ex);
+        } catch (final InvocationTargetException ex) {
+            final Throwable targetException = ex.getTargetException();
+            if (targetException instanceof RuntimeException) {
+                throw (RuntimeException) targetException;
+            } else if (targetException instanceof Error) {
+                throw (Error) targetException;
+            } else {
+                throw new RuntimeException("Unexpected exception in creating: " + CLASS_NAME, ex);
+            }
+        }
+    }
+
+    public abstract ConfigSource newConfigSource();
+
+    public abstract ConfigSource fromJsonString(String string);
+
+    public abstract ConfigSource fromJsonFile(File file) throws IOException;
+
+    public abstract ConfigSource fromJson(InputStream stream) throws IOException;
+
+    public abstract ConfigSource fromYamlString(String string);
+
+    public abstract ConfigSource fromYamlFile(File file) throws IOException;
+
+    public abstract ConfigSource fromYaml(InputStream stream) throws IOException;
+
+    public abstract ConfigSource fromPropertiesYamlLiteral(Properties props, String keyPrefix);
+
+    public abstract ConfigSource fromPropertiesYamlLiteral(Map<String, String> props, String keyPrefix);
+
+    public abstract ConfigSource fromPropertiesAsIs(Properties properties);
+
+    @SuppressWarnings("unchecked")
+    private static Class<ConfigLoaderDelegate> loadImplClass() {
+        try {
+            return (Class<ConfigLoaderDelegate>) CLASS_LOADER.loadClass(CLASS_NAME);
+        } catch (final ClassNotFoundException ex) {
+            throw new LinkageError("Dependencies for Jackson are not loaded correctly: " + CLASS_NAME, ex);
+        }
+    }
+
+    private static final ClassLoader CLASS_LOADER = EmbulkDependencyClassLoaders.get();
+    private static final String CLASS_NAME = "org.embulk.deps.config.ConfigLoaderDelegateImpl";
+
+    static {
+        final Class<ConfigLoaderDelegate> clazz = loadImplClass();
+        try {
+            CONSTRUCTOR = clazz.getConstructor(ModelManager.class);
+        } catch (final NoSuchMethodException ex) {
+            throw new LinkageError("Dependencies for Jackson are not loaded correctly: " + CLASS_NAME, ex);
+        }
+    }
+
+    private static final Constructor<ConfigLoaderDelegate> CONSTRUCTOR;
+}

--- a/embulk-deps/src/main/java/org/embulk/deps/config/ConfigLoaderDelegateImpl.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/config/ConfigLoaderDelegateImpl.java
@@ -1,0 +1,159 @@
+package org.embulk.deps.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.DataSource;
+import org.embulk.config.DataSourceImpl;
+import org.embulk.config.ModelManager;
+import org.embulk.deps.config.YamlProcessor;
+
+public class ConfigLoaderDelegateImpl extends ConfigLoaderDelegate {
+    @Deprecated  // https://github.com/embulk/embulk/issues/1304
+    private final ModelManager model;
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1304
+    public ConfigLoaderDelegateImpl(ModelManager model) {
+        this.model = model;
+    }
+
+    @Override
+    public ConfigSource newConfigSource() {
+        return new DataSourceImpl(model);
+    }
+
+    @Override
+    public ConfigSource fromJsonString(String string) {
+        JsonNode node;
+        try {
+            node = new ObjectMapper().readTree(string);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        validateJsonNode(node);
+        return new DataSourceImpl(model, (ObjectNode) node);
+    }
+
+    @Override
+    public ConfigSource fromJsonFile(File file) throws IOException {
+        try (FileInputStream is = new FileInputStream(file)) {
+            return fromJson(is);
+        }
+    }
+
+    @Override
+    public ConfigSource fromJson(InputStream stream) throws IOException {
+        JsonNode node = new ObjectMapper().readTree(stream);
+        validateJsonNode(node);
+        return new DataSourceImpl(model, (ObjectNode) node);
+    }
+
+    @Override
+    public ConfigSource fromYamlString(String string) {
+        YamlProcessor yamlProc = YamlProcessor.create(true);
+        JsonNode node = objectToJson(yamlProc.load(string));
+        validateJsonNode(node);
+        return new DataSourceImpl(model, (ObjectNode) node);
+    }
+
+    @Override
+    public ConfigSource fromYamlFile(File file) throws IOException {
+        try (FileInputStream stream = new FileInputStream(file)) {
+            return fromYaml(stream);
+        }
+    }
+
+    @Override
+    public ConfigSource fromYaml(InputStream stream) throws IOException {
+        YamlProcessor yamlProc = YamlProcessor.create(true);
+        JsonNode node = objectToJson(yamlProc.load(stream));
+        validateJsonNode(node);
+        return new DataSourceImpl(model, (ObjectNode) node);
+    }
+
+    private static void validateJsonNode(JsonNode node) {
+        if (!node.isObject()) {
+            throw new RuntimeJsonMappingException("Expected object to load ConfigSource but got " + node);
+        }
+    }
+
+    // To be removed by v0.10. Not used from Embulk core.
+    @Deprecated  // https://github.com/embulk/embulk/issues/934
+    @SuppressWarnings("checkstyle:OverloadMethodsDeclarationOrder")
+    public ConfigSource fromJson(JsonParser parser) throws IOException {
+        // TODO check parsed.isObject()
+        ObjectNode source = (ObjectNode) new ObjectMapper().readTree(parser);
+        return new DataSourceImpl(model, source);
+    }
+
+    @Override
+    public ConfigSource fromPropertiesYamlLiteral(Properties props, String keyPrefix) {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (String propName : props.stringPropertyNames()) {
+            builder.put(propName, props.getProperty(propName));
+        }
+        return fromPropertiesYamlLiteral(builder.build(), keyPrefix);
+    }
+
+    @Override
+    public ConfigSource fromPropertiesYamlLiteral(Map<String, String> props, String keyPrefix) {
+        ObjectNode source = new ObjectNode(JsonNodeFactory.instance);
+        DataSource ds = new DataSourceImpl(model, source);
+        YamlProcessor yamlProc = YamlProcessor.create(true);
+        for (Map.Entry<String, String> pair : props.entrySet()) {
+            if (!pair.getKey().startsWith(keyPrefix)) {
+                continue;
+            }
+            String keyName = pair.getKey().substring(keyPrefix.length());
+            Object parsedValue = yamlProc.load(pair.getValue());
+            JsonNode node = objectToJson(parsedValue);
+
+            // handle "." as a map acccessor. for example:
+            // in.parser.type=csv => {"in": {"parser": {"type": "csv"}}}
+            // TODO handle "[]" as array index
+            String[] fragments = keyName.split("\\.");
+            DataSource key = ds;
+            for (int i = 0; i < fragments.length - 1; i++) {
+                key = key.getNestedOrSetEmpty(fragments[i]);  // TODO exception handling
+            }
+            key.set(fragments[fragments.length - 1], node);
+        }
+        return new DataSourceImpl(model, source);
+    }
+
+    /**
+     * Creates ConfigSource from java.util.Properties as-is.
+     *
+     * <p>Users and plugins MUST NOT call this directly. No any compatibility is guaranteed.
+     */
+    @Deprecated
+    @Override
+    public ConfigSource fromPropertiesAsIs(final Properties properties) {
+        final ObjectNode sourceNode = new ObjectNode(JsonNodeFactory.instance);
+        final DataSource dataSource = new DataSourceImpl(model, sourceNode);
+        for (final String key : properties.stringPropertyNames()) {
+            dataSource.set(key, properties.getProperty(key));
+        }
+        return new DataSourceImpl(model, sourceNode);
+    }
+
+    private JsonNode objectToJson(Object object) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readTree(objectMapper.writeValueAsString(object));
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}


### PR DESCRIPTION
`ConfigLoader`, a big direct user of Jackson, is to load JSON/YAML into `ConfigSource`. It moves the main implementation to `embulk-deps` behind a sub class loader to hide Jackson from plugins.