### PR TITLE
Update standard plugin's embulk-util-config to 0.3.0, embulk-util-text to 0.1.1, and embulk-util-json to 0.1.1

### DIFF
--- a/embulk-decoder-bzip2/build.gradle
+++ b/embulk-decoder-bzip2/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
     compile "org.apache.commons:commons-compress:1.10"
 }

--- a/embulk-decoder-bzip2/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-decoder-bzip2/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.apache.commons:commons-compress:1.10
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-decoder-bzip2/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-decoder-bzip2/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,5 +7,5 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.apache.commons:commons-compress:1.10
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3

--- a/embulk-decoder-gzip/build.gradle
+++ b/embulk-decoder-gzip/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
 }
 

--- a/embulk-decoder-gzip/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-decoder-gzip/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-decoder-gzip/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-decoder-gzip/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,5 +6,5 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3

--- a/embulk-encoder-bzip2/build.gradle
+++ b/embulk-encoder-bzip2/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
     compile "org.apache.commons:commons-compress:1.10"
 }

--- a/embulk-encoder-bzip2/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-encoder-bzip2/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.apache.commons:commons-compress:1.10
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-encoder-bzip2/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-encoder-bzip2/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,5 +7,5 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.apache.commons:commons-compress:1.10
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3

--- a/embulk-encoder-gzip/build.gradle
+++ b/embulk-encoder-gzip/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
 }
 

--- a/embulk-encoder-gzip/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-encoder-gzip/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-encoder-gzip/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-encoder-gzip/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,5 +6,5 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3

--- a/embulk-filter-remove_columns/build.gradle
+++ b/embulk-filter-remove_columns/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
 
     testImplementation "junit:junit:4.12"
     testImplementation project(":embulk-api")

--- a/embulk-filter-remove_columns/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-filter-remove_columns/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-filter-remove_columns/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-filter-remove_columns/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,4 +6,4 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0

--- a/embulk-filter-rename/build.gradle
+++ b/embulk-filter-rename/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
 
     testImplementation "junit:junit:4.12"
     testImplementation project(":embulk-api")

--- a/embulk-filter-rename/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-filter-rename/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-filter-rename/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-filter-rename/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,4 +6,4 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0

--- a/embulk-formatter-csv/build.gradle
+++ b/embulk-formatter-csv/build.gradle
@@ -26,9 +26,9 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-core:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
-    compile "org.embulk:embulk-util-text:0.1.0"
+    compile "org.embulk:embulk-util-text:0.1.1"
     compile "org.embulk:embulk-util-timestamp:0.2.1"
 
     testImplementation "junit:junit:4.12"

--- a/embulk-formatter-csv/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-formatter-csv/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,9 +4,9 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
-org.embulk:embulk-util-text:0.1.0
+org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-formatter-csv/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-formatter-csv/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,8 +6,8 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-rubytime:0.3.2
-org.embulk:embulk-util-text:0.1.0
+org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-formatter-csv/src/main/java/org/embulk/formatter/csv/CsvFormatterPlugin.java
+++ b/embulk-formatter-csv/src/main/java/org/embulk/formatter/csv/CsvFormatterPlugin.java
@@ -36,7 +36,6 @@ import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.config.Task;
-import org.embulk.util.config.modules.CharsetModule;
 import org.embulk.util.text.LineEncoder;
 import org.embulk.util.text.Newline;
 import org.embulk.util.timestamp.TimestampFormatter;
@@ -370,10 +369,7 @@ public class CsvFormatterPlugin implements FormatterPlugin {
         }
     }
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder()
-            .addDefaultModules()
-            .addModule(new CharsetModule())
-            .build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 
     private static final Logger logger = LoggerFactory.getLogger(CsvFormatterPlugin.class);
 }

--- a/embulk-formatter-csv/src/test/java/org/embulk/formatter/csv/TestCsvFormatterPlugin.java
+++ b/embulk-formatter-csv/src/test/java/org/embulk/formatter/csv/TestCsvFormatterPlugin.java
@@ -27,7 +27,6 @@ import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigSource;
 import org.embulk.util.config.ConfigMapper;
 import org.embulk.util.config.ConfigMapperFactory;
