### PR TITLE
Remove Guava

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -16,11 +16,11 @@ dependencies {
     // those "compile" declaration would be kept so that plugin developers won't be confused unnecessarily.
     api project(":embulk-api")
     api project(":embulk-spi")
-    api "com.google.guava:guava:18.0"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":embulk-junit4")
     testImplementation "ch.qos.logback:logback-classic:1.1.3"
+    testImplementation "com.google.guava:guava:18.0"
 
     // TODO: Remove this, and load it with the proper DependencyClassLoader.
     // This statement gets it loaded by the top-level ClassLoader.

--- a/embulk-core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-core/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.google.guava:guava:18.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,6 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.google.guava:guava:18.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
@@ -1,6 +1,5 @@
 package org.embulk.exec;
 
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -216,12 +215,12 @@ public class GuessExecutor {
             Buffer sample = readSample(input, guessParserSampleBufferBytes);
 
             // load guess plugins
-            ImmutableList.Builder<GuessPlugin> builder = ImmutableList.builder();
+            final ArrayList<GuessPlugin> builder = new ArrayList<>();
             for (PluginType guessType : task.getGuessPluginTypes()) {
                 GuessPlugin guess = ExecInternal.newPlugin(GuessPlugin.class, guessType);
                 builder.add(guess);
             }
-            List<GuessPlugin> guesses = builder.build();
+            final List<GuessPlugin> guesses = Collections.unmodifiableList(builder);
 
             // run guess plugins
             ConfigSource mergedConfig = originalConfig.deepCopy();
@@ -262,12 +261,12 @@ public class GuessExecutor {
                 return guessed;
             } else {
                 List<ConfigSource> assumedDecoders = originalConfig.get(ConfigSourceList.class, "decoders", new ConfigSourceList());
-                ImmutableList.Builder<ConfigSource> added = ImmutableList.builder();
+                final ArrayList<ConfigSource> added = new ArrayList<>();
                 for (ConfigSource assuemed : assumedDecoders) {
                     added.add(Exec.newConfigSource());
                 }
                 added.addAll(guessedDecoders);
-                return guessed.set("decoders", added.build());
+                return guessed.set("decoders", Collections.unmodifiableList(added));
             }
         }
 

--- a/embulk-core/src/main/java/org/embulk/exec/ResumeState.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ResumeState.java
@@ -1,7 +1,7 @@
 package org.embulk.exec;
 
-import com.google.common.base.Optional;
 import java.util.List;
+import java.util.Optional;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;

--- a/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
+++ b/embulk-core/src/main/java/org/embulk/exec/SamplingParserPlugin.java
@@ -3,7 +3,6 @@ package org.embulk.exec;
 import static java.util.Locale.ENGLISH;
 import static org.embulk.spi.util.Inputs.each;
 
-import com.google.common.base.Preconditions;
 import java.text.NumberFormat;
 import java.util.List;
 import org.embulk.config.Config;
