### PR TITLE
Revert "Set guess_sample_buffer_bytes and preview_sample_buffer_bytes from Embulk System Properties"

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -79,7 +79,7 @@ public class EmbulkEmbed {
 
         this.bulkLoader = injector.getInstance(BulkLoader.class);
         this.guessExecutor = injector.getInstance(GuessExecutor.class);
-        this.previewExecutor = new PreviewExecutor(embulkSystemProperties);
+        this.previewExecutor = new PreviewExecutor();
     }
 
     public static class Bootstrap {

--- a/embulk-core/src/main/java/org/embulk/EmbulkSystemProperties.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkSystemProperties.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -62,14 +61,6 @@ public final class EmbulkSystemProperties extends Properties {
             return defaultValue;
         }
         return parseInteger(value);
-    }
-
-    public OptionalInt getPropertyAsOptionalInt(final String key) {
-        final String value = this.getProperty(key);
-        if (value == null) {
-            return OptionalInt.empty();
-        }
-        return OptionalInt.of(parseInteger(value));
     }
 
     @Override  // From Properties

--- a/embulk-core/src/main/java/org/embulk/plugin/BuiltinPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/BuiltinPluginSource.java
@@ -3,7 +3,6 @@ package org.embulk.plugin;
 import com.google.inject.Injector;  // Only for instantiating a plugin.
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.embulk.EmbulkSystemProperties;
 import org.embulk.spi.DecoderPlugin;
 import org.embulk.spi.EncoderPlugin;
 import org.embulk.spi.ExecutorPlugin;