-import org.embulk.util.config.modules.CharsetModule;
 import org.embulk.util.text.Newline;
 import org.junit.Rule;
 import org.junit.Test;
@@ -316,10 +315,7 @@ public class TestCsvFormatterPlugin {
         assertEquals("N/A", method.invoke(formatter, "N/A", delimiter, CsvFormatterPlugin.QuotePolicy.NONE, quote, escape, newline, "N/A"));
     }
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder()
-            .addDefaultModules()
-            .addModule(new CharsetModule())
-            .build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 
     private static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
 }

--- a/embulk-guess-bzip2/build.gradle
+++ b/embulk-guess-bzip2/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
 }
 
 embulkPlugin {

--- a/embulk-guess-bzip2/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-bzip2/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-guess-bzip2/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-guess-bzip2/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,4 +6,4 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0

--- a/embulk-guess-csv/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-csv/gradle/dependency-locks/compileClasspath.lockfile
@@ -8,7 +8,7 @@ com.ibm.icu:icu4j:54.1.1
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-guess:0.1.1
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11

--- a/embulk-guess-csv/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-csv/gradle/dependency-locks/compileClasspath.lockfile
@@ -5,11 +5,11 @@ com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.ibm.icu:icu4j:54.1.1
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-guess:0.1.1
 org.embulk:embulk-util-json:0.1.0
-org.embulk:embulk-util-text:0.1.0
+org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-guess-csv/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-guess-csv/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -10,7 +10,7 @@ javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-guess:0.1.1
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-guess-csv/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-guess-csv/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,10 +7,10 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 com.ibm.icu:icu4j:54.1.1
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-guess:0.1.1
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
-org.embulk:embulk-util-text:0.1.0
+org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-guess-csv/src/main/java/org/embulk/guess/csv/CsvGuessPlugin.java
+++ b/embulk-guess-csv/src/main/java/org/embulk/guess/csv/CsvGuessPlugin.java
@@ -35,7 +35,6 @@ import org.embulk.spi.Buffer;
 import org.embulk.spi.Exec;
 import org.embulk.spi.GuessPlugin;
 import org.embulk.util.config.ConfigMapperFactory;
-import org.embulk.util.config.modules.TypeModule;
 import org.embulk.util.file.ListFileInput;
 import org.embulk.util.guess.CharsetGuess;
 import org.embulk.util.guess.LineGuessHelper;
@@ -598,10 +597,7 @@ public class CsvGuessPlugin implements GuessPlugin {
         return data.toByteArray();
     }
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder()
-            .addDefaultModules()
-            .addModule(new TypeModule())
-            .build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 
     private static List<Character> DELIMITER_CANDIDATES = Collections.unmodifiableList(Arrays.asList(
             ',',

--- a/embulk-guess-csv/src/test/java/org/embulk/guess/csv/TestCsvGuessPlugin.java
+++ b/embulk-guess-csv/src/test/java/org/embulk/guess/csv/TestCsvGuessPlugin.java
@@ -27,7 +27,6 @@ import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.util.config.ConfigMapperFactory;
-import org.embulk.util.config.modules.TypeModule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -391,8 +390,5 @@ public class TestCsvGuessPlugin {
         return new CsvGuessPlugin().guessLines(config, Arrays.asList(sampleLines));
     }
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder()
-            .addDefaultModules()
-            .addModule(new TypeModule())
-            .build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 }

--- a/embulk-guess-csv_all_strings/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-csv_all_strings/gradle/dependency-locks/compileClasspath.lockfile
@@ -8,7 +8,7 @@ com.ibm.icu:icu4j:54.1.1
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-guess:0.1.1
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11

--- a/embulk-guess-csv_all_strings/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-csv_all_strings/gradle/dependency-locks/compileClasspath.lockfile
@@ -5,11 +5,11 @@ com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.ibm.icu:icu4j:54.1.1
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-guess:0.1.1
 org.embulk:embulk-util-json:0.1.0
-org.embulk:embulk-util-text:0.1.0
+org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-guess-csv_all_strings/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-guess-csv_all_strings/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -10,7 +10,7 @@ javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-guess:0.1.1
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-guess-csv_all_strings/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-guess-csv_all_strings/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,10 +7,10 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 com.ibm.icu:icu4j:54.1.1
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-guess:0.1.1
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
-org.embulk:embulk-util-text:0.1.0
+org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-guess-csv_all_strings/src/test/java/org/embulk/guess/csv/TestCsvAllStringsGuessPlugin.java
+++ b/embulk-guess-csv_all_strings/src/test/java/org/embulk/guess/csv/TestCsvAllStringsGuessPlugin.java
@@ -25,7 +25,6 @@ import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.util.config.ConfigMapperFactory;
-import org.embulk.util.config.modules.TypeModule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -112,8 +111,5 @@ public class TestCsvAllStringsGuessPlugin {
         return new CsvAllStringsGuessPlugin().guessLines(config, Arrays.asList(sampleLines));
     }
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder()
-            .addDefaultModules()
-            .addModule(new TypeModule())
-            .build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 }

--- a/embulk-guess-gzip/build.gradle
+++ b/embulk-guess-gzip/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
 }
 
 embulkPlugin {

--- a/embulk-guess-gzip/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-gzip/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-guess-gzip/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-guess-gzip/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,4 +6,4 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0

--- a/embulk-guess-json/build.gradle
+++ b/embulk-guess-json/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
     compile("org.embulk:embulk-util-json:0.1.0") {
         exclude group: "org.msgpack", module: "msgpack-core"

--- a/embulk-guess-json/build.gradle
+++ b/embulk-guess-json/build.gradle
@@ -25,9 +25,7 @@ dependencies {
 
     compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
-    compile("org.embulk:embulk-util-json:0.1.0") {
-        exclude group: "org.msgpack", module: "msgpack-core"
-    }
+    compile "org.embulk:embulk-util-json:0.1.1"
 }
 
 embulkPlugin {

--- a/embulk-guess-json/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-json/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,6 +4,6 @@
 com.fasterxml.jackson.core:jackson-core:2.6.7
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-guess-json/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-guess-json/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-core:2.6.7
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-json:0.1.0
 org.msgpack:msgpack-core:0.8.11

--- a/embulk-guess-json/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-guess-json/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -8,4 +8,4 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1

--- a/embulk-guess-json/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-guess-json/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,6 +6,6 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-json:0.1.0

--- a/embulk-input-config/build.gradle
+++ b/embulk-input-config/build.gradle
@@ -27,9 +27,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-core:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
     compile "org.embulk:embulk-util-config:0.3.0"
-    compile("org.embulk:embulk-util-json:0.1.0") {
-        exclude group: "org.msgpack", module: "msgpack-core"
-    }
+    compile "org.embulk:embulk-util-json:0.1.1"
     compile "org.embulk:embulk-util-timestamp:0.2.1"
 }
 

--- a/embulk-input-config/build.gradle
+++ b/embulk-input-config/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-core:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile("org.embulk:embulk-util-json:0.1.0") {
         exclude group: "org.msgpack", module: "msgpack-core"
     }

--- a/embulk-input-config/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-input-config/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,7 +4,7 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11

--- a/embulk-input-config/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-input-config/gradle/dependency-locks/compileClasspath.lockfile
@@ -5,7 +5,7 @@ com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 org.embulk:embulk-util-config:0.3.0
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-input-config/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-config/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,7 +6,7 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-config/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-config/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,6 +7,6 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-config/src/main/java/org/embulk/input/config/ConfigInputPlugin.java
+++ b/embulk-input-config/src/main/java/org/embulk/input/config/ConfigInputPlugin.java
@@ -39,7 +39,6 @@ import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.config.Task;
-import org.embulk.util.config.modules.TypeModule;
 import org.embulk.util.config.units.ColumnConfig;
 import org.embulk.util.config.units.SchemaConfig;
 import org.embulk.util.json.JsonParseException;
@@ -250,10 +249,7 @@ public class ConfigInputPlugin implements InputPlugin {
         }
     }
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder()
-            .addDefaultModules()
-            .addModule(new TypeModule())
-            .build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigInputPlugin.class);
 }