@@ -142,7 +141,9 @@ public class SamplingParserPlugin implements ParserPlugin {
     @Override
     public void transaction(ConfigSource config, ParserPlugin.Control control) {
         final PluginTask task = loadPluginTask(config);
-        Preconditions.checkArgument(minSampleBufferBytes < task.getSampleBufferBytes(), "minSampleBufferBytes must be smaller than sample_buffer_bytes");
+        if (minSampleBufferBytes >= task.getSampleBufferBytes()) {
+            throw new IllegalArgumentException("minSampleBufferBytes must be smaller than sample_buffer_bytes");
+        }
 
         logger.info("Try to read {} bytes from input source", numberFormat.format(task.getSampleBufferBytes()));
         control.run(task.dump(), null);

--- a/embulk-core/src/main/java/org/embulk/spi/SchemaConfig.java
+++ b/embulk-core/src/main/java/org/embulk/spi/SchemaConfig.java
@@ -1,6 +1,7 @@
 package org.embulk.spi;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.embulk.spi.type.Type;
@@ -50,11 +51,11 @@ public class SchemaConfig {
     }
 
     public Schema toSchema() {
-        ImmutableList.Builder<Column> builder = ImmutableList.builder();
+        final ArrayList<Column> builder = new ArrayList<>();
         for (int i = 0; i < columns.size(); i++) {
             builder.add(columns.get(i).toColumn(i));
         }
-        return new Schema(builder.build());
+        return new Schema(Collections.unmodifiableList(builder));
     }
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/spi/TaskState.java
+++ b/embulk-core/src/main/java/org/embulk/spi/TaskState.java
@@ -1,13 +1,13 @@
 package org.embulk.spi;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.embulk.config.TaskReport;
 
 public class TaskState {
     private volatile boolean started = false;
     private volatile boolean finished = false;
-    private volatile Optional<TaskReport> taskReport = Optional.absent();
-    private volatile Optional<Throwable> exception = Optional.absent();
+    private volatile Optional<TaskReport> taskReport = Optional.empty();
+    private volatile Optional<Throwable> exception = Optional.empty();
 
     public void start() {
         this.started = true;
@@ -25,12 +25,12 @@ public class TaskState {
 
     public void setException(Throwable exception) {
         this.started = true;
-        this.exception = Optional.fromNullable(exception);
+        this.exception = Optional.ofNullable(exception);
     }
 
     public void resetException() {
         this.started = true;
-        this.exception = Optional.absent();
+        this.exception = Optional.empty();
     }
 
     public boolean isStarted() {

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatter.java
@@ -1,6 +1,5 @@
 package org.embulk.spi.time;
 
-import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.deps.timestamp.DepsTimestampFormatter;
@@ -13,38 +12,15 @@ public class TimestampFormatter {
         this.zoneIdString = zoneIdString;
     }
 
-    @Deprecated  // This constructor will be removed sooner when Joda-Time is removed from Embulk during v0.10.
-    public TimestampFormatter(final Task task, final Optional<? extends TimestampColumnOption> columnOption) {
-        this(columnOption.isPresent()
-                     ? columnOption.get().getFormat().or(task.getDefaultTimestampFormat())
-                     : task.getDefaultTimestampFormat(),
-             columnOption.isPresent()
-                     ? columnOption.get().getTimeZoneId().or(task.getDefaultTimeZoneId())
-                     : task.getDefaultTimeZoneId());
-    }
+    // The constructor has been removed:
+    // public TimestampFormatter(TimestampFormatter.Task, com.google.commom.base.Optional<? extends TimestampFormatter.TimestampColumnOption>)
 
     public static TimestampFormatter of(final String pattern, final String zoneIdString) {
         return new TimestampFormatter(pattern, zoneIdString);
     }
 
-    @Deprecated  // This constructor will be removed sooner when Joda-Time is removed from Embulk during v0.10.
-    public static TimestampFormatter of(final Task task, final Optional<? extends TimestampColumnOption> columnOption) {
-        final String pattern;
-        if (columnOption.isPresent()) {
-            pattern = columnOption.get().getFormat().or(task.getDefaultTimestampFormat());
-        } else {
-            pattern = task.getDefaultTimestampFormat();
-        }
-
-        final String zoneIdString;
-        if (columnOption.isPresent()) {
-            zoneIdString = columnOption.get().getTimeZoneId().or(task.getDefaultTimeZoneId());
-        } else {
-            zoneIdString = task.getDefaultTimeZoneId();
-        }
-
-        return new TimestampFormatter(pattern, zoneIdString);
-    }
+    // The method has been removed:
+    // public static TimestampFormatter of(TimestampFormatter.Task, com.google.common.base.Optional<? extends TimestampFormatter.TimestampColumnOption>)
 
     @Deprecated  // This interface will be removed sooner when Joda-Time is removed from Embulk during v0.10.
     public interface Task {
@@ -59,18 +35,7 @@ public class TimestampFormatter {
         public String getDefaultTimestampFormat();
     }
 
-    @Deprecated  // This interface will be removed sooner when Joda-Time is removed from Embulk during v0.10.
-    public interface TimestampColumnOption {
-        @Config("timezone")
-        @ConfigDefault("null")
-        public Optional<String> getTimeZoneId();
-
-        // The method has been removed: public default org.joda.time.DateTimeZone getDefaultTimeZone()
-
-        @Config("format")
-        @ConfigDefault("null")
-        public Optional<String> getFormat();
-    }
+    // The interface has been removed: public interface TimestampFormatter.TimestampColumnOption
 
     // The method has been removed: public org.joda.time.DateTimeZone getTimeZone()
 

--- a/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java
@@ -1,6 +1,5 @@
 package org.embulk.spi.time;
 
-import com.google.common.base.Optional;
 import java.time.DateTimeException;
 import java.time.Instant;
 import org.embulk.config.Config;
@@ -18,13 +17,7 @@ public class TimestampParser {
         this(formatString, defaultZoneIdString, null);
     }
 
-    @Deprecated  // This constructor will be removed sooner when Joda-Time is removed from Embulk during v0.10.
-    public TimestampParser(final Task task,
-                           final TimestampColumnOption columnOption) {
-        this(columnOption.getFormat().or(task.getDefaultTimestampFormat()),
-             columnOption.getTimeZoneId().or(task.getDefaultTimeZoneId()),
-             columnOption.getDate().or(task.getDefaultDate()));
-    }
+    // The constructor has been removed: public TimestampParser(TimestampParser.Task, TimestampParser.TimestampColumnOption)
 
     @Deprecated  // "default_date" is deprecated, but the creator method is kept for plugin compatibility.
     public static TimestampParser of(final String pattern,
@@ -39,15 +32,7 @@ public class TimestampParser {
         return new TimestampParser(pattern, defaultZoneIdString);
     }
 
-    @Deprecated  // This constructor will be removed sooner when Joda-Time is removed from Embulk during v0.10.
-    public static TimestampParser of(final Task task,
-                                     final TimestampColumnOption columnOption) {
-        final String pattern = columnOption.getFormat().or(task.getDefaultTimestampFormat());
-        return new TimestampParser(
-                    pattern,
-                    columnOption.getTimeZoneId().or(task.getDefaultTimeZoneId()),
-                    columnOption.getDate().or(task.getDefaultDate()));
-    }
+    // The method has been removed: public static TimestampParser of(TimestampParser.Task, TimestampParser.TimestampColumnOption)
 
     @Deprecated  // This interface will be removed sooner when Joda-Time is removed from Embulk during v0.10.
     public interface Task {
@@ -66,22 +51,7 @@ public class TimestampParser {
         public String getDefaultDate();
     }
 
-    @Deprecated  // This interface will be removed sooner when Joda-Time is removed from Embulk during v0.10.
-    public interface TimestampColumnOption {
-        @Config("timezone")
-        @ConfigDefault("null")
-        public Optional<String> getTimeZoneId();
-
-        // The method has been removed: public default Optional<org.joda.time.DateTimeZone> getTimeZone()
-
-        @Config("format")
-        @ConfigDefault("null")
-        public Optional<String> getFormat();
-
-        @Config("date")
-        @ConfigDefault("null")
-        public Optional<String> getDate();
-    }
+    // The interface has been removed: public interface TimestampParser.TimestampColumnOption
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public final Timestamp parse(final String text) throws TimestampParseException {

--- a/embulk-core/src/main/java/org/embulk/spi/unit/ByteSize.java
+++ b/embulk-core/src/main/java/org/embulk/spi/unit/ByteSize.java
@@ -1,6 +1,5 @@
 package org.embulk.spi.unit;
 
-import com.google.common.base.Preconditions;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -17,18 +16,30 @@ import org.slf4j.LoggerFactory;
 public class ByteSize implements Comparable<ByteSize> {
     public ByteSize(double size, Unit unit) {
         logger.warn("org.embulk.spi.unit.ByteSize is deprecated. Used at:", new Throwable());
-        Preconditions.checkArgument(!Double.isInfinite(size), "size is infinite");
-        Preconditions.checkArgument(!Double.isNaN(size), "size is not a number");
-        Preconditions.checkArgument(size >= 0, "size is negative");
-        Preconditions.checkNotNull(unit, "unit is null");
-        Preconditions.checkArgument(size * unit.getFactor() <= (double) Long.MAX_VALUE, "size is large than (2^63)-1 in bytes");
+        if (Double.isInfinite(size)) {
+            throw new IllegalArgumentException("size is infinite");
+        }
+        if (Double.isNaN(size)) {
+            throw new IllegalArgumentException("size is not a number");
+        }
+        if (size < 0) {
+            throw new IllegalArgumentException("size is negative");
+        }
+        if (unit == null) {
+            throw new NullPointerException("unit is null");
+        }
+        if (size * unit.getFactor() > (double) Long.MAX_VALUE) {
+            throw new IllegalArgumentException("size is large than (2^63)-1 in bytes");
+        }
         this.bytes = (long) (size * unit.getFactor());
         this.displayUnit = unit;
     }
 
     public ByteSize(long bytes) {
         logger.warn("org.embulk.spi.unit.ByteSize is deprecated. Used at:", new Throwable());
-        Preconditions.checkArgument(bytes >= 0, "size is negative");
+        if (bytes < 0) {
+            throw new IllegalArgumentException("size is negative");
+        }
         this.bytes = bytes;
         this.displayUnit = Unit.BYTES;
     }
@@ -53,8 +64,12 @@ public class ByteSize implements Comparable<ByteSize> {
     }
 
     public static ByteSize parseByteSize(String size) {
-        Preconditions.checkNotNull(size, "size is null");
-        Preconditions.checkArgument(!size.isEmpty(), "size is empty");
+        if (size == null) {
+            throw new NullPointerException("size is null");
+        }
+        if (size.isEmpty()) {
+            throw new IllegalArgumentException("size is empty");
+        }
 
         Matcher matcher = PATTERN.matcher(size);
         if (!matcher.matches()) {

--- a/embulk-core/src/main/java/org/embulk/spi/util/DecodersInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DecodersInternal.java
@@ -1,6 +1,7 @@
 package org.embulk.spi.util;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskSource;
@@ -13,11 +14,11 @@ public abstract class DecodersInternal {
     private DecodersInternal() {}
 
     public static List<DecoderPlugin> newDecoderPlugins(ExecSessionInternal execInternal, List<ConfigSource> configs) {
-        ImmutableList.Builder<DecoderPlugin> builder = ImmutableList.builder();
+        final ArrayList<DecoderPlugin> builder = new ArrayList<>();
         for (ConfigSource config : configs) {
             builder.add(execInternal.newPlugin(DecoderPlugin.class, config.get(PluginType.class, "type")));
         }
-        return builder.build();
+        return Collections.unmodifiableList(builder);
     }
 
     public interface Control {
@@ -42,7 +43,7 @@ public abstract class DecodersInternal {
         private final List<DecoderPlugin> plugins;
         private final List<ConfigSource> configs;
         private final DecodersInternal.Control finalControl;
-        private final ImmutableList.Builder<TaskSource> taskSources;
+        private final ArrayList<TaskSource> taskSources;
         private int pos;
 
         RecursiveControl(List<DecoderPlugin> plugins, List<ConfigSource> configs,
@@ -50,7 +51,7 @@ public abstract class DecodersInternal {
             this.plugins = plugins;
             this.configs = configs;
             this.finalControl = finalControl;
-            this.taskSources = ImmutableList.builder();
+            this.taskSources = new ArrayList<>();
         }
 
         public void transaction() {
@@ -63,7 +64,7 @@ public abstract class DecodersInternal {
                         }
                     });
             } else {
-                finalControl.run(taskSources.build());
+                finalControl.run(Collections.unmodifiableList(this.taskSources));
             }
         }
     }

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetterFactory.java
@@ -3,6 +3,7 @@ package org.embulk.spi.util;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.Column;
+import org.embulk.spi.Exec;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.type.BooleanType;
 import org.embulk.spi.type.DoubleType;
@@ -84,39 +85,36 @@ class DynamicColumnSetterFactory {
     }
 
     private String getTimestampFormatForFormatter(Column column) {
-        DynamicPageBuilder.ColumnOption option = getColumnOption(column);
-        if (option != null) {
-            return option.getTimestampFormatString();
-        } else {
+        final ConfigSource option = this.getColumnOption(column);
+        if (option == null) {
             return "%Y-%m-%d %H:%M:%S.%6N";
         }
+        return option.get(String.class, "timestamp_format", "%Y-%m-%d %H:%M:%S.%6N");
     }
 
     private String getTimestampFormatForParser(Column column) {
-        DynamicPageBuilder.ColumnOption option = getColumnOption(column);
-        if (option != null) {
-            return option.getTimestampFormatString();
-        } else {
+        final ConfigSource option = this.getColumnOption(column);
+        if (option == null) {
             return "%Y-%m-%d %H:%M:%S.%N";
         }
+        return option.get(String.class, "timestamp_format", "%Y-%m-%d %H:%M:%S.%N");
     }
 
     private String getTimeZoneId(Column column) {
-        DynamicPageBuilder.ColumnOption option = getColumnOption(column);
-        if (option != null) {
-            return option.getTimeZoneId().or(task.getDefaultTimeZoneId());
-        } else {
-            return task.getDefaultTimeZoneId();
+        final ConfigSource option = this.getColumnOption(column);
+        if (option == null) {
+            return this.task.getDefaultTimeZoneId();
         }
+        return option.get(String.class, "timezone", this.task.getDefaultTimeZoneId());
     }
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1301
-    private DynamicPageBuilder.ColumnOption getColumnOption(Column column) {
-        ConfigSource option = task.getColumnOptions().get(column.getName());
+    private ConfigSource getColumnOption(final Column column) {
+        final ConfigSource option = this.task.getColumnOptions().get(column.getName());
         if (option != null) {
-            return option.loadConfig(DynamicPageBuilder.ColumnOption.class);
+            return option;
         } else {
-            return null;
+            return Exec.newConfigSource();
         }
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/util/EncodersInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/EncodersInternal.java
@@ -1,6 +1,7 @@
 package org.embulk.spi.util;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskSource;
@@ -13,11 +14,11 @@ public abstract class EncodersInternal {
     private EncodersInternal() {}
 
     public static List<EncoderPlugin> newEncoderPlugins(ExecSessionInternal exec, List<ConfigSource> configs) {
-        ImmutableList.Builder<EncoderPlugin> builder = ImmutableList.builder();
+        final ArrayList<EncoderPlugin> builder = new ArrayList<>();
         for (ConfigSource config : configs) {
             builder.add(exec.newPlugin(EncoderPlugin.class, config.get(PluginType.class, "type")));
         }
-        return builder.build();
+        return Collections.unmodifiableList(builder);
     }
 
     public interface Control {
@@ -44,7 +45,7 @@ public abstract class EncodersInternal {
         private final List<EncoderPlugin> plugins;
         private final List<ConfigSource> configs;
         private final EncodersInternal.Control finalControl;
-        private final ImmutableList.Builder<TaskSource> taskSources;
+        private final ArrayList<TaskSource> taskSources;
         private int pos;
 
         RecursiveControl(List<EncoderPlugin> plugins, List<ConfigSource> configs,
@@ -52,7 +53,7 @@ public abstract class EncodersInternal {
             this.plugins = plugins;
             this.configs = configs;
             this.finalControl = finalControl;
-            this.taskSources = ImmutableList.builder();
+            this.taskSources = new ArrayList<>();
         }
 
         public void transaction() {
@@ -65,7 +66,7 @@ public abstract class EncodersInternal {
                         }
                     });
             } else {
-                finalControl.run(taskSources.build());
+                finalControl.run(Collections.unmodifiableList(taskSources));
             }
         }
     }

--- a/embulk-core/src/main/java/org/embulk/spi/util/FiltersInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/FiltersInternal.java
@@ -1,6 +1,7 @@
 package org.embulk.spi.util;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskSource;
@@ -14,11 +15,11 @@ public abstract class FiltersInternal {
     private FiltersInternal() {}
 
     public static List<PluginType> getPluginTypes(List<ConfigSource> configs) {
-        ImmutableList.Builder<PluginType> builder = ImmutableList.builder();
+        final ArrayList<PluginType> builder = new ArrayList<>();
         for (ConfigSource config : configs) {
             builder.add(config.get(PluginType.class, "type"));
         }
-        return builder.build();
+        return Collections.unmodifiableList(builder);
     }
 
     public static List<FilterPlugin> newFilterPluginsFromConfigSources(ExecSessionInternal exec, List<ConfigSource> configs) {
@@ -26,11 +27,11 @@ public abstract class FiltersInternal {
     }
 
     public static List<FilterPlugin> newFilterPlugins(ExecSessionInternal exec, List<PluginType> pluginTypes) {
-        ImmutableList.Builder<FilterPlugin> builder = ImmutableList.builder();
+        final ArrayList<FilterPlugin> builder = new ArrayList<>();
         for (PluginType pluginType : pluginTypes) {
             builder.add(exec.newPlugin(FilterPlugin.class, pluginType));
         }
-        return builder.build();
+        return Collections.unmodifiableList(builder);
     }
 
     public interface Control {
@@ -57,8 +58,8 @@ public abstract class FiltersInternal {
         private final List<FilterPlugin> plugins;
         private final List<ConfigSource> configs;
         private final FiltersInternal.Control finalControl;
-        private final ImmutableList.Builder<TaskSource> taskSources;
-        private final ImmutableList.Builder<Schema> filterSchemas;
+        private final ArrayList<TaskSource> taskSources;
+        private final ArrayList<Schema> filterSchemas;
         private int pos;
 
         RecursiveControl(List<FilterPlugin> plugins, List<ConfigSource> configs,
@@ -66,8 +67,8 @@ public abstract class FiltersInternal {
             this.plugins = plugins;
             this.configs = configs;
             this.finalControl = finalControl;
-            this.taskSources = ImmutableList.builder();
-            this.filterSchemas = ImmutableList.builder();
+            this.taskSources = new ArrayList<>();
+            this.filterSchemas = new ArrayList<>();
         }
 
         public void transaction(Schema inputSchema) {
@@ -81,7 +82,7 @@ public abstract class FiltersInternal {
                         }
                     });
             } else {
-                finalControl.run(taskSources.build(), filterSchemas.build());
+                finalControl.run(Collections.unmodifiableList(this.taskSources), Collections.unmodifiableList(this.filterSchemas));
             }
         }
     }

--- a/embulk-core/src/main/java/org/embulk/spi/util/Pages.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Pages.java
@@ -1,6 +1,7 @@
 package org.embulk.spi.util;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.embulk.spi.Column;
@@ -17,12 +18,14 @@ import org.embulk.spi.Schema;
 @Deprecated
 public class Pages {
     public static List<Object[]> toObjects(Schema schema, Page page) {
-        return toObjects(schema, ImmutableList.of(page));
+        final ArrayList<Page> pages = new ArrayList<>();
+        pages.add(page);
+        return toObjects(schema, Collections.unmodifiableList(pages));
     }
 
     // TODO use streaming and return Iterable
     public static List<Object[]> toObjects(final Schema schema, final Iterable<Page> pages, final boolean useInstant) {
-        ImmutableList.Builder<Object[]> builder = ImmutableList.builder();
+        final ArrayList<Object[]> builder = new ArrayList<>();
         Iterator<Page> ite = pages.iterator();
         try (PageReader reader = new PageReader(schema)) {
             while (ite.hasNext()) {
@@ -32,7 +35,7 @@ public class Pages {
                 }
             }
         }
-        return builder.build();
+        return Collections.unmodifiableList(builder);
     }
 
     public static List<Object[]> toObjects(Schema schema, Iterable<Page> pages) {

--- a/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/Timestamps.java
@@ -1,19 +1,16 @@
 package org.embulk.spi.util;
 
-import com.google.common.base.Optional;
-import java.util.Map;
+import java.util.Optional;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
 import org.embulk.config.Task;
-import org.embulk.spi.Column;
 import org.embulk.spi.ColumnConfig;
-import org.embulk.spi.Schema;
 import org.embulk.spi.SchemaConfig;
 import org.embulk.spi.type.TimestampType;
 
 @Deprecated  // Along with TimestampFormatter and TimestampParser: https://github.com/embulk/embulk/issues/1298
 public class Timestamps {
     private Timestamps() {}
-
-    private interface TimestampColumnOption extends Task, org.embulk.spi.time.TimestampParser.TimestampColumnOption {}
 
     @Deprecated
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1289
@@ -23,29 +20,37 @@ public class Timestamps {
         int i = 0;
         for (ColumnConfig column : schema.getColumns()) {
             if (column.getType() instanceof TimestampType) {
-                TimestampColumnOption option = column.getOption().loadConfig(TimestampColumnOption.class);
-                parsers[i] = org.embulk.spi.time.TimestampParser.of(parserTask, option);
+                final ParserTimestampColumnOption option = column.getOption().loadConfig(ParserTimestampColumnOption.class);
+                parsers[i] = org.embulk.spi.time.TimestampParser.of(
+                        option.getFormat().orElse(parserTask.getDefaultTimestampFormat()),
+                        option.getTimeZoneId().orElse(parserTask.getDefaultTimeZoneId()),
+                        option.getDate().orElse(parserTask.getDefaultDate()));
             }
             i++;
         }
         return parsers;
     }
 
-    @Deprecated
-    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1289
-    public static org.embulk.spi.time.TimestampFormatter[] newTimestampColumnFormatters(
-            org.embulk.spi.time.TimestampFormatter.Task formatterTask, Schema schema,
-            Map<String, ? extends org.embulk.spi.time.TimestampFormatter.TimestampColumnOption> columnOptions) {
-        org.embulk.spi.time.TimestampFormatter[] formatters = new org.embulk.spi.time.TimestampFormatter[schema.getColumnCount()];
-        int i = 0;
-        for (Column column : schema.getColumns()) {
-            if (column.getType() instanceof TimestampType) {
-                final Optional<org.embulk.spi.time.TimestampFormatter.TimestampColumnOption> option =
-                        Optional.fromNullable(columnOptions.get(column.getName()));
-                formatters[i] = org.embulk.spi.time.TimestampFormatter.of(formatterTask, option);
-            }
-            i++;
-        }
-        return formatters;
+    private interface ParserTimestampColumnOption extends Task {
+        // From org.embulk.spi.time.TimestampParser.TimestampColumnOption.
+        @Config("timezone")
+        @ConfigDefault("null")
+        public Optional<String> getTimeZoneId();
+
+        // From org.embulk.spi.time.TimestampParser.TimestampColumnOption.
+        @Config("format")
+        @ConfigDefault("null")
+        public Optional<String> getFormat();
+
+        // From org.embulk.spi.time.TimestampParser.TimestampColumnOption.
+        @Config("date")
+        @ConfigDefault("null")
+        public Optional<String> getDate();
     }
+
+    // The method has been removed:
+    // public static org.embulk.spi.time.TimestampFormatter[] newTimestampColumnFormatters(
+    //         org.embulk.spi.time.TimestampFormatter.Task formatterTask,
+    //         Schema schema,
+    //         Map<String, ? extends org.embulk.spi.time.TimestampFormatter.TimestampColumnOption> columnOptions)
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/BooleanColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/BooleanColumnSetter.java
@@ -1,19 +1,24 @@
 package org.embulk.spi.util.dynamic;
 
-import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.msgpack.value.Value;
 
 public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
-    private static final ImmutableSet<String> TRUE_STRINGS =
-            ImmutableSet.of(
-                    "true", "True", "TRUE",
-                    "yes", "Yes", "YES",
-                    "t", "T", "y", "Y",
-                    "on", "On",
-                    "ON", "1");
+    private static final String[] TRUE_STRINGS_ARRAY = {
+            "true", "True", "TRUE",
+            "yes", "Yes", "YES",
+            "t", "T", "y", "Y",
+            "on", "On",
+            "ON", "1"};
+
+    private static final Set<String> TRUE_STRINGS = Collections.unmodifiableSet(
+            new LinkedHashSet<>(Arrays.asList(TRUE_STRINGS_ARRAY)));
 
     public BooleanColumnSetter(PageBuilder pageBuilder, Column column,
             DefaultValueSetter defaultValue) {

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/LongColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/LongColumnSetter.java
@@ -1,7 +1,5 @@
 package org.embulk.spi.util.dynamic;
 
-import com.google.common.math.DoubleMath;
-import java.math.RoundingMode;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
@@ -32,8 +30,15 @@ public class LongColumnSetter extends AbstractDynamicColumnSetter {
     public void set(double v) {
         long lv;
         try {
-            // TODO configurable rounding mode
-            lv = DoubleMath.roundToLong(v, RoundingMode.HALF_UP);
+            final double roundedDouble = Math.rint(v);
+            final double diff = v - roundedDouble;
+            if (diff == 0.5) {
+                lv = (long) (v + 0.5);
+            } else if (diff == -0.5) {
+                lv = (long) (v - 0.5);
+            } else {
+                lv = (long) roundedDouble;
+            }
         } catch (ArithmeticException ex) {
             // NaN / Infinite / -Infinite
             defaultValue.setLong(pageBuilder, column);

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/LongColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/LongColumnSetter.java
@@ -32,10 +32,8 @@ public class LongColumnSetter extends AbstractDynamicColumnSetter {
         try {
             final double roundedDouble = Math.rint(v);
             final double diff = v - roundedDouble;
-            if (diff == 0.5) {
-                lv = (long) (v + 0.5);
-            } else if (diff == -0.5) {
-                lv = (long) (v - 0.5);
+            if (Math.abs(diff) == 0.5) {
+                lv = (long) (v + Math.copySign(0.5, v));
             } else {
                 lv = (long) roundedDouble;
             }

--- a/embulk-deps/build.gradle
+++ b/embulk-deps/build.gradle
@@ -29,9 +29,6 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     api "com.fasterxml.jackson.core:jackson-core:2.6.7"
     api "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    api("com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7") {
-        exclude group: "com.google.guava", module: "guava"
-    }
     api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"
 
     api "javax.validation:validation-api:1.1.0.Final"
@@ -71,4 +68,5 @@ dependencies {
     testImplementation project(":embulk-core")
     testImplementation project(":embulk-junit4")
     testImplementation "junit:junit:4.13.2"
+    testImplementation "com.google.guava:guava:18.0"
 }

--- a/embulk-deps/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,9 +4,7 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
-com.google.guava:guava:18.0
 com.ibm.icu:icu4j:54.1.1
 commons-beanutils:commons-beanutils-core:1.8.3
 commons-cli:commons-cli:1.4

--- a/embulk-deps/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-deps/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -4,7 +4,6 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 com.ibm.icu:icu4j:54.1.1
 commons-beanutils:commons-beanutils-core:1.8.3

--- a/embulk-deps/src/main/java/org/embulk/deps/config/ConfigLoaderDelegateImpl.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/config/ConfigLoaderDelegateImpl.java
@@ -6,11 +6,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.embulk.config.ConfigSource;
@@ -94,11 +95,11 @@ public class ConfigLoaderDelegateImpl extends ConfigLoaderDelegate {
 
     @Override
     public ConfigSource fromPropertiesYamlLiteral(Properties props, String keyPrefix) {
-        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        final LinkedHashMap<String, String> builder = new LinkedHashMap<>();
         for (String propName : props.stringPropertyNames()) {
             builder.put(propName, props.getProperty(propName));
         }
-        return fromPropertiesYamlLiteral(builder.build(), keyPrefix);
+        return fromPropertiesYamlLiteral(Collections.unmodifiableMap(builder), keyPrefix);
     }
 
     @Override

--- a/embulk-deps/src/main/java/org/embulk/deps/config/ModelManagerDelegateImpl.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/config/ModelManagerDelegateImpl.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import javax.validation.Validation;
 import org.apache.bval.jsr303.ApacheValidationProvider;
@@ -37,7 +36,6 @@ public class ModelManagerDelegateImpl extends ModelManagerDelegate {
         objectMapper.registerModule(new TypeJacksonModule());
         objectMapper.registerModule(new ColumnJacksonModule());
         objectMapper.registerModule(new SchemaJacksonModule());
-        objectMapper.registerModule(new GuavaModule());  // jackson-datatype-guava
         objectMapper.registerModule(new Jdk8Module());  // jackson-datatype-jdk8
         this.configObjectMapper = objectMapper.copy();
         this.taskValidator = new TaskValidator(

--- a/embulk-deps/src/main/java/org/embulk/deps/config/ResumeStateJacksonModule.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/config/ResumeStateJacksonModule.java
@@ -14,10 +14,10 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Optional;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
@@ -103,7 +103,7 @@ final class ResumeStateJacksonModule extends SimpleModule {
                 final ArrayList<Optional<TaskReport>> inputTaskReports = new ArrayList<>();
                 for (final JsonNode inputTaskReportNode : (ArrayNode) inputTaskReportsNode) {
                     if (inputTaskReportNode == null || inputTaskReportNode.isNull()) {
-                        inputTaskReports.add(Optional.<TaskReport>absent());
+                        inputTaskReports.add(Optional.<TaskReport>empty());
                     } else {
                         inputTaskReports.add(Optional.of(this.model.readObject(TaskReport.class, inputTaskReportNode.traverse())));
                     }
@@ -117,7 +117,7 @@ final class ResumeStateJacksonModule extends SimpleModule {
                 final ArrayList<Optional<TaskReport>> outputTaskReports = new ArrayList<>();
                 for (final JsonNode outputTaskReportNode : (ArrayNode) outputTaskReportsNode) {
                     if (outputTaskReportNode == null || outputTaskReportNode.isNull()) {
-                        outputTaskReports.add(Optional.<TaskReport>absent());
+                        outputTaskReports.add(Optional.<TaskReport>empty());
                     } else {
                         outputTaskReports.add(Optional.of(this.model.readObject(TaskReport.class, outputTaskReportNode.traverse())));
                     }

--- a/embulk-deps/src/main/java/org/embulk/deps/config/TaskInvocationHandler.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/config/TaskInvocationHandler.java
@@ -1,13 +1,15 @@
 package org.embulk.deps.config;
 
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.embulk.config.Config;
 import org.embulk.config.TaskSource;
@@ -31,18 +33,18 @@ class TaskInvocationHandler implements InvocationHandler {
      *
      * It expects to be called only from TaskSerDe. Multimap is used inside org.embulk.config.
      */
-    static Multimap<String, Method> fieldGetters(Class<?> iface) {
-        ImmutableMultimap.Builder<String, Method> builder = ImmutableMultimap.builder();
+    static List<Map.Entry<String, Method>> fieldGetters(final Class<?> iface) {
+        final ArrayList<Map.Entry<String, Method>> builder = new ArrayList<>();
         for (Method method : iface.getMethods()) {
             String methodName = method.getName();
             String fieldName = getterFieldNameOrNull(methodName);
             if (fieldName != null && hasExpectedArgumentLength(method, 0)
                     && (!method.isDefault() || method.getAnnotation(Config.class) != null)) {
                 // If the method has default implementation, and @Config is not annotated there, the method is kept.
-                builder.put(fieldName, method);
+                builder.add(new AbstractMap.SimpleImmutableEntry<>(fieldName, method));
             }
         }
-        return builder.build();
+        return Collections.unmodifiableList(builder);
     }
 
     // visible for ModelManagerDelegateImpl.AccessorSerializer

--- a/embulk-deps/src/main/java/org/embulk/deps/config/TaskSerDe.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/config/TaskSerDe.java
@@ -17,17 +17,22 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.Deserializers;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigException;
@@ -69,7 +74,7 @@ class TaskSerDe {
         private final ModelManagerDelegateImpl model;
 
         private final Class<?> iface;
-        private final Multimap<String, FieldEntry> mappings;
+        private final Map<String, List<FieldEntry>> mappings;
 
         public TaskDeserializer(ObjectMapper nestedObjectMapper, ModelManagerDelegateImpl model, Class<T> iface) {
             this.nestedObjectMapper = nestedObjectMapper;
@@ -78,8 +83,8 @@ class TaskSerDe {
             this.mappings = getterMappings(iface);
         }
 
-        protected Multimap<String, FieldEntry> getterMappings(Class<?> iface) {
-            ImmutableMultimap.Builder<String, FieldEntry> builder = ImmutableMultimap.builder();
+        protected Map<String, List<FieldEntry>> getterMappings(Class<?> iface) {
+            final LinkedHashMap<String, ArrayList<FieldEntry>> builder = new LinkedHashMap<>();
             for (Map.Entry<String, Method> getter : TaskInvocationHandler.fieldGetters(iface)) {
                 Method getterMethod = getter.getValue();
                 String fieldName = getter.getKey();
@@ -98,9 +103,24 @@ class TaskSerDe {
                     continue;
                 }
                 final Optional<String> defaultJsonString = getDefaultJsonString(getterMethod);
-                builder.put(jsonKey.get(), new FieldEntry(fieldName, fieldType, defaultJsonString));
+                builder.compute(jsonKey.get(), (key, oldValue) -> {
+                    final ArrayList<FieldEntry> newValue;
+                    if (oldValue == null) {
+                        newValue = new ArrayList<>();
+                    } else {
+                        newValue = oldValue;
+                    }
+                    newValue.add(new FieldEntry(fieldName, fieldType, defaultJsonString));
+                    return newValue;
+                });
             }
-            return builder.build();
+            return Collections.unmodifiableMap(StreamSupport.stream(builder.entrySet().spliterator(), false)
+                    .map(entry -> new AbstractMap.SimpleImmutableEntry<>(entry.getKey(), Collections.unmodifiableList(entry.getValue())))
+                    .collect(Collectors.toMap(
+                            Map.Entry<String, List<FieldEntry>>::getKey,
+                            Map.Entry<String, List<FieldEntry>>::getValue,
+                            (e1, e2) -> e1,
+                            LinkedHashMap::new)));
         }
 
         protected Optional<String> getJsonKey(final Method getterMethod, final String fieldName) {
@@ -115,7 +135,12 @@ class TaskSerDe {
         @SuppressWarnings("unchecked")
         public T deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
             Map<String, Object> objects = new ConcurrentHashMap<String, Object>();
-            HashMultimap<String, FieldEntry> unusedMappings = HashMultimap.<String, FieldEntry>create(mappings);
+            final ArrayList<Map.Entry<String, FieldEntry>> unusedMappings = new ArrayList<>();
+            for (final Map.Entry<String, List<FieldEntry>> entry : this.mappings.entrySet()) {
+                for (final FieldEntry fieldEntry : entry.getValue()) {
+                    unusedMappings.add(new AbstractMap.SimpleImmutableEntry(entry.getKey(), fieldEntry));
+                }
+            }
 
             String key;
             JsonToken current = jp.getCurrentToken();
@@ -129,7 +154,7 @@ class TaskSerDe {
             for (; key != null; key = jp.nextFieldName()) {
                 JsonToken t = jp.nextToken(); // to get to value
                 final Collection<FieldEntry> fields = mappings.get(key);
-                if (fields.isEmpty()) {
+                if (fields == null || fields.isEmpty()) {
                     jp.skipChildren();
                 } else {
                     final JsonNode children = nestedObjectMapper.readValue(jp, JsonNode.class);
@@ -139,7 +164,7 @@ class TaskSerDe {
                             throw new JsonMappingException("Setting null to a task field is not allowed. Use Optional<T> to represent null.");
                         }
                         objects.put(field.getName(), value);
-                        if (!unusedMappings.remove(key, field)) {
+                        if (!unusedMappings.remove(new AbstractMap.SimpleImmutableEntry(key, field))) {
                             throw new JsonMappingException(String.format(
                                     "FATAL: Expected to be a bug in Embulk. Mapping \"%s: (%s) %s\" might have already been processed, or not in %s.",
                                     key,
@@ -152,7 +177,7 @@ class TaskSerDe {
             }
 
             // set default values
-            for (Map.Entry<String, FieldEntry> unused : unusedMappings.entries()) {
+            for (final Map.Entry<String, FieldEntry> unused : unusedMappings) {
                 FieldEntry field = unused.getValue();
                 if (field.getDefaultJsonString().isPresent()) {
                     Object value = nestedObjectMapper.readValue(field.getDefaultJsonString().get(), new GenericTypeReference(field.getType()));
@@ -197,6 +222,25 @@ class TaskSerDe {
 
             public Optional<String> getDefaultJsonString() {
                 return defaultJsonString;
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(this.name, this.type, this.defaultJsonString);
+            }
+
+            @Override
+            public boolean equals(final Object otherObject) {
+                if (this == otherObject) {
+                    return true;
+                }
+                if (!(otherObject instanceof FieldEntry)) {
+                    return false;
+                }
+                final FieldEntry other = (FieldEntry) otherObject;
+                return Objects.equals(this.name, other.name)
+                        && Objects.equals(this.type, other.type)
+                        && Objects.equals(this.defaultJsonString, other.defaultJsonString);
             }
         }
     }

--- a/embulk-deps/src/main/java/org/embulk/deps/config/TaskSerDe.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/config/TaskSerDe.java
@@ -80,7 +80,7 @@ class TaskSerDe {
 
         protected Multimap<String, FieldEntry> getterMappings(Class<?> iface) {
             ImmutableMultimap.Builder<String, FieldEntry> builder = ImmutableMultimap.builder();
-            for (Map.Entry<String, Method> getter : TaskInvocationHandler.fieldGetters(iface).entries()) {
+            for (Map.Entry<String, Method> getter : TaskInvocationHandler.fieldGetters(iface)) {
                 Method getterMethod = getter.getValue();
                 String fieldName = getter.getKey();
 

--- a/embulk-deps/src/main/java/org/embulk/deps/config/TypeDeserializer.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/config/TypeDeserializer.java
@@ -3,9 +3,9 @@ package org.embulk.deps.config;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
@@ -14,14 +14,14 @@ class TypeDeserializer extends FromStringDeserializer<Type> {
     private static final Map<String, Type> stringToTypeMap;
 
     static {
-        ImmutableMap.Builder<String, Type> builder = ImmutableMap.builder();
+        final LinkedHashMap<String, Type> builder = new LinkedHashMap<>();
         builder.put(Types.BOOLEAN.getName(), Types.BOOLEAN);
         builder.put(Types.LONG.getName(), Types.LONG);
         builder.put(Types.DOUBLE.getName(), Types.DOUBLE);
         builder.put(Types.STRING.getName(), Types.STRING);
         builder.put(Types.TIMESTAMP.getName(), Types.TIMESTAMP);
         builder.put(Types.JSON.getName(), Types.JSON);
-        stringToTypeMap = builder.build();
+        stringToTypeMap = Collections.unmodifiableMap(builder);
     }
 
     public TypeDeserializer() {
@@ -35,7 +35,7 @@ class TypeDeserializer extends FromStringDeserializer<Type> {
             throw new JsonMappingException(
                     String.format("Unknown type name '%s'. Supported types are: %s",
                                   value,
-                                  Joiner.on(", ").join(stringToTypeMap.keySet())));
+                                  String.join(", ", stringToTypeMap.keySet())));
         }
         return t;
     }

--- a/embulk-deps/src/main/java/org/embulk/deps/preview/ValueFormatter.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/preview/ValueFormatter.java
@@ -2,7 +2,6 @@ package org.embulk.deps.preview;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.text.NumberFormat;
 import java.time.Instant;
@@ -28,7 +27,6 @@ final class ValueFormatter {
         this.objectMapper.registerModule(new ToStringJacksonModule());
         this.objectMapper.registerModule(new ToStringMapJacksonModule());
         // PreviewPrinter would not need TypeJacksonModule, ColumnJacksonModule, and SchemaJacksonModule.
-        this.objectMapper.registerModule(new GuavaModule());
         this.objectMapper.registerModule(new Jdk8Module());
     }
 

--- a/embulk-junit4/src/main/java/org/embulk/test/TestingBulkLoader.java
+++ b/embulk-junit4/src/main/java/org/embulk/test/TestingBulkLoader.java
@@ -1,8 +1,9 @@
 package org.embulk.test;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.TaskReport;
 import org.embulk.exec.BulkLoader;
@@ -51,11 +52,11 @@ class TestingBulkLoader extends BulkLoader {
         }
 
         private static List<TaskReport> buildReports(List<Optional<TaskReport>> optionalReports, ExecSessionInternal session) {
-            ImmutableList.Builder<TaskReport> reports = ImmutableList.builder();
+            final ArrayList<TaskReport> reports = new ArrayList<>();
             for (Optional<TaskReport> report : optionalReports) {
-                reports.add(report.or(session.newTaskReport()));
+                reports.add(report.orElse(session.newTaskReport()));
             }
-            return reports.build();
+            return Collections.unmodifiableList(reports);
         }
 
         @Override


### PR DESCRIPTION
Like we did move Jackson from embulk-core's top-level class loader in #1437, we'd also like to remove Guava so that embulk-core's Guava does not interfere plugin's Guava.

But unlike Jackson, all Guava usage in Embulk can be replaced with trivial use of Java 8 features. We decided to remove all Guava usage, then.