### PR TITLE
Move dependency on javax.inject to embulk-api from embulk-core

### DIFF
--- a/embulk-api/build.gradle
+++ b/embulk-api/build.gradle
@@ -12,4 +12,9 @@ configurations {
 dependencies {
     api "org.msgpack:msgpack-core:0.8.11"
     api "org.slf4j:slf4j-api:1.7.30"
+
+    // We have a plan to enable @Inject for each plugin instance.
+    // "javax.inject" is intentionally included in "embulk-api" for that purpose.
+    // https://github.com/embulk/embulk/issues/1452
+    api "javax.inject:javax.inject:1"
 }

--- a/embulk-api/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-api/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,5 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-api/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-api/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,5 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     api project(":embulk-api")
     api project(":embulk-spi")
     api "com.google.guava:guava:18.0"
-    api "javax.inject:javax.inject:1"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":embulk-junit4")

--- a/embulk-decoder-bzip2/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-decoder-bzip2/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.apache.commons:commons-compress:1.10
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3

--- a/embulk-decoder-gzip/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-decoder-gzip/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3
 org.msgpack:msgpack-core:0.8.11

--- a/embulk-encoder-bzip2/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-encoder-bzip2/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.apache.commons:commons-compress:1.10
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3

--- a/embulk-encoder-gzip/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-encoder-gzip/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3
 org.msgpack:msgpack-core:0.8.11

--- a/embulk-filter-remove_columns/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-filter-remove_columns/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-filter-rename/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-filter-rename/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-formatter-csv/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-formatter-csv/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,6 +4,7 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-text:0.1.0

--- a/embulk-guess-bzip2/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-bzip2/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-guess-csv/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-csv/gradle/dependency-locks/compileClasspath.lockfile
@@ -5,6 +5,7 @@ com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.ibm.icu:icu4j:54.1.1
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-guess:0.1.1

--- a/embulk-guess-csv_all_strings/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-csv_all_strings/gradle/dependency-locks/compileClasspath.lockfile
@@ -5,6 +5,7 @@ com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.ibm.icu:icu4j:54.1.1
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-guess:0.1.1

--- a/embulk-guess-gzip/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-gzip/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-guess-json/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-json/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,6 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-core:2.6.7
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-json:0.1.0

--- a/embulk-input-config/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-input-config/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,6 +4,7 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-file/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-input-file/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3
 org.msgpack:msgpack-core:0.8.11

--- a/embulk-output-file/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-output-file/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-output-null/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-output-null/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-output-stdout/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-output-stdout/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11

--- a/embulk-parser-csv/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-parser-csv/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,6 +4,7 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-json:0.1.0

--- a/embulk-parser-json/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-parser-json/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,6 +4,7 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
+javax.inject:javax.inject:1
 org.embulk:embulk-util-config:0.2.1
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-json:0.1.0

--- a/embulk-spi/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-spi/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,5 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-spi/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-spi/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,5 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+javax.inject:javax.inject:1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30


### PR DESCRIPTION
Note: we need to reconsider this because `javax.inject.Inject` is going to be modified to `jakarta.inject.Inject`. There will be no compatibility.
https://github.com/eclipse-ee4j/injection-api/blob/2.0.0/src/main/java/jakarta/inject/Inject.java