--- a/embulk-input-file/build.gradle
+++ b/embulk-input-file/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
 
     testImplementation "junit:junit:4.12"

--- a/embulk-input-file/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-input-file/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-input-file/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-file/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,5 +6,5 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3

--- a/embulk-output-file/build.gradle
+++ b/embulk-output-file/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
 }
 
 embulkPlugin {

--- a/embulk-output-file/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-output-file/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-output-file/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-output-file/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,4 +6,4 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0

--- a/embulk-output-null/build.gradle
+++ b/embulk-output-null/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
 }
 
 embulkPlugin {

--- a/embulk-output-null/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-output-null/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-output-null/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-output-null/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,4 +6,4 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0

--- a/embulk-output-stdout/build.gradle
+++ b/embulk-output-stdout/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly project(":embulk-api")
     compileOnly project(":embulk-spi")
 
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-timestamp:0.2.1"
 }
 

--- a/embulk-output-stdout/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-output-stdout/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-output-stdout/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-output-stdout/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,6 +6,6 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-parser-csv/build.gradle
+++ b/embulk-parser-csv/build.gradle
@@ -26,12 +26,12 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-core:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
     compile("org.embulk:embulk-util-json:0.1.0") {
         exclude group: "org.msgpack", module: "msgpack-core"
     }