@@ -21,7 +20,6 @@ import org.embulk.spi.ParserPlugin;
 public class BuiltinPluginSource implements PluginSource {
     private BuiltinPluginSource(
             final Injector injector,
-            final EmbulkSystemProperties embulkSystemProperties,
             final Map<String, Class<? extends DecoderPlugin>> decoderPlugins,
             final Map<String, Class<? extends EncoderPlugin>> encoderPlugins,
             final Map<String, Class<? extends ExecutorPlugin>> executorPlugins,
@@ -34,7 +32,6 @@ public class BuiltinPluginSource implements PluginSource {
             final Map<String, Class<? extends OutputPlugin>> outputPlugins,
             final Map<String, Class<? extends ParserPlugin>> parserPlugins) {
         this.injector = injector;
-        this.embulkSystemProperties = embulkSystemProperties;
         this.decoderPlugins = decoderPlugins;
         this.encoderPlugins = encoderPlugins;
         this.executorPlugins = executorPlugins;
@@ -149,15 +146,9 @@ public class BuiltinPluginSource implements PluginSource {
             return this;
         }
 
-        public Builder setEmbulkSystemProperties(final EmbulkSystemProperties embulkSystemProperties) {
-            this.embulkSystemProperties = embulkSystemProperties;
-            return this;
-        }
-
         public BuiltinPluginSource build() {
             return new BuiltinPluginSource(
                     this.injector,
-                    this.embulkSystemProperties,
                     this.decoderPlugins,
                     this.encoderPlugins,
                     this.executorPlugins,
@@ -183,8 +174,6 @@ public class BuiltinPluginSource implements PluginSource {
         private final LinkedHashMap<String, Class<? extends InputPlugin>> inputPlugins;
         private final LinkedHashMap<String, Class<? extends OutputPlugin>> outputPlugins;
         private final LinkedHashMap<String, Class<? extends ParserPlugin>> parserPlugins;
-
-        private EmbulkSystemProperties embulkSystemProperties;
     }
 
     public static Builder builder(final Injector injector) {
@@ -206,8 +195,7 @@ public class BuiltinPluginSource implements PluginSource {
             }
             final Class<? extends FileInputPlugin> fileInputPluginImpl = this.fileInputPlugins.get(name);
             if (fileInputPluginImpl != null) {
-                return pluginInterface.cast(new FileInputRunner(
-                        (FileInputPlugin) this.injector.getInstance(fileInputPluginImpl), this.embulkSystemProperties));
+                return pluginInterface.cast(new FileInputRunner((FileInputPlugin) this.injector.getInstance(fileInputPluginImpl)));
             }
         } else if (OutputPlugin.class.isAssignableFrom(pluginInterface)) {
             // Duplications between Output Plugins and File Output Plugins are rejected when registered above.
@@ -247,7 +235,6 @@ public class BuiltinPluginSource implements PluginSource {
     }
 
     private final Injector injector;
-    private final EmbulkSystemProperties embulkSystemProperties;
     private final Map<String, Class<? extends DecoderPlugin>> decoderPlugins;
     private final Map<String, Class<? extends EncoderPlugin>> encoderPlugins;
     private final Map<String, Class<? extends ExecutorPlugin>> executorPlugins;

--- a/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginSource.java
@@ -96,7 +96,7 @@ public class SelfContainedPluginSource implements PluginSource {
                             "[FATAL/INTERNAL] Plugin class \"" + pluginMainClass.getName() + "\" is not file-input.",
                             ex);
                 }
-                pluginMainObject = new FileInputRunner(fileInputPluginMainObject, this.embulkSystemProperties);
+                pluginMainObject = new FileInputRunner(fileInputPluginMainObject);
             } else if (FileOutputPlugin.class.isAssignableFrom(pluginMainClass)) {
                 final FileOutputPlugin fileOutputPluginMainObject;
                 try {

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
@@ -125,7 +125,7 @@ public class MavenPluginSource implements PluginSource {
                             "[FATAL/INTERNAL] Plugin class \"" + pluginMainClass.getName() + "\" is not file-input.",
                             ex);
                 }
-                pluginMainObject = new FileInputRunner(fileInputPluginMainObject, this.embulkSystemProperties);
+                pluginMainObject = new FileInputRunner(fileInputPluginMainObject);
             } else if (FileOutputPlugin.class.isAssignableFrom(pluginMainClass)) {
                 final FileOutputPlugin fileOutputPluginMainObject;
                 try {

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSessionInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSessionInternal.java
@@ -150,7 +150,6 @@ public class ExecSessionInternal extends ExecSession {
 
         public Builder setEmbulkSystemProperties(final EmbulkSystemProperties embulkSystemProperties) {
             this.embulkSystemProperties = embulkSystemProperties;
-            this.builtinPluginSourceBuilder.setEmbulkSystemProperties(embulkSystemProperties);
             return this;
         }
 

--- a/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
@@ -4,7 +4,6 @@ import static org.embulk.exec.GuessExecutor.createSampleBufferConfigFromExecConf
 
 import java.util.ArrayList;
 import java.util.List;
-import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -20,11 +19,9 @@ import org.embulk.spi.util.DecodersInternal;
 
 public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugin {
     private final FileInputPlugin fileInputPlugin;
-    private final EmbulkSystemProperties embulkSystemProperties;
 
-    public FileInputRunner(final FileInputPlugin fileInputPlugin, final EmbulkSystemProperties embulkSystemProperties) {
+    public FileInputRunner(FileInputPlugin fileInputPlugin) {
         this.fileInputPlugin = fileInputPlugin;
-        this.embulkSystemProperties = embulkSystemProperties;
     }
 
     private interface RunnerTask extends Task {
@@ -78,8 +75,7 @@ public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugi
     }
 
     public ConfigDiff guess(ConfigSource execConfig, ConfigSource inputConfig) {
-        final ConfigSource sampleBufferConfig = createSampleBufferConfigFromExecConfig(
-                execConfig, this.embulkSystemProperties);
+        final ConfigSource sampleBufferConfig = createSampleBufferConfigFromExecConfig(execConfig);
         final Buffer sample = SamplingParserPlugin.runFileInputSampling(this, inputConfig, sampleBufferConfig);
         // SamplingParserPlugin.runFileInputSampling throws NoSampleException if there're
         // no files or all files are smaller than minSampleSize (40 bytes).

--- a/embulk-core/src/test/java/org/embulk/spi/TestFileInputRunner.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestFileInputRunner.java
@@ -9,9 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Properties;
 import java.util.Queue;
-import org.embulk.EmbulkSystemProperties;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
@@ -96,7 +94,7 @@ public class TestFileInputRunner {
                 runtime.getBufferAllocator().allocate() };
         MockFileInputPlugin fileInputPlugin = new MockFileInputPlugin(
                 new LinkedList<Buffer>(Arrays.asList(buffers)));
-        final FileInputRunner runner = new FileInputRunner(fileInputPlugin, EmbulkSystemProperties.of(new Properties()));
+        final FileInputRunner runner = new FileInputRunner(fileInputPlugin);
 
         ConfigSource config = Exec.newConfigSource().set(
                 "parser",
@@ -145,7 +143,7 @@ public class TestFileInputRunner {
                 runtime.getBufferAllocator().allocate() };
         MockFileInputPlugin fileInputPlugin = new MockFileInputPlugin(
                 new LinkedList<Buffer>(Arrays.asList(buffers)));
-        final FileInputRunner runner = new FileInputRunner(fileInputPlugin, EmbulkSystemProperties.of(new Properties()));
+        final FileInputRunner runner = new FileInputRunner(fileInputPlugin);
 
         ConfigSource config = Exec.newConfigSource().set(
                 "parser",


### PR DESCRIPTION
Reverting #1414 since it caused an error in loading a File Input Plugin in a Ruby gem format.

It changed the arguments of Java `FileInputRunner`'s constructor, but the Ruby side did not catch up. It caused the error below.

Unfortunately, it is not trivial to pass the second argument, `EmbulkSystemProperties`, from Ruby as of now -- it would be easier with a planned change when Guice is removed. This change #1414 was not necessary as of now. Let's revert it now, and think about it later.

```
	Caused by: org.jruby.embed.InvokeFailedException: (ArgumentError) wrong number of arguments (1 for 2)
		at org.jruby.embed.internal.EmbedRubyObjectAdapterImpl.call(EmbedRubyObjectAdapterImpl.java:320)
		at org.jruby.embed.internal.EmbedRubyObjectAdapterImpl.callMethod(EmbedRubyObjectAdapterImpl.java:159)
		at org.jruby.embed.ScriptingContainer.callMethod(ScriptingContainer.java:1459)
		at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.lang.reflect.Method.invoke(Method.java:498)
		at org.embulk.jruby.ScriptingContainerDelegateImpl.callMethod(ScriptingContainerDelegateImpl.java:634)
		at org.embulk.jruby.LazyScriptingContainerDelegate.callMethod(LazyScriptingContainerDelegate.java:233)
		at org.embulk.jruby.JRubyPluginSource.newPlugin(JRubyPluginSource.java:87)
		... 16 more
	Caused by: org.jruby.exceptions.RaiseException: (ArgumentError) wrong number of arguments (1 for 2)
		at RUBY.new_java(/home/dai/work/embulk/.embulk/lib/gems/gems/embulk-0.10.32.snapshot-java/lib/embulk/file_input_plugin.rb:16)
		at RUBY.new_java_input(/home/dai/work/embulk/.embulk/lib/gems/gems/embulk-0.10.32.snapshot-java/lib/embulk/plugin.rb:155)
		at RUBY.new_java_input(uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/forwardable.rb:189)
```