-    compile "org.embulk:embulk-util-text:0.1.0"
+    compile "org.embulk:embulk-util-text:0.1.1"
     compile "org.embulk:embulk-util-timestamp:0.2.1"
 
     testImplementation "junit:junit:4.12"

--- a/embulk-parser-csv/build.gradle
+++ b/embulk-parser-csv/build.gradle
@@ -28,9 +28,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
     compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
-    compile("org.embulk:embulk-util-json:0.1.0") {
-        exclude group: "org.msgpack", module: "msgpack-core"
-    }
+    compile "org.embulk:embulk-util-json:0.1.1"
     compile "org.embulk:embulk-util-text:0.1.1"
     compile "org.embulk:embulk-util-timestamp:0.2.1"
 

--- a/embulk-parser-csv/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-parser-csv/gradle/dependency-locks/compileClasspath.lockfile
@@ -6,7 +6,7 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11

--- a/embulk-parser-csv/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-parser-csv/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,10 +4,10 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-json:0.1.0
-org.embulk:embulk-util-text:0.1.0
+org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-parser-csv/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-parser-csv/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -8,7 +8,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-parser-csv/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-parser-csv/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,9 +6,9 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
-org.embulk:embulk-util-text:0.1.0
+org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-parser-csv/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
+++ b/embulk-parser-csv/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
@@ -46,7 +46,6 @@ import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.config.Task;
-import org.embulk.util.config.modules.TypeModule;
 import org.embulk.util.config.units.ColumnConfig;
 import org.embulk.util.config.units.SchemaConfig;
 import org.embulk.util.json.JsonParseException;
@@ -518,10 +517,7 @@ public class CsvParserPlugin implements ParserPlugin {
         }
     }
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder()
-            .addDefaultModules()
-            .addModule(new TypeModule())
-            .build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 
     private static final Logger logger = LoggerFactory.getLogger(CsvParserPlugin.class);
 }

--- a/embulk-parser-csv/src/test/java/org/embulk/parser/csv/TestCsvParserPlugin.java
+++ b/embulk-parser-csv/src/test/java/org/embulk/parser/csv/TestCsvParserPlugin.java
@@ -26,7 +26,6 @@ import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.util.config.ConfigMapperFactory;
-import org.embulk.util.config.modules.TypeModule;
 import org.embulk.util.text.Newline;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,10 +34,7 @@ public class TestCsvParserPlugin {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder()
-            .addDefaultModules()
-            .addModule(new TypeModule())
-            .build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 
     @Test
     public void checkDefaultValues() {

--- a/embulk-parser-csv/src/test/java/org/embulk/parser/csv/TestCsvTokenizer.java
+++ b/embulk-parser-csv/src/test/java/org/embulk/parser/csv/TestCsvTokenizer.java
@@ -33,7 +33,6 @@ import org.embulk.spi.Column;
 import org.embulk.spi.FileInput;
 import org.embulk.spi.Schema;
 import org.embulk.util.config.ConfigMapperFactory;
-import org.embulk.util.config.modules.TypeModule;
 import org.embulk.util.file.ListFileInput;
 import org.embulk.util.text.LineDecoder;
 import org.junit.Before;
@@ -47,10 +46,7 @@ public class TestCsvTokenizer {
     protected ConfigSource config;
     protected CsvParserPlugin.PluginTask task;
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder()
-            .addDefaultModules()
-            .addModule(new TypeModule())
-            .build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 
     @Before
     public void setup() {

--- a/embulk-parser-json/build.gradle
+++ b/embulk-parser-json/build.gradle
@@ -28,9 +28,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
     compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
-    compile("org.embulk:embulk-util-json:0.1.0") {
-        exclude group: "org.msgpack", module: "msgpack-core"
-    }
+    compile "org.embulk:embulk-util-json:0.1.1"
     compile "org.embulk:embulk-util-timestamp:0.2.1"
 
     testImplementation "junit:junit:4.12"

--- a/embulk-parser-json/build.gradle
+++ b/embulk-parser-json/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-core:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    compile "org.embulk:embulk-util-config:0.2.1"
+    compile "org.embulk:embulk-util-config:0.3.0"
     compile "org.embulk:embulk-util-file:0.1.3"
     compile("org.embulk:embulk-util-json:0.1.0") {
         exclude group: "org.msgpack", module: "msgpack-core"

--- a/embulk-parser-json/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-parser-json/gradle/dependency-locks/compileClasspath.lockfile
@@ -6,7 +6,7 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.30

--- a/embulk-parser-json/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-parser-json/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,7 +4,7 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-parser-json/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-parser-json/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -8,6 +8,6 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-parser-json/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-parser-json/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -6,7 +6,7 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-util-config:0.2.1
+org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-file:0.1.3
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2

--- a/embulk-parser-json/src/main/java/org/embulk/parser/json/JsonParserPlugin.java
+++ b/embulk-parser-json/src/main/java/org/embulk/parser/json/JsonParserPlugin.java
@@ -50,7 +50,6 @@ import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.config.Task;
-import org.embulk.util.config.modules.TypeModule;
 import org.embulk.util.config.units.ColumnConfig;
 import org.embulk.util.config.units.SchemaConfig;
 import org.embulk.util.file.FileInputInputStream;
@@ -508,8 +507,7 @@ public class JsonParserPlugin implements ParserPlugin {
 
     private static final Logger logger = LoggerFactory.getLogger(JsonParserPlugin.class);
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
-            ConfigMapperFactory.builder().addDefaultModules().addModule(new TypeModule()).build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 
     private static final Pattern DIGITS_PATTERN = Pattern.compile("\\p{XDigit}+");
 

--- a/embulk-parser-json/src/test/java/org/embulk/parser/json/TestJsonParserPlugin.java
+++ b/embulk-parser-json/src/test/java/org/embulk/parser/json/TestJsonParserPlugin.java
@@ -44,7 +44,6 @@ import org.embulk.spi.FileInput;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TestPageBuilderReader.MockPageOutput;
 import org.embulk.util.config.ConfigMapperFactory;
-import org.embulk.util.config.modules.TypeModule;
 import org.embulk.util.file.InputStreamFileInput;
 import org.embulk.util.json.JsonParser;
 import org.embulk.util.timestamp.TimestampFormatter;
@@ -499,8 +498,7 @@ public class TestJsonParserPlugin {
         return JSON_PARSER.parse(json);
     }
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
-            ConfigMapperFactory.builder().addDefaultModules().addModule(new TypeModule()).build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 
     private static TimestampFormatter TIMESTAMP_FORMATTER = TimestampFormatter.builderWithJava("yyyy-MM-dd HH:mm:ss").build();
 


### PR DESCRIPTION
The standard plugins have used `embulk-util-config:0.2.1`, but `0.2.1` did not include some standard-ish Jackson `Module`s by default in `ConfigMapperFactory`.

It is to update `embulk-util-config` to `0.3.0`, and remove unnecessary additions of Jackson `Module`s.

At the same time, it updates `embulk-util-text` to `0.1.1`, and `embulk-util-json` to `0.1.1`, too.