### PR TITLE
Add org.embulk.spi.json.JsonValue to deprecate use of msgpack-core in embulk-api

### DIFF
--- a/embulk-api/build.gradle
+++ b/embulk-api/build.gradle
@@ -20,4 +20,20 @@ dependencies {
     // * "msgpack-core" will not split their "value" classes to another artifact very soon.
     //   https://github.com/msgpack/msgpack-java/pull/571
     api "org.msgpack:msgpack-core:0.8.24"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.2"
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed", "standardOut", "standardError"
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
+        showStandardStreams = true
+        outputs.upToDateWhen { false }
+    }
 }

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonArray.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonArray.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Represents an array in JSON.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8259">RFC 8259 - The JavaScript Object Notation (JSON) Data Interchange Format</a>
+ *
+ * @since 0.10.42
+ */
+public final class JsonArray extends AbstractList<JsonValue> implements JsonValue {
+    private JsonArray(final JsonValue[] values) {
+        this.values = values;
+    }
+
+    /**
+     * Returns a JSON array containing zero JSON values.
+     *
+     * @return an empty JSON array
+     *
+     * @since 0.10.42
+     */
+    public static JsonArray of() {
+        return EMPTY;
+    }
+
+    /**
+     * Returns a JSON array containing an arbitrary number of JSON values.
+     *
+     * @param values  the JSON values to be contained in the JSON array
+     * @return a JSON array containing the specified JSON values
+     *
+     * @since 0.10.42
+     */
+    public static JsonArray of(final JsonValue... values) {
+        if (values.length == 0) {
+            return EMPTY;
+        }
+        return new JsonArray(Arrays.copyOf(values, values.length));
+    }
+
+    /**
+     * Returns a JSON array containing an arbitrary number of JSON values.
+     *
+     * @param values  the JSON values to be contained in the JSON array
+     * @return a JSON array containing the specified JSON values
+     *
+     * @since 0.10.42
+     */
+    public static JsonArray ofList(final List<? extends JsonValue> values) {
+        if (values.isEmpty()) {
+            return EMPTY;
+        }
+        return new JsonArray(values.toArray(new JsonValue[values.size()]));
+    }
+
+    /**
+     * Returns a JSON array containing the specified array as its internal representation.
+     *
+     * <p><strong>This method is not safe.</strong> If the specified array is modified after creating a {@link JsonArray}
+     * instance with this method, the created {@link JsonArray} instance can unintentionally behave differently.
+     *
+     * @param array  the array of JSON values to be the internal representation as-is in the new {@link JsonArray}
+     * @return a JSON array containing the specified array as the internal representation
+     *
+     * @since 0.10.42
+     */
+    public static JsonArray ofUnsafe(final JsonValue... array) {
+        return new JsonArray(array);
+    }
+
+    /**
+     * Returns {@link JsonValue.Type#ARRAY}, which is the type of {@link JsonArray}.
+     *
+     * @return {@link JsonValue.Type#ARRAY}, which is the type of {@link JsonArray}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public Type getType() {
+        return Type.ARRAY;
+    }
+
+    /**
+     * Returns this value as {@link JsonArray}.
+     *
+     * @return itself as {@link JsonArray}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public JsonArray asJsonArray() {
+        return this;
+    }
+
+    /**
+     * Returns the number of JSON values in this array.
+     *
+     * @return the number of JSON values in this array
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public int size() {
+        return this.values.length;
+    }
+
+    /**
+     * Returns the JSON value at the specified position in this array.
+     *
+     * @param index  index of the JSON value to return
+     * @return the JSON value at the specified position in this array
+     * @throws IndexOutOfBoundsException  If the index is out of range ({@code index < 0 || index >= size()})
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public JsonValue get(final int index) {
+        return this.values[index];
+    }
+
+    /**
+     * Returns the stringified JSON representation of this JSON array.
+     *
+     * @return the stringified JSON representation of this JSON array
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toJson() {
+        if (this.values.length == 0) {
+            return "[]";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        builder.append("[");
+        builder.append(this.values[0].toJson());
+        for (int i = 1; i < this.values.length; i++) {
+            builder.append(",");
+            builder.append(this.values[i].toJson());
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+
+    /**
+     * Returns the string representation of this JSON array.
+     *
+     * @return the string representation of this JSON array
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toString() {
+        if (this.values.length == 0) {
+            return "[]";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        builder.append("[");
+        builder.append(this.values[0].toString());
+        for (int i = 1; i < this.values.length; i++) {
+            builder.append(",");
+            builder.append(this.values[i].toString());
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+
+    /**
+     * Compares the specified object with this JSON array for equality.
+     *
+     * @return {@code true} if the specified object is equal to this JSON array
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+        final JsonValue otherValue = (JsonValue) otherObject;
+
+        if (otherValue instanceof JsonArray) {
+            final JsonArray other = (JsonArray) otherValue;
+            return Arrays.equals(this.values, other.values);
+        }
+
+        if (!otherValue.isArray()) {
+            return false;
+        }
+        final JsonArray other = otherValue.asJsonArray();
+        if (this.size() != other.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < this.size(); i++) {
+            if (!this.get(i).equals(other.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the hash code value for this JSON array.
+     *
+     * @return the hash code value for this JSON array
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public int hashCode() {
+        int hash = 1;
+        for (int i = 0; i < this.values.length; i++) {
+            final JsonValue value = this.values[i];
+            hash = 31 * hash + value.hashCode();
+        }
+        return hash;
+    }
+
+    private static final JsonArray EMPTY = new JsonArray(new JsonValue[0]);
+
+    private final JsonValue[] values;
+}

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonBoolean.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonBoolean.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+/**
+ * Represents {@code true} or {@code false} in JSON.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8259">RFC 8259 - The JavaScript Object Notation (JSON) Data Interchange Format</a>
+ *
+ * @since 0.10.42
+ */
+public final class JsonBoolean implements JsonValue {
+    private JsonBoolean(final boolean value) {
+        // No direct instantiation.
+        this.value = value;
+    }
+
+    /**
+     * The singleton instance that represents {@code false} in JSON.
+     *
+     * @since 0.10.42
+     */
+    public static final JsonBoolean FALSE = new JsonBoolean(false);
+
+    /**
+     * The singleton instance that represents {@code true} in JSON.
+     *
+     * @since 0.10.42
+     */
+    public static final JsonBoolean TRUE = new JsonBoolean(true);
+
+    /**
+     * Returns the singleton instance of {@link JsonBoolean#TRUE} or {@link JsonBoolean#FALSE}.
+     *
+     * @return the singleton instance of {@link JsonBoolean#TRUE} or {@link JsonBoolean#FALSE}
+     *
+     * @since 0.10.42
+     */
+    public static JsonBoolean of(final boolean value) {
+        if (value) {
+            return TRUE;
+        }
+        return FALSE;
+    }
+
+    /**
+     * Returns {@link JsonValue.Type#BOOLEAN}, which is the type of {@link JsonBoolean}.
+     *
+     * @return {@link JsonValue.Type#BOOLEAN}, which is the type of {@link JsonBoolean}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public Type getType() {
+        return Type.BOOLEAN;
+    }
+
+    /**
+     * Returns this value as {@link JsonBoolean}.
+     *
+     * @return itself as {@link JsonBoolean}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public JsonBoolean asJsonBoolean() {
+        return this;
+    }
+
+    /**
+     * Returns this JSON {@code true} or {@code false} as a primitive {@code boolean}.
+     *
+     * @return the {@code boolean} representation of this JSON {@code true} or {@code false}
+     *
+     * @since 0.10.42
+     */
+    public boolean booleanValue() {
+        return this.value;
+    }
+
+    /**
+     * Returns the stringified JSON representation of this JSON {@code true} or {@code false}.
+     *
+     * @return the stringified JSON representation of this JSON {@code true} or {@code false}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toJson() {
+        if (this.value) {
+            return "true";
+        }
+        return "false";
+    }
+
+    /**
+     * Returns the string representation of this JSON {@code true} or {@code false}.
+     *
+     * @return the string representation of this JSON {@code true} or {@code false}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toString() {
+        if (this.value) {
+            return "true";
+        }
+        return "false";
+    }
+
+    /**
+     * Compares the specified object with this JSON {@code true} or {@code false} for equality.
+     *
+     * @return {@code true} if the specified object is equal to this JSON {@code true} or {@code false}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+
+        final JsonValue other = (JsonValue) otherObject;
+        if (!other.isBoolean()) {
+            return false;
+        }
+        return value == other.asJsonBoolean().booleanValue();
+    }
+
+    /**
+     * Returns the hash code value for this JSON {@code true} or {@code false}.
+     *
+     * @return the hash code value for this JSON {@code true} or {@code false}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public int hashCode() {
+        if (this.value) {
+            return 1231;
+        }
+        return 1237;
+    }
+
+    private final boolean value;
+}

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonDecimal.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonDecimal.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Represents a decimal number in JSON.
+ *
+ * <p>It represents the decimal number as a Java primitive {@code double}, which is the same as Embulk's {@code DOUBLE} column type.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8259">RFC 8259 - The JavaScript Object Notation (JSON) Data Interchange Format</a>
+ *
+ * @since 0.10.42
+ */
+public final class JsonDecimal implements JsonValue {
+    private JsonDecimal(final double value, final String literal) {
+        this.value = value;
+        this.literal = literal;
+    }
+
+    /**
+     * Returns a JSON decimal number that is represented by the specified primitive {@code double}.
+     *
+     * @param value  the decimal number
+     * @return a JSON decimal number represented by the specified primitive {@code double}
+     *
+     * @since 0.10.42
+     */
+    public static JsonDecimal of(final double value) {
+        return new JsonDecimal(value, null);
+    }
+
+    /**
+     * Returns a JSON decimal number that is represented by the specified primitive {@code double}, with the specified JSON literal.
+     *
+     * <p>The literal is just subsidiary information used when stringifying this JSON decimal number as JSON by {@link #toJson}.
+     *
+     * @param value  the decimal number
+     * @param literal  the JSON literal of the decimal number
+     * @return a JSON decimal number represented by the specified primitive {@code double}
+     *
+     * @since 0.10.42
+     */
+    public static JsonDecimal withLiteral(final double value, final String literal) {
+        return new JsonDecimal(value, literal);
+    }
+
+    /**
+     * Returns {@link JsonValue.Type#DECIMAL}, which is the type of {@link JsonDecimal}.
+     *
+     * @return {@link JsonValue.Type#DECIMAL}, which is the type of {@link JsonDecimal}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public Type getType() {
+        return Type.DECIMAL;
+    }
+
+    /**
+     * Returns this value as {@link JsonDecimal}.
+     *
+     * @return itself as {@link JsonDecimal}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public JsonDecimal asJsonDecimal() {
+        return this;
+    }
+
+    /**
+     * Returns {@code true} if this JSON decimal number is an integer number.
+     *
+     * <p>Note that it does not guarantee this JSON decimal number can be represented as a primitive exact {@code long}.
+     * This JSON decimal number can be out of the range of {@code long}.
+     *
+     * @return {@code true} if this JSON decimal number is an integer number
+     *
+     * @since 0.10.42
+     */
+    public boolean isIntegral() {
+        return !Double.isNaN(this.value) && !Double.isInfinite(this.value) && this.value == Math.rint(this.value);
+    }
+
+    /**
+     * Returns {@code true} if the JSON decimal number is an integer number in the range of {@code byte}, [-2<sup>7</sup> to 2<sup>7</sup>-1].
+     *
+     * @return {@code true} if the JSON decimal number is an integer number in the range of {@code byte}
+     *
+     * @since 0.10.42
+     */
+    public boolean isByteValue() {
+        return this.isIntegral() && ((double) Byte.MIN_VALUE) <= this.value && this.value <= ((double) Byte.MAX_VALUE);
+    }
+
+    /**
+     * Returns {@code true} if the JSON decimal number is an integer number in the range of {@code short}, [-2<sup>15</sup> to 2<sup>15</sup>-1].
+     *
+     * @return {@code true} if the JSON decimal number is an integer number in the range of {@code short}
+     *
+     * @since 0.10.42
+     */
+    public boolean isShortValue() {
+        return this.isIntegral() && ((double) Short.MIN_VALUE) <= this.value && this.value <= ((double) Short.MAX_VALUE);
+    }
+
+    /**
+     * Returns {@code true} if the JSON decimal number is an integer number in the range of {@code int}, [-2<sup>31</sup> to 2<sup>31</sup>-1].
+     *
+     * @return {@code true} if the JSON decimal number is an integer number in the range of {@code int}
+     *
+     * @since 0.10.42
+     */
+    public boolean isIntValue() {
+        return this.isIntegral() && ((double) Integer.MIN_VALUE) <= this.value && this.value <= ((double) Integer.MAX_VALUE);
+    }
+
+    /**
+     * Returns {@code true} if the JSON decimal number is an integer number in the range of {@code long}, [-2<sup>63</sup> to 2<sup>63</sup>-1].
+     *
+     * @return {@code true} if the JSON decimal number is an integer number in the range of {@code long}
+     *
+     * @since 0.10.42
+     */
+    public boolean isLongValue() {
+        return this.isIntegral() && ((double) Long.MIN_VALUE) <= this.value && this.value <= ((double) Long.MAX_VALUE);
+    }
+
+    /**
+     * Returns this JSON decimal number as a primitive {@code byte}.
+     *
+     * <p>It narrows down {@code double} to {@code byte} as a Java primitive. Note that this conversion can lose information
+     * about the magnitude of this JSON decimal number, precision, and range.
+     *
+     * @return the {@code byte} representation of this JSON decimal number
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3">Java Language Specification - 5.1.3. Narrowing Primitive Conversion</a>
+     *
+     * @since 0.10.42
+     */
+    public byte byteValue() {
+        return (byte) this.value;
+    }
+
+    /**
+     * Returns this JSON decimal number as a primitive {@code byte}.
+     *
+     * <p>It throws {@link ArithmeticException} if the JSON decimal number is out of the range of {@code byte}, or has a
+     * non-zero fractional part.
+     *
+     * @return the {@code byte} representation of this JSON decimal number
+     * @throws ArithmeticException  if the JSON decimal number is out of the range of {@code byte}, or has a non-zero fractional part
+     *
+     * @since 0.10.42
+     */
+    public byte byteValueExact() {
+        if (!this.isIntegral()) {
+            throw new ArithmeticException("Not an integer: " + this.value);
+        }
+        if (((double) Byte.MIN_VALUE) <= this.value && this.value <= ((double) Byte.MAX_VALUE)) {
+            throw new ArithmeticException("Out of the range of byte: " + this.value);
+        }
+        return (byte) this.value;
+    }
+
+    /**
+     * Returns this JSON decimal number as a primitive {@code short}.
+     *
+     * <p>It narrows down {@code double} to {@code short} as a Java primitive. Note that this conversion can lose information
+     * about the magnitude of this JSON decimal number, precision, and range.
+     *
+     * @return the {@code short} representation of this JSON decimal number
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3">Java Language Specification - 5.1.3. Narrowing Primitive Conversion</a>
+     *
+     * @since 0.10.42
+     */
+    public short shortValue() {
+        return (short) this.value;
+    }
+
+    /**
+     * Returns this JSON decimal number as a primitive {@code short}.
+     *
+     * <p>It throws {@link ArithmeticException} if the JSON decimal number is out of the range of {@code short}, or has a
+     * non-zero fractional part.
+     *
+     * @return the {@code short} representation of this JSON decimal number
+     * @throws ArithmeticException  if the JSON decimal number is out of the range of {@code short}, or has a non-zero fractional part
+     *
+     * @since 0.10.42
+     */
+    public short shortValueExact() {
+        if (!this.isIntegral()) {
+            throw new ArithmeticException("Not an integer: " + this.value);
+        }
+        if (((double) Short.MIN_VALUE) <= this.value && this.value <= ((double) Short.MAX_VALUE)) {
+            throw new ArithmeticException("Out of the range of short: " + this.value);
+        }
+        return (short) this.value;
+    }
+
+    /**
+     * Returns this JSON decimal number as a primitive {@code int}.
+     *
+     * <p>It narrows down {@code double} to {@code int} as a Java primitive. Note that this conversion can lose information
+     * about the magnitude of this JSON decimal number, precision, and range.
+     *
+     * @return the {@code int} representation of this JSON decimal number
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3">Java Language Specification - 5.1.3. Narrowing Primitive Conversion</a>
+     *
+     * @since 0.10.42
+     */
+    public int intValue() {
+        return (int) this.value;
+    }
+
+    /**
+     * Returns this JSON decimal number as a primitive {@code int}.
+     *
+     * <p>It throws {@link ArithmeticException} if the JSON decimal number is out of the range of {@code int}, or has a
+     * non-zero fractional part.
+     *
+     * @return the {@code int} representation of this JSON decimal number
+     * @throws ArithmeticException  if the JSON decimal number is out of the range of {@code int}, or has a non-zero fractional part
+     *
+     * @since 0.10.42
+     */
+    public int intValueExact() {
+        if (!this.isIntegral()) {
+            throw new ArithmeticException("Not an integer: " + this.value);
+        }
+        if (((double) Integer.MIN_VALUE) <= this.value && this.value <= ((double) Integer.MAX_VALUE)) {
+            throw new ArithmeticException("Out of the range of int: " + this.value);
+        }
+        return (int) this.value;
+    }
+
+    /**
+     * Returns this JSON decimal number as a primitive {@code long}.
+     *
+     * <p>It narrows down {@code double} to {@code long} as a Java primitive. Note that this conversion can lose information
+     * about the magnitude of this JSON decimal number, precision, and range.
+     *
+     * @return the {@code long} representation of this JSON decimal number
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3">Java Language Specification - 5.1.3. Narrowing Primitive Conversion</a>
+     *
+     * @since 0.10.42
+     */
+    public long longValue() {
+        return (long) this.value;
+    }
+
+    /**
+     * Returns this JSON decimal number as a primitive {@code long}.
+     *
+     * <p>It throws {@link ArithmeticException} if the JSON decimal number is out of the range of {@code long}, or has a
+     * non-zero fractional part.
+     *
+     * @return the {@code long} representation of this JSON decimal number
+     * @throws ArithmeticException  if the JSON decimal number is out of the range of {@code long}, or has a non-zero fractional part
+     *
+     * @since 0.10.42
+     */
+    public long longValueExact() {
+        if (!this.isIntegral()) {
+            throw new ArithmeticException("Not an integer: " + this.value);
+        }
+        if (((double) Long.MIN_VALUE) <= this.value && this.value <= ((double) Long.MAX_VALUE)) {
+            throw new ArithmeticException("Out of the range of long: " + this.value);
+        }
+        return (long) this.value;
+    }
+
+    /**
+     * Returns this JSON decimal number as a {@link java.math.BigInteger}.
+     *
+     * <p>Note that this conversion loses the fractional part and the precision of the decimal number.
+     * This is a convenience method for {@code bigDecimalValue().toBigInteger()}.
+     *
+     * @return the {@link java.math.BigInteger} representation of this JSON decimal number
+     *
+     * @since 0.10.42
+     */
+    public BigInteger bigIntegerValue() {
+        return BigDecimal.valueOf(this.value).toBigInteger();
+    }
+
+    /**
+     * Returns this JSON decimal number as a {@link java.math.BigInteger}.
+     *
+     * <p>It throws {@link ArithmeticException} if the JSON decimal number has a non-zero fractional part.
+     *
+     * @return the {@link java.math.BigInteger} representation of this JSON decimal number
+     * @throws ArithmeticException  if the JSON decimal number has a non-zero fractional part
+     *
+     * @since 0.10.42
+     */
+    public BigInteger bigIntegerValueExact() {
+        return BigDecimal.valueOf(this.value).toBigIntegerExact();
+    }
+
+    /**
+     * Returns this JSON decimal number as a primitive {@code float}.
+     *
+     * <p>It narrows down {@code double} to {@code float} as a Java primitive. Note that this conversion can lose information
+     * about the magnitude and the precision of the decimal number.
+     *
+     *
+     * @return the {@code float} representation of this JSON decimal number
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3">Java Language Specification - 5.1.3. Na
+rrowing Primitive Conversion</a>
+     *
+     * @since 0.10.42
+     */
+    public float floatValue() {
+        return (float) this.value;
+    }
+
+    /**
+     * Returns this JSON decimal number as a primitive {@code double}, as-is.
+     *
+     * <p>This method does not lose any information because {@link JsonDecimal} represents the decimal number as a primitive
+     * {@code double} inside.
+     *
+     * @return the {@code double} representation of this JSON decimal number
+     */
+    public double doubleValue() {
+        return this.value;
+    }
+
+    /**
+     * Returns this JSON decimal number as {@link java.math.BigDecimal}.
+     *
+     * @return the {@link java.math.BigDecimal} representation of this JSON decimal number
+     */
+    public BigDecimal bigDecimalValue() {
+        return BigDecimal.valueOf(this.value);
+    }
+
+    /**
+     * Returns the stringified JSON representation of this JSON decimal number.
+     *
+     * <p>If this JSON decimal number is {@code NaN} or {@code Infinity}, it returns {@code "null"}.
+     *
+     * <p>If this JSON decimal number is created with a literal by {@link #withLiteral}, it returns the literal.
+     *
+     * @return the stringified JSON representation of this JSON decimal number
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toJson() {
+        if (Double.isNaN(this.value) || Double.isInfinite(this.value)) {
+            return "null";
+        }
+        if (this.literal != null) {
+            return this.literal;
+        }
+        return Double.toString(this.value);
+    }
+
+    /**
+     * Returns the string representation of this JSON decimal number.
+     *
+     * @return the string representation of this JSON decimal number
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toString() {
+        return Double.toString(this.value);
+    }
+
+    /**
+     * Compares the specified object with this JSON decimal number for equality.
+     *
+     * @return {@code true} if the specified object is equal to this JSON decimal number
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+        final JsonValue otherValue = (JsonValue) otherObject;
+
+        if (!otherValue.isDecimal()) {
+            return false;
+        }
+        return value == otherValue.asJsonDecimal().doubleValue();
+    }
+
+    /**
+     * Returns the hash code value for this JSON decimal number.
+     *
+     * @return the hash code value for this JSON decimal number
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public int hashCode() {
+        final long bits = Double.doubleToLongBits(this.value);
+        return (int) (bits ^ (bits >>> 32));
+    }
+
+    private final double value;
+    private final String literal;
+}

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonDecimal.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonDecimal.java
@@ -49,7 +49,7 @@ public final class JsonDecimal implements JsonValue {
     /**
      * Returns a JSON decimal number that is represented by the specified primitive {@code double}, with the specified JSON literal.
      *
-     * <p>The literal is just subsidiary information used when stringifying this JSON decimal number as JSON by {@link #toJson}.
+     * <p>The literal is just subsidiary information used when stringifying this JSON decimal number as JSON by {@link #toJson()}.
      *
      * @param value  the decimal number
      * @param literal  the JSON literal of the decimal number
@@ -363,7 +363,7 @@ rrowing Primitive Conversion</a>
      *
      * <p>If this JSON decimal number is {@code NaN} or {@code Infinity}, it returns {@code "null"}.
      *
-     * <p>If this JSON decimal number is created with a literal by {@link #withLiteral}, it returns the literal.
+     * <p>If this JSON decimal number is created with a literal by {@link #withLiteral(double, String)}, it returns the literal.
      *
      * @return the stringified JSON representation of this JSON decimal number
      *

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonInteger.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonInteger.java
@@ -50,7 +50,7 @@ public final class JsonInteger implements JsonValue {
     /**
      * Returns a JSON integer number that is represented by the specified primitive {@code long}, with the specified JSON literal.
      *
-     * <p>The literal is just subsidiary information used when stringifying this JSON integer number as JSON by {@link #toJson}.
+     * <p>The literal is just subsidiary information used when stringifying this JSON integer number as JSON by {@link #toJson()}.
      *
      * @param value  the integer number
      * @param literal  the JSON literal of the integer number
@@ -333,7 +333,7 @@ public final class JsonInteger implements JsonValue {
     /**
      * Returns the stringified JSON representation of this JSON integer number.
      *
-     * <p>If this JSON integer number is created with a literal by {@link #withLiteral}, it returns the literal.
+     * <p>If this JSON integer number is created with a literal by {@link #withLiteral(long, String)}, it returns the literal.
      *
      * @return the stringified JSON representation of this JSON integer number
      *

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonInteger.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonInteger.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Represents a integer number in JSON.
+ *
+ * <p>It represents the integer number as a Java primitive {@code long}, which is the same as Embulk's {@code LONG} column type.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8259">RFC 8259 - The JavaScript Object Notation (JSON) Data Interchange Format</a>
+ *
+ * @since 0.10.42
+ */
+public final class JsonInteger implements JsonValue {
+    private JsonInteger(final long value, final String literal) {
+        // No direct instantiation.
+        this.value = value;
+        this.literal = literal;
+    }
+
+    /**
+     * Returns a JSON integer number that is represented by the specified primitive {@code long}.
+     *
+     * @param value  the integer number
+     * @return a JSON integer number represented by the specified primitive {@code long}
+     *
+     * @since 0.10.42
+     */
+    public static JsonInteger of(final long value) {
+        return new JsonInteger(value, null);
+    }
+
+    /**
+     * Returns a JSON integer number that is represented by the specified primitive {@code long}, with the specified JSON literal.
+     *
+     * <p>The literal is just subsidiary information used when stringifying this JSON integer number as JSON by {@link #toJson}.
+     *
+     * @param value  the integer number
+     * @param literal  the JSON literal of the integer number
+     * @return a JSON integer number represented by the specified primitive {@code long}
+     *
+     * @since 0.10.42
+     */
+    public static JsonInteger withLiteral(final long value, final String literal) {
+        return new JsonInteger(value, literal);
+    }
+
+    /**
+     * Returns {@link JsonValue.Type#INTEGER}, which is the type of {@link JsonInteger}.
+     *
+     * @return {@link JsonValue.Type#INTEGER}, which is the type of {@link JsonInteger}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public Type getType() {
+        return Type.INTEGER;
+    }
+
+    /**
+     * Returns this value as {@link JsonInteger}.
+     *
+     * @return itself as {@link JsonInteger}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public JsonInteger asJsonInteger() {
+        return this;
+    }
+
+    /**
+     * Returns {@code true} to represent this JSON number is an integer number.
+     *
+     * @return {@code true}
+     *
+     * @since 0.10.42
+     */
+    public boolean isIntegral() {
+        return true;
+    }
+
+    /**
+     * Returns {@code true} if the JSON integer number is in the range of {@code byte}, [-2<sup>7</sup> to 2<sup>7</sup>-1].
+     *
+     * @return {@code true} if the JSON integer number is in the range of {@code byte}
+     *
+     * @since 0.10.42
+     */
+    public boolean isByteValue() {
+        return ((long) Byte.MIN_VALUE) <= this.value && this.value <= ((long) Byte.MAX_VALUE);
+    }
+
+    /**
+     * Returns {@code true} if the JSON integer number is in the range of {@code short}, [-2<sup>15</sup> to 2<sup>15</sup>-1].
+     *
+     * @return {@code true} if the JSON integer number is in the range of {@code short}
+     *
+     * @since 0.10.42
+     */
+    public boolean isShortValue() {
+        return ((long) Short.MIN_VALUE) <= this.value && this.value <= ((long) Short.MAX_VALUE);
+    }
+
+    /**
+     * Returns {@code true} if the JSON integer number is in the range of {@code int}, [-2<sup>31</sup> to 2<sup>31</sup>-1].
+     *
+     * @return {@code true} if the JSON integer number is in the range of {@code int}
+     *
+     * @since 0.10.42
+     */
+    public boolean isIntValue() {
+        return ((long) Integer.MIN_VALUE) <= this.value && this.value <= ((long) Integer.MAX_VALUE);
+    }
+
+    /**
+     * Returns {@code true}.
+     *
+     * @return {@code true}, always
+     *
+     * @since 0.10.42
+     */
+    public boolean isLongValue() {
+        return true;
+    }
+
+    /**
+     * Returns this JSON integer number as a primitive {@code byte}.
+     *
+     * <p>It narrows down {@code long} to {@code byte} as a Java primitive. Note that this conversion can lose information
+     * about the magnitude of this JSON integer number, and can cause the sign of the resulting value to differ from the sign
+     * of this JSON integer number.
+     *
+     * @return the {@code byte} representation of this JSON integer number
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3">Java Language Specification - 5.1.3. Narrowing Primitive Conversion</a>
+     *
+     * @since 0.10.42
+     */
+    public byte byteValue() {
+        return (byte) this.value;
+    }
+
+    /**
+     * Returns this JSON integer number as a primitive {@code byte}.
+     *
+     * <p>It throws {@link ArithmeticException} if the JSON integer number is out of the range of {@code byte}.
+     *
+     * @return the {@code byte} representation of this JSON integer number
+     * @throws ArithmeticException  if the JSON integer number does not fir in a primitive {@code byte}
+     *
+     * @since 0.10.42
+     */
+    public byte byteValueExact() {
+        if (!this.isByteValue()) {
+            throw new ArithmeticException("Out of the range of byte: " + this.value);
+        }
+        return (byte) this.value;
+    }
+
+    /**
+     * Returns this JSON integer number as a primitive {@code short}.
+     *
+     * <p>It narrows down {@code long} to {@code short} as a Java primitive. Note that this conversion can lose information
+     * about the magnitude of this JSON integer number, and can cause the sign of the resulting value to differ from the sign
+     * of this JSON integer number.
+     *
+     * @return the {@code short} representation of this JSON integer number
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3">Java Language Specification - 5.1.3. Narrowing Primitive Conversion</a>
+     *
+     * @since 0.10.42
+     */
+    public short shortValue() {
+        return (short) this.value;
+    }
+
+    /**
+     * Returns this JSON integer number as a primitive {@code short}.
+     *
+     * <p>It throws {@link ArithmeticException} if the JSON integer number is out of the range of {@code short}.
+     *
+     * @return the {@code short} representation of this JSON integer number
+     * @throws ArithmeticException  if the JSON integer number does not fir in a primitive {@code short}
+     *
+     * @since 0.10.42
+     */
+    public short shortValueExact() {
+        if (!this.isShortValue()) {
+            throw new ArithmeticException("Out of the range of short: " + this.value);
+        }
+        return (short) this.value;
+    }
+
+    /**
+     * Returns this JSON integer number as a primitive {@code int}.
+     *
+     * <p>It narrows down {@code long} to {@code int} as a Java primitive. Note that this conversion can lose information
+     * about the magnitude of this JSON integer number, and can cause the sign of the resulting value to differ from the sign
+     * of this JSON integer number.
+     *
+     * @return the {@code int} representation of this JSON integer number
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3">Java Language Specification - 5.1.3. Narrowing Primitive Conversion</a>
+     *
+     * @since 0.10.42
+     */
+    public int intValue() {
+        return (int) this.value;
+    }
+
+    /**
+     * Returns this JSON integer number as a primitive {@code int}.
+     *
+     * <p>It throws {@link ArithmeticException} if the JSON integer number is out of the range of {@code int}.
+     *
+     * @return the {@code int} representation of this JSON integer number
+     * @throws ArithmeticException  if the JSON integer number does not fir in a primitive {@code int}
+     *
+     * @since 0.10.42
+     */
+    public int intValueExact() {
+        if (!this.isIntValue()) {
+            throw new ArithmeticException("Out of the range of int: " + this.value);
+        }
+        return (int) this.value;
+    }
+
+    /**
+     * Returns this JSON integer number as a primitive {@code long}.
+     *
+     * @return the {@code long} representation of this JSON integer number
+     *
+     * @since 0.10.42
+     */
+    public long longValue() {
+        return (long) this.value;
+    }
+
+    /**
+     * Returns this JSON integer number as a primitive {@code long}.
+     *
+     * @return the {@code long} representation of this JSON integer number
+     *
+     * @since 0.10.42
+     */
+    public long longValueExact() {
+        return (long) this.value;
+    }
+
+    /**
+     * Returns this JSON integer number as a {@link java.math.BigInteger}.
+     *
+     * @return the {@link java.math.BigInteger} representation of this JSON integer number
+     *
+     * @since 0.10.42
+     */
+    public BigInteger bigIntegerValue() {
+        return BigInteger.valueOf(this.value);
+    }
+
+    /**
+     * Returns this JSON integer number as a {@link java.math.BigInteger}.
+     *
+     * @return the {@link java.math.BigInteger} representation of this JSON integer number
+     *
+     * @since 0.10.42
+     */
+    public BigInteger bigIntegerValueExact() {
+        return BigInteger.valueOf(this.value);
+    }
+
+    /**
+     * Returns this JSON integer number as a primitive {@code float}.
+     *
+     * <p>It widens {@code long} to {@code float} as a Java primitive. Note that this conversion can lose precision of
+     * this JSON integer number.
+     *
+     * @return the {@code float} representation of this JSON integer number
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.2">Java Language Specification - 5.1.2. Widening Primitive Conversion</a>
+     *
+     * @since 0.10.42
+     */
+    public float floatValue() {
+        return (float) this.value;
+    }
+
+    /**
+     * Returns this JSON integer number as a primitive {@code double}.
+     *
+     * <p>It widens {@code long} to {@code double} as a Java primitive. Note that this conversion can lose precision of
+     * this JSON integer number.
+     *
+     * @return the {@code double} representation of this JSON integer number
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.2">Java Language Specification - 5.1.2. Widening Primitive Conversion</a>
+     *
+     * @since 0.10.42
+     */
+    public double doubleValue() {
+        return (double) this.value;
+    }
+
+    /**
+     * Returns this JSON integer number as a {@link java.math.BigDecimal}.
+     *
+     * @return the {@link java.math.BigDecimal} representation of this JSON integer number
+     *
+     * @since 0.10.42
+     */
+    public BigDecimal bigDecimalValue() {
+        return BigDecimal.valueOf(this.value);
+    }
+
+    /**
+     * Returns the stringified JSON representation of this JSON integer number.
+     *
+     * <p>If this JSON integer number is created with a literal by {@link #withLiteral}, it returns the literal.
+     *
+     * @return the stringified JSON representation of this JSON integer number
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toJson() {
+        if (this.literal != null) {
+            return this.literal;
+        }
+        return Long.toString(this.value);
+    }
+
+    /**
+     * Returns the string representation of this JSON integer number.
+     *
+     * @return the string representation of this JSON integer number
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toString() {
+        return Long.toString(this.value);
+    }
+
+    /**
+     * Compares the specified object with this JSON integer number for equality.
+     *
+     * @return {@code true} if the specified object is equal to this JSON integer number
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+
+        final JsonValue otherValue = (JsonValue) otherObject;
+        if (!otherValue.isInteger()) {
+            return false;
+        }
+
+        final JsonInteger other = otherValue.asJsonInteger();
+        if (!other.isLongValue()) {
+            return false;
+        }
+        return this.value == other.longValue();
+    }
+
+    /**
+     * Returns the hash code value for this JSON integer number.
+     *
+     * @return the hash code value for this JSON integer number
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public int hashCode() {
+        if (((long) Integer.MIN_VALUE) <= this.value && this.value <= ((long) Integer.MAX_VALUE)) {
+            return (int) value;
+        }
+        return (int) (value ^ (value >>> 32));
+    }
+
+    private final long value;
+
+    private final String literal;
+}

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+/**
+ * Represents {@code null} in JSON.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8259">RFC 8259 - The JavaScript Object Notation (JSON) Data Interchange Format</a>
+ *
+ * @since 0.10.42
+ */
+public final class JsonNull implements JsonValue {
+    private JsonNull() {
+        // No direct instantiation.
+    }
+
+    /**
+     * Returns the singleton instance of {@link JsonNull}.
+     *
+     * @return the singleton instance of {@link JsonNull}
+     *
+     * @since 0.10.42
+     */
+    public static JsonNull of() {
+        return INSTANCE;
+    }
+
+    /**
+     * Returns {@link JsonValue.Type#NULL}, which is the type of {@link JsonNull}.
+     *
+     * @return {@link JsonValue.Type#NULL}, which is the type of {@link JsonNull}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public Type getType() {
+        return Type.NULL;
+    }
+
+    /**
+     * Returns this value as {@link JsonNull}.
+     *
+     * @return itself as {@link JsonNull}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public JsonNull asJsonNull() {
+        return this;
+    }
+
+    /**
+     * Returns the stringified JSON representation of this JSON {@code null}.
+     *
+     * @return {@code "null"}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toJson() {
+        return "null";
+    }
+
+    /**
+     * Returns the string representation of this JSON {@code null}.
+     *
+     * @return {@code "null"}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toString() {
+        return "null";
+    }
+
+    /**
+     * Compares the specified object with this JSON {@code null} for equality.
+     *
+     * @return {@code true} if the specified object is equal to this JSON {@code null}.
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+        return ((JsonValue) otherObject).isNull();
+    }
+
+    /**
+     * Returns the hash code value for this JSON {@code null}.
+     *
+     * @return the hash code value for this JSON {@code null}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    private static final JsonNull INSTANCE = new JsonNull();
+}

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
@@ -1,0 +1,572 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Represents an object in JSON.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8259">RFC 8259 - The JavaScript Object Notation (JSON) Data Interchange Format</a>
+ *
+ * @since 0.10.42
+ */
+public final class JsonObject extends AbstractMap<String, JsonValue> implements JsonValue {
+    private JsonObject(final JsonValue[] values) {
+        this.values = values;
+    }
+
+    /**
+     * Returns a JSON object containing zero JSON key-value mapping.
+     *
+     * @return an empty JSON object
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of() {
+        return EMPTY;
+    }
+
+    /**
+     * Returns a JSON object containing an arbitrary number of JSON key-value mappings.
+     *
+     * <p>Keys and values are specified as varargs. Even numbers of arguments must be specified. Where <i>i</i> as an
+     * odd number, the <i>i</i>-th argument represents a key that must be {@link JsonString}, and the <i>i+1</i>-th
+     * argument represents a value for the key at the <i>i</i>-th argument.
+     *
+     * @param values  the JSON keys and values to be contained in the JSON object
+     * @return a JSON object containing the specified JSON key-value mappings
+     * @throws IllegalArgumentException  if odd numbers of arguments are specified, or non-{@link JsonString} is specified as key
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(final JsonValue... values) {
+        if (values.length == 0) {
+            return EMPTY;
+        }
+        if (values.length % 2 != 0) {
+            throw new IllegalArgumentException("Even numbers of arguments must be specified to JsonObject#of(...).");
+        }
+        for (int i = 0; i < values.length; i += 2) {
+            if (!(values[i * 2] instanceof JsonString)) {
+                throw new IllegalArgumentException("JsonString must be specified as a key for JsonObject#of(...).");
+            }
+        }
+        return new JsonObject(Arrays.copyOf(values, values.length));
+    }
+
+    /**
+     * Returns a JSON object containing keys and values extracted from the given entries.
+     *
+     * <p>The specified entries themselves are not stored in the JSON object.
+     *
+     * @param entries  {@link java.util.Map.Entry}s containing {@link String} keys and {@link JsonValue} values from which the JSON object is populated
+     * @return a JSON object containing the specified JSON key-value mappings
+     *
+     * @since 0.10.42
+     */
+    @SafeVarargs
+    public static JsonObject ofEntries(final Map.Entry<String, JsonValue>... entries) {
+        final JsonValue[] values = new JsonValue[entries.length * 2];
+        for (int i = 0; i < entries.length; ++i) {
+            values[i * 2] = JsonString.of(entries[i].getKey());
+            values[i * 2 + 1] = entries[i].getValue();
+        }
+        return new JsonObject(values);
+    }
+
+    /**
+     * Returns a JSON object containing keys and values extracted from the given entries.
+     *
+     * <p>The specified entries themselves are not stored in the JSON object.
+     *
+     * @param entries  {@link java.util.Map.Entry}s containing {@link JsonString} keys and {@link JsonValue} values from which the JSON object is populated
+     * @return a JSON object containing the specified JSON key-value mappings
+     *
+     * @since 0.10.42
+     */
+    @SafeVarargs
+    public static JsonObject ofEntriesWithJsonStringKeys(final Map.Entry<JsonString, JsonValue>... entries) {
+        final JsonValue[] values = new JsonValue[entries.length * 2];
+        for (int i = 0; i < entries.length; ++i) {
+            values[i * 2] = entries[i].getKey();
+            values[i * 2 + 1] = entries[i].getValue();
+        }
+        return new JsonObject(values);
+    }
+
+    /**
+     * Returns a JSON object containing keys and values extracted from the given {@link java.util.Map}.
+     *
+     * <p>The specified map itself is not stored in the JSON object.
+     *
+     * @param map  a {@link java.util.Map} containing {@link String} keys and {@link JsonValue} values from which the JSON object is populated
+     * @return a JSON object containing the specified JSON key-value mappings
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject ofMap(final Map<String, JsonValue> map) {
+        final JsonValue[] values = new JsonValue[map.size() * 2];
+        int index = 0;
+        for (final Map.Entry<String, JsonValue> pair : map.entrySet()) {
+            values[index] = JsonString.of(pair.getKey());
+            index++;
+            values[index] = pair.getValue();
+            index++;
+        }
+        return new JsonObject(values);
+    }
+
+    /**
+     * Returns a JSON object containing keys and values extracted from the given {@link java.util.Map}.
+     *
+     * <p>The specified map itself is not stored in the JSON object.
+     *
+     * @param map  a {@link java.util.Map} containing {@link JsonString} keys and {@link JsonValue} values from which the JSON object is populated
+     * @return a JSON object containing the specified JSON key-value mappings
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject ofMapWithJsonStringKeys(final Map<JsonString, JsonValue> map) {
+        final JsonValue[] values = new JsonValue[map.size() * 2];
+        int index = 0;
+        for (final Map.Entry<JsonString, JsonValue> pair : map.entrySet()) {
+            values[index] = pair.getKey();
+            index++;
+            values[index] = pair.getValue();
+            index++;
+        }
+        return new JsonObject(values);
+    }
+
+    /**
+     * Returns a JSON object containing the specified array as its internal representation.
+     *
+     * <p><strong>This method is not safe.</strong> If the specified array is modified after creating a {@link JsonObject}
+     * instance with this method, the created {@link JsonObject} instance can unintentionally behave differently.
+     *
+     * @param values  the array of JSON keys and values to be the internal representation as-is in the new {@link JsonObject}
+     * @return a JSON object containing the specified array as the internal representation
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject ofUnsafe(final JsonValue... values) {
+        return new JsonObject(values);
+    }
+
+    /**
+     * Returns a {@link JsonObject.Builder}.
+     *
+     * @return a {@link JsonObject.Builder}
+     *
+     * @since 0.10.42
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds instances of {@link JsonObject} from keys and values configured by {@code put*} methods.
+     *
+     * @since 0.10.42
+     */
+    public static class Builder {
+        private Builder() {
+            this.map = new LinkedHashMap<>();
+        }
+
+        /**
+         * Returns a {@link JsonObject} that is built from keys and values configured by {@code put*} methods.
+         *
+         * @return a {@link JsonObject} that is built from keys and values configured by {@code put*} methods
+         *
+         * @since 0.10.42
+         */
+        public JsonObject build() {
+            return JsonObject.ofMapWithJsonStringKeys(this.map);
+        }
+
+        /**
+         * Puts a pair of a {@link String} key and a {@link JsonValue} value.
+         *
+         * @param key  the key
+         * @param value  the value
+         * @return this builder itself
+         *
+         * @since 0.10.42
+         */
+        public Builder put(final String key, final JsonValue value) {
+            this.map.put(JsonString.of(key), value);
+            return this;
+        }
+
+        /**
+         * Puts a pair of a {@link JsonString} key and a {@link JsonValue} value.
+         *
+         * @param key  the key
+         * @param value  the value
+         * @return this builder itself
+         *
+         * @since 0.10.42
+         */
+        public Builder put(final JsonString key, final JsonValue value) {
+            this.map.put(key, value);
+            return this;
+        }
+
+        /**
+         * Puts a {@link java.util.Map.Entry} of a {@link String} key and a {@link JsonValue} value.
+         *
+         * @param entry  an entry of a key and a value
+         * @return this builder itself
+         *
+         * @since 0.10.42
+         */
+        public Builder putEntry(final Map.Entry<String, JsonValue> entry) {
+            this.put(JsonString.of(entry.getKey()), entry.getValue());
+            return this;
+        }
+
+        /**
+         * Puts a {@link java.util.Map.Entry} of a {@link JsonString} key and a {@link JsonValue} value.
+         *
+         * @param entry  an entry of a key and a value
+         * @return this builder itself
+         *
+         * @since 0.10.42
+         */
+        public Builder putEntryWithJsonStringKey(final Map.Entry<JsonString, JsonValue> entry) {
+            this.put(entry.getKey(), entry.getValue());
+            return this;
+        }
+
+        /**
+         * Puts {@link java.util.Map.Entry}s of {@link String} keys and {@link JsonValue} values.
+         *
+         * @param entries  entries of keys and values
+         * @return this builder itself
+         *
+         * @since 0.10.42
+         */
+        public Builder putAllEntries(final Iterable<? extends Map.Entry<String, JsonValue>> entries) {
+            for (final Map.Entry<String, JsonValue> entry : entries) {
+                this.put(JsonString.of(entry.getKey()), entry.getValue());
+            }
+            return this;
+        }
+
+        /**
+         * Puts {@link java.util.Map.Entry}s of {@link JsonString} keys and {@link JsonValue} values.
+         *
+         * @param entries  entries of keys and values
+         * @return this builder itself
+         *
+         * @since 0.10.42
+         */
+        public Builder putAllEntriesWithJsonStringKeys(final Iterable<? extends Map.Entry<JsonString, JsonValue>> entries) {
+            for (final Map.Entry<JsonString, JsonValue> entry : entries) {
+                this.put(entry.getKey(), entry.getValue());
+            }
+            return this;
+        }
+
+        /**
+         * Copies all of the JSON key-value mappings from the specified {@link java.util.Map} to this JSON object.
+         *
+         * @param map  a {@link java.util.Map}
+         * @return this builder itself
+         *
+         * @since 0.10.42
+         */
+        public Builder putAll(final Map<String, JsonValue> map) {
+            for (final Map.Entry<String, JsonValue> entry : map.entrySet()) {
+                this.putEntry(entry);
+            }
+            return this;
+        }
+
+        /**
+         * Copies all of the JSON key-value mappings from the specified {@link java.util.Map} to this JSON object.
+         *
+         * @param map  a {@link java.util.Map}
+         * @return this builder itself
+         *
+         * @since 0.10.42
+         */
+        public Builder putAllWithJsonStringKeys(final Map<JsonString, JsonValue> map) {
+            for (final Map.Entry<JsonString, JsonValue> entry : map.entrySet()) {
+                this.putEntryWithJsonStringKey(entry);
+            }
+            return this;
+        }
+
+        private final LinkedHashMap<JsonString, JsonValue> map;
+    }
+
+    /**
+     * Returns a {@link java.util.Map.Entry} of a {@link String} key and a {@link JsonValue} value.
+     *
+     * @param key  the key
+     * @param value  the value
+     * @return a {@link java.util.Map.Entry}
+     *
+     * @since 0.10.42
+     */
+    public static Map.Entry<String, JsonValue> entry(final String key, final JsonValue value) {
+        return new AbstractMap.SimpleEntry<String, JsonValue>(key, value);
+    }
+
+    /**
+     * Returns a {@link java.util.Map.Entry} of a {@link JsonString} key and a {@link JsonValue} value.
+     *
+     * @param key  the key
+     * @param value  the value
+     * @return a {@link java.util.Map.Entry}
+     *
+     * @since 0.10.42
+     */
+    public static Map.Entry<JsonString, JsonValue> entry(final JsonString key, final JsonValue value) {
+        return new AbstractMap.SimpleEntry<JsonString, JsonValue>(key, value);
+    }
+
+    /**
+     * Returns {@link JsonValue.Type#OBJECT}, which is the type of {@link JsonObject}.
+     *
+     * @return {@link JsonValue.Type#OBJECT}, which is the type of {@link JsonObject}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public Type getType() {
+        return Type.OBJECT;
+    }
+
+    /**
+     * Returns this value as {@link JsonObject}.
+     *
+     * @return itself as {@link JsonObject}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public JsonObject asJsonObject() {
+        return this;
+    }
+
+    /**
+     * Returns the number of JSON key-value mappings in this object.
+     *
+     * @return the number of JSON key-value mappings in this object
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public int size() {
+        return this.values.length / 2;
+    }
+
+    /**
+     * Returns a {@link java.util.Set} view of the JSON key-value mappings contained in this JSON object.
+     *
+     * <p>This JSON object is unmodifiable, then the set is unmodifiable, too.
+     *
+     * @return a {@link java.util.Set} view of the JSON value key-mappings contained in this JSON object
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public Set<Map.Entry<String, JsonValue>> entrySet() {
+        return new EntrySet(this.values);
+    }
+
+    /**
+     * Returns the key-value pairs as an array of {@code JsonValue}.
+     *
+     * Odd elements are keys. Next element of an odd element is a value corresponding to the key.
+     *
+     * For example, if this value represents <code>{"k1": "v1", "k2": "v2"}</code>, this method returns ["k1", "v1", "k2", "v2"].
+     */
+    public JsonValue[] getKeyValueArray() {
+        return Arrays.copyOf(this.values, this.values.length);
+    }
+
+    /**
+     * Returns the stringified JSON representation of this JSON object.
+     *
+     * @return the stringified JSON representation of this JSON object
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toJson() {
+        if (this.values.length == 0) {
+            return "{}";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        if (this.values[0].isString()) {
+            builder.append(this.values[0].toJson());
+        } else {
+            throw new IllegalStateException("Keys in JsonObject must be String.");
+        }
+        builder.append(":");
+        builder.append(this.values[1].toJson());
+        for (int i = 2; i < this.values.length; i += 2) {
+            builder.append(",");
+            if (this.values[i].isString()) {
+                builder.append(this.values[i].toJson());
+            } else {
+                throw new IllegalStateException("Keys in JsonObject must be String.");
+            }
+            builder.append(":");
+            builder.append(this.values[i + 1].toJson());
+        }
+        builder.append("}");
+        return builder.toString();
+    }
+
+    /**
+     * Returns the string representation of this JSON object.
+     *
+     * @return the string representation of this JSON object
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toString() {
+        if (this.values.length == 0) {
+            return "{}";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        builder.append(this.values[0].toString());
+        builder.append(":");
+        builder.append(this.values[1].toString());
+        for (int i = 2; i < this.values.length; i += 2) {
+            builder.append(",");
+            builder.append(this.values[i].toString());
+            builder.append(":");
+            builder.append(this.values[i + 1].toString());
+        }
+        builder.append("}");
+        return builder.toString();
+    }
+
+    /**
+     * Compares the specified object with this JSON object for equality.
+     *
+     * @return {@code true} if the specified object is equal to this JSON object
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+
+        final JsonValue otherValue = (JsonValue) otherObject;
+        if (!otherValue.isObject()) {
+            return false;
+        }
+
+        return this.entrySet().equals(otherValue.asJsonObject().entrySet());
+    }
+
+    /**
+     * Returns the hash code value for this JSON object.
+     *
+     * @return the hash code value for this JSON object
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        for (int i = 0; i < this.values.length; i += 2) {
+            hash += this.values[i].hashCode() ^ this.values[i + 1].hashCode();
+        }
+        return hash;
+    }
+
+    private static class EntrySet extends AbstractSet<Map.Entry<String, JsonValue>> {
+        EntrySet(final JsonValue[] values) {
+            this.values = values;
+        }
+
+        @Override
+        public int size() {
+            return this.values.length / 2;
+        }
+
+        @Override
+        public Iterator<Map.Entry<String, JsonValue>> iterator() {
+            return new EntryIterator(this.values);
+        }
+
+        private final JsonValue[] values;
+    }
+
+    private static class EntryIterator implements Iterator<Map.Entry<String, JsonValue>> {
+        EntryIterator(final JsonValue[] values) {
+            this.values = values;
+            this.index = 0;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return this.index < this.values.length;
+        }
+
+        @Override
+        public Map.Entry<String, JsonValue> next() {
+            if (this.index >= this.values.length) {
+                throw new NoSuchElementException();
+            }
+
+            if (!this.values[this.index].isString()) {
+                throw new IllegalStateException("Keys in JsonObject must be String.");
+            }
+            final String key = ((JsonString) this.values[index]).getString();
+            final JsonValue value = this.values[index + 1];
+            final Map.Entry<String, JsonValue> pair = new AbstractMap.SimpleImmutableEntry<>(key, value);
+
+            this.index += 2;
+            return pair;
+        }
+
+        private final JsonValue[] values;
+
+        private int index;
+    }
+
+    private static final JsonObject EMPTY = new JsonObject(new JsonValue[0]);
+
+    private final JsonValue[] values;
+}

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
@@ -69,7 +69,7 @@ public final class JsonObject extends AbstractMap<String, JsonValue> implements 
             throw new IllegalArgumentException("Even numbers of arguments must be specified to JsonObject#of(...).");
         }
         for (int i = 0; i < values.length; i += 2) {
-            if (!(values[i * 2] instanceof JsonString)) {
+            if (!(values[i] instanceof JsonString)) {
                 throw new IllegalArgumentException("JsonString must be specified as a key for JsonObject#of(...).");
             }
         }
@@ -258,36 +258,6 @@ public final class JsonObject extends AbstractMap<String, JsonValue> implements 
          */
         public Builder putEntryWithJsonStringKey(final Map.Entry<JsonString, JsonValue> entry) {
             this.put(entry.getKey(), entry.getValue());
-            return this;
-        }
-
-        /**
-         * Puts {@link java.util.Map.Entry}s of {@link String} keys and {@link JsonValue} values.
-         *
-         * @param entries  entries of keys and values
-         * @return this builder itself
-         *
-         * @since 0.10.42
-         */
-        public Builder putAllEntries(final Iterable<? extends Map.Entry<String, JsonValue>> entries) {
-            for (final Map.Entry<String, JsonValue> entry : entries) {
-                this.put(JsonString.of(entry.getKey()), entry.getValue());
-            }
-            return this;
-        }
-
-        /**
-         * Puts {@link java.util.Map.Entry}s of {@link JsonString} keys and {@link JsonValue} values.
-         *
-         * @param entries  entries of keys and values
-         * @return this builder itself
-         *
-         * @since 0.10.42
-         */
-        public Builder putAllEntriesWithJsonStringKeys(final Iterable<? extends Map.Entry<JsonString, JsonValue>> entries) {
-            for (final Map.Entry<JsonString, JsonValue> entry : entries) {
-                this.put(entry.getKey(), entry.getValue());
-            }
             return this;
         }
 

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import java.util.Objects;
+
+/**
+ * Represents a string in JSON.
+ *
+ * <p>It represents the string as a {@link String}, which is the same as Embulk's {@code STRING} column type.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8259">RFC 8259 - The JavaScript Object Notation (JSON) Data Interchange Format</a>
+ *
+ * @since 0.10.42
+ */
+public final class JsonString implements JsonValue {
+    private JsonString(final String value, final String literal) {
+        this.value = value;
+        this.literal = literal;
+    }
+
+    /**
+     * Returns a JSON string that is represented by the specified {@link String}.
+     *
+     * @param value  the string
+     * @return a JSON string represented by the specified {@link String}
+     *
+     * @since 0.10.42
+     */
+    public static JsonString of(final String value) {
+        return new JsonString(value.intern(), null);
+    }
+
+    /**
+     * Returns a JSON string that is represented by the specified {@link String}, with the specified JSON literal.
+     *
+     * <p>The literal is just subsidiary information used when stringifying this JSON string as JSON by {@link #toJson}.
+     *
+     * @param value  the string
+     * @param literal  the JSON literal of the string
+     * @return a JSON string represented by the specified {@link String}
+     *
+     * @since 0.10.42
+     */
+    public static JsonString withLiteral(final String value, final String literal) {
+        return new JsonString(value.intern(), literal.intern());
+    }
+
+    /**
+     * Returns {@link JsonValue.Type#STRING}, which is the type of {@link JsonString}.
+     *
+     * @return {@link JsonValue.Type#STRING}, which is the type of {@link JsonString}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public Type getType() {
+        return Type.STRING;
+    }
+
+    /**
+     * Returns this value as {@link JsonString}.
+     *
+     * @return itself as {@link JsonString}
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public JsonString asJsonString() {
+        return this;
+    }
+
+    /**
+     * Returns this JSON string as {@link String}.
+     *
+     * @return the {@link String} representation of this JSON string
+     *
+     * @since 0.10.42
+     */
+    public String getString() {
+        return this.value;
+    }
+
+    /**
+     * Returns this JSON string as {@link CharSequence}.
+     *
+     * @return the {@link CharSequence} representation of this JSON string
+     *
+     * @since 0.10.42
+     */
+    public CharSequence getChars() {
+        return this.value;
+    }
+
+    /**
+     * Returns the stringified JSON representation of this JSON string.
+     *
+     * <p>If this JSON string is created with a literal by {@link #withLiteral}, it returns the literal.
+     *
+     * @return the stringified JSON representation of this JSON string
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toJson() {
+        if (this.literal != null) {
+            return this.literal;
+        }
+        return escapeStringForJsonLiteral(this.value).toString();
+    }
+
+    /**
+     * Returns the string representation of this JSON string.
+     *
+     * @return the string representation of this JSON string
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    /**
+     * Compares the specified object with this JSON string for equality.
+     *
+     * @return {@code true} if the specified object is equal to this JSON string
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (this == otherObject) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+
+        final JsonValue other = (JsonValue) otherObject;
+        if (!other.isString()) {
+            return false;
+        }
+
+        if (otherObject instanceof JsonString) {
+            final JsonString otherString = (JsonString) otherObject;
+            return Objects.equals(this.value, otherString.toString());
+        }
+        return false;
+    }
+
+    /**
+     * Returns the hash code value for this JSON string.
+     *
+     * @return the hash code value for this JSON string
+     *
+     * @since 0.10.42
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.value);
+    }
+
+    static void appendEscapedStringForJsonLiteral(final String original, final StringBuilder builder) {
+        if (original == null) {
+            return;
+        }
+        if (original.isEmpty()) {
+            builder.append("\"\"");
+            return;
+        }
+
+        builder.append("\"");
+
+        final int length = original.length();
+        for (int i = 0; i < length; i++) {
+            final char current = original.charAt(i);
+            switch (current) {
+                case '\\':
+                    builder.append("\\\\");
+                    break;
+                case '"':
+                    builder.append("\\\"");
+                    break;
+                case '\b':  // 0008
+                    builder.append("\\b");
+                    break;
+                case '\f':  // 000c
+                    builder.append("\\f");
+                    break;
+                case '\n':  // 000a
+                    builder.append("\\n");
+                    break;
+                case '\r':  // 000d
+                    builder.append("\\r");
+                    break;
+                case '\t':  // 0009
+                    builder.append("\\t");
+                    break;
+                case '\0':
+                case '\u0001':
+                case '\u0002':
+                case '\u0003':
+                case '\u0004':
+                case '\u0005':
+                case '\u0006':
+                case '\u0007':
+                case '\u000b':
+                case '\u000e':
+                case '\u000f':
+                case '\u0010':
+                case '\u0011':
+                case '\u0012':
+                case '\u0013':
+                case '\u0014':
+                case '\u0015':
+                case '\u0016':
+                case '\u0017':
+                case '\u0018':
+                case '\u0019':
+                case '\u001a':
+                case '\u001b':
+                case '\u001c':
+                case '\u001d':
+                case '\u001e':
+                case '\u001f':
+                    builder.append("\\u00");
+                    final String hex = Integer.toHexString(current);
+                    builder.append("00", 0, 2 - hex.length());
+                    builder.append(hex);
+                    break;
+                default:
+                    builder.append(current);
+            }
+        }
+
+        builder.append("\"");
+    }
+
+    private static String escapeStringForJsonLiteral(final String original) {
+        final StringBuilder builder = new StringBuilder();
+        appendEscapedStringForJsonLiteral(original, builder);
+        return builder.toString();
+    }
+
+    private final String value;
+    private final String literal;
+}

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
@@ -48,7 +48,7 @@ public final class JsonString implements JsonValue {
     /**
      * Returns a JSON string that is represented by the specified {@link String}, with the specified JSON literal.
      *
-     * <p>The literal is just subsidiary information used when stringifying this JSON string as JSON by {@link #toJson}.
+     * <p>The literal is just subsidiary information used when stringifying this JSON string as JSON by {@link #toJson()}.
      *
      * @param value  the string
      * @param literal  the JSON literal of the string
@@ -109,7 +109,8 @@ public final class JsonString implements JsonValue {
     /**
      * Returns the stringified JSON representation of this JSON string.
      *
-     * <p>If this JSON string is created with a literal by {@link #withLiteral}, it returns the literal.
+     * <p>If this JSON string is created with a literal by {@link #withLiteral(String, String)}, it returns the literal. Otherwise,
+     * it returns an escaped and quoted representation, which is valid as JSON, of this JSON string.
      *
      * @return the stringified JSON representation of this JSON string
      *
@@ -126,13 +127,17 @@ public final class JsonString implements JsonValue {
     /**
      * Returns the string representation of this JSON string.
      *
+     * <p>It returns an escaped and quoted representation like {@code "string"}, which is valid as JSON, of this JSON string.
+     *
+     * <p>It does not consider a literal by {@link #withLiteral(String, String)} unlike {@link #toJson()}.
+     *
      * @return the string representation of this JSON string
      *
      * @since 0.10.42
      */
     @Override
     public String toString() {
-        return this.value;
+        return escapeStringForJsonLiteral(this.value).toString();
     }
 
     /**
@@ -158,7 +163,7 @@ public final class JsonString implements JsonValue {
 
         if (otherObject instanceof JsonString) {
             final JsonString otherString = (JsonString) otherObject;
-            return Objects.equals(this.value, otherString.toString());
+            return Objects.equals(this.value, otherString.value);
         }
         return false;
     }

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonValue.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonValue.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+/**
+ * Represents a value in JSON: {@code null}, {@code true}, {@code false}, numbers, strings, arrays, or objects.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8259">RFC 8259 - The JavaScript Object Notation (JSON) Data Interchange Format</a>
+ *
+ * @since 0.10.42
+ */
+public interface JsonValue {
+    /**
+     * A type of a JSON value.
+     *
+     * @since 0.10.42
+     */
+    public static enum Type {
+        /**
+         * The singleton instance that represents the type of {@code null} in JSON.
+         *
+         * @since 0.10.42
+         */
+        NULL,
+
+        /**
+         * The singleton instance that represents the type of {@code true} or {@code false} in JSON.
+         *
+         * @since 0.10.42
+         */
+        BOOLEAN,
+
+        /**
+         * The singleton instance that represents the type of integer numbers in JSON.
+         *
+         * @since 0.10.42
+         */
+        INTEGER,
+
+        /**
+         * The singleton instance that represents the type of decimal numbers in JSON.
+         *
+         * @since 0.10.42
+         */
+        DECIMAL,
+
+        /**
+         * The singleton instance that represents the type of strings in JSON.
+         *
+         * @since 0.10.42
+         */
+        STRING,
+
+        /**
+         * The singleton instance that represents the type of arrays in JSON.
+         *
+         * @since 0.10.42
+         */
+        ARRAY,
+
+        /**
+         * The singleton instance that represents the type of objects in JSON.
+         *
+         * @since 0.10.42
+         */
+        OBJECT,
+        ;
+
+        /**
+         * Returns {@code true} if the JSON value is {@code null}.
+         *
+         * @since 0.10.42
+         */
+        public boolean isNull() {
+            return this == NULL;
+        }
+
+        /**
+         * Returns {@code true} if the JSON value is {@code true} or {@code false}.
+         *
+         * @since 0.10.42
+         */
+        public boolean isBoolean() {
+            return this == BOOLEAN;
+        }
+
+        /**
+         * Returns {@code true} if the JSON value is a number represented as an integer.
+         *
+         * @since 0.10.42
+         */
+        public boolean isInteger() {
+            return this == INTEGER;
+        }
+
+        /**
+         * Returns {@code true} if the JSON value is a number represented as a decimal.
+         *
+         * @since 0.10.42
+         */
+        public boolean isDecimal() {
+            return this == DECIMAL;
+        }
+
+        /**
+         * Returns {@code true} if the JSON value is a string.
+         *
+         * @since 0.10.42
+         */
+        public boolean isString() {
+            return this == STRING;
+        }
+
+        /**
+         * Returns {@code true} if the JSON value is an array.
+         *
+         * @since 0.10.42
+         */
+        public boolean isArray() {
+            return this == ARRAY;
+        }
+
+        /**
+         * Returns {@code true} if the JSON value is an object.
+         *
+         * @since 0.10.42
+         */
+        public boolean isObject() {
+            return this == OBJECT;
+        }
+    }
+
+    /**
+     * Returns the type of this JSON value.
+     *
+     * @return the type of this JSON value
+     *
+     * @since 0.10.42
+     */
+    Type getType();
+
+    /**
+     * Returns {@code true} if the type of this JSON value is {@code null}.
+     *
+     * <p>If this method returns {@code true}, {@link #asJsonNull} never throws exceptions.
+     *
+     * @return {@code true} if type of this JSON value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    default boolean isNull() {
+        return this.getType().isNull();
+    }
+
+    /**
+     * Returns {@code true} if the type of this JSON value is {@code true} or {@code false}.
+     *
+     * <p>If this method returns {@code true}, {@link #asJsonBoolean} never throws exceptions.
+     *
+     * @return {@code true} if type of this JSON value is {@code true} or {@code false}
+     *
+     * @since 0.10.42
+     */
+    default boolean isBoolean() {
+        return this.getType().isBoolean();
+    }
+
+    /**
+     * Returns {@code true} if the type of this JSON value is a number that is represented as an integer.
+     *
+     * <p>If this method returns {@code true}, {@link #asJsonInteger} never throws exceptions.
+     *
+     * @return {@code true} if type of this JSON value is a number that is represented as an integer
+     *
+     * @since 0.10.42
+     */
+    default boolean isInteger() {
+        return this.getType().isInteger();
+    }
+
+    /**
+     * Returns {@code true} if the type of this JSON value is a number that is represented as a decimal.
+     *
+     * <p>If this method returns {@code true}, {@link #asJsonDecimal} never throws exceptions.
+     *
+     * @return {@code true} if type of this JSON value is a number that is represented as a decimal
+     *
+     * @since 0.10.42
+     */
+    default boolean isDecimal() {
+        return this.getType().isDecimal();
+    }
+
+    /**
+     * Returns {@code true} if the type of this JSON value is a string.
+     *
+     * If this method returns {@code true}, {@link #asJsonString} never throws exceptions.
+     *
+     * @return {@code true} if type of this JSON value is a string
+     *
+     * @since 0.10.42
+     */
+    default boolean isString() {
+        return this.getType().isString();
+    }
+
+    /**
+     * Returns {@code true} if the type of this JSON value is an array.
+     *
+     * <p>If this method returns {@code true}, {@link #asJsonArray} never throws exceptions.
+     *
+     * @return {@code true} if type of this JSON value is an array
+     *
+     * @since 0.10.42
+     */
+    default boolean isArray() {
+        return this.getType().isArray();
+    }
+
+    /**
+     * Returns {@code true} if the type of this JSON value is an object.
+     *
+     * <p>If this method returns {@code true}, {@link #asJsonObject} never throws exceptions.
+     *
+     * @return {@code true} if type of this JSON value is an object
+     *
+     * @since 0.10.42
+     */
+    default boolean isObject() {
+        return this.getType().isObject();
+    }
+
+    /**
+     * Returns this value as {@link JsonNull}, or throws {@code ClassCastException} otherwise.
+     *
+     * @return itself as {@link JsonNull}
+     * @throws ClassCastException  if this JSON value is not {@code null}
+     *
+     * @since 0.10.42
+     */
+    default JsonNull asJsonNull() {
+        throw new ClassCastException(this.getClass().getSimpleName() + " cannot be cast to JsonNull.");
+    }
+
+    /**
+     * Returns this value as {@code JsonBoolean}, or throws {@code ClassCastException} otherwise.
+     *
+     * @return itself as {@link JsonBoolean}
+     * @throws ClassCastException  if this JSON value is not {@code true} nor {@code false}
+     *
+     * @since 0.10.42
+     */
+    default JsonBoolean asJsonBoolean() {
+        throw new ClassCastException(this.getClass().getSimpleName() + " cannot be cast to JsonBoolean.");
+    }
+
+    /**
+     * Returns this value as {@code JsonInteger}, or throws {@code ClassCastException} otherwise.
+     *
+     * @return itself as {@link JsonInteger}
+     * @throws ClassCastException  if this JSON value is not a number represented as an integer
+     *
+     * @since 0.10.42
+     */
+    default JsonInteger asJsonInteger() {
+        throw new ClassCastException(this.getClass().getSimpleName() + " cannot be cast to JsonInteger.");
+    }
+
+    /**
+     * Returns this value as {@code JsonDecimal}, or throws {@code ClassCastException} otherwise.
+     *
+     * @return itself as {@link JsonDecimal}
+     * @throws ClassCastException  if this JSON value is not a number represented as a decimal
+     *
+     * @since 0.10.42
+     */
+    default JsonDecimal asJsonDecimal() {
+        throw new ClassCastException(this.getClass().getSimpleName() + " cannot be cast to JsonDecimal.");
+    }
+
+    /**
+     * Returns this value as {@code JsonString}, or throws {@code ClassCastException} otherwise.
+     *
+     * @return itself as {@link JsonString}
+     * @throws ClassCastException  if this JSON value is not a number represented as a string
+     *
+     * @since 0.10.42
+     */
+    default JsonString asJsonString() {
+        throw new ClassCastException(this.getClass().getSimpleName() + " cannot be cast to JsonString.");
+    }
+
+    /**
+     * Returns this value as {@code JsonArray}, or throws {@code ClassCastException} otherwise.
+     *
+     * @return itself as {@link JsonArray}
+     * @throws ClassCastException  if this JSON value is not a number represented as an array
+     *
+     * @since 0.10.42
+     */
+    default JsonArray asJsonArray() {
+        throw new ClassCastException(this.getClass().getSimpleName() + " cannot be cast to JsonArray.");
+    }
+
+    /**
+     * Returns this value as {@code JsonObject}, or throws {@code ClassCastException} otherwise.
+     *
+     * @return itself as {@link JsonObject}
+     * @throws ClassCastException  if this JSON value is not a number represented as an object
+     *
+     * @since 0.10.42
+     */
+    default JsonObject asJsonObject() {
+        throw new ClassCastException(this.getClass().getSimpleName() + " cannot be cast to JsonObject.");
+    }
+
+    /**
+     * Compares the specified object with this JSON value for equality.
+     *
+     * @return {@code true} if the specified object is equal to this JSON value
+     *
+     * @since 0.10.42
+     */
+    boolean equals(Object other);
+
+    /**
+     * Returns the stringified JSON representation of this JSON value.
+     *
+     * <p>{@code NaN} and {@code Infinity} of {@link JsonDecimal} are converted to {@code "null"}.
+     *
+     * @return the stringified JSON representation of this JSON value
+     *
+     * @since 0.10.42
+     */
+    String toJson();
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
@@ -108,6 +108,7 @@ public class TestJsonArray {
         assertEquals("[987,\"foo\",true]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
 
+        // Tests that changing the original array does NOT affect the JsonArray instance.
         values[0] = JsonInteger.of(1234);
 
         assertEquals(3, jsonArray.size());
@@ -153,6 +154,7 @@ public class TestJsonArray {
         assertEquals("[987,\"foo\",true]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
 
+        // Tests that changing the original array does NOT affect the JsonArray instance.
         values.add(JsonInteger.of(1234));
 
         assertEquals(3, jsonArray.size());
@@ -199,6 +201,7 @@ public class TestJsonArray {
         assertEquals("[987,\"foo\",true]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
 
+        // Tests that changing the original array DOES affect the JsonArray instance that is created by #ofUnsafe.
         values[0] = JsonInteger.of(1234);
 
         assertEquals(3, jsonArray.size());

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+public class TestJsonArray {
+    @Test
+    public void testEmpty() {
+        final JsonArray jsonArray = JsonArray.of();
+        assertEquals(JsonValue.Type.ARRAY, jsonArray.getType());
+        assertFalse(jsonArray.isNull());
+        assertFalse(jsonArray.isBoolean());
+        assertFalse(jsonArray.isInteger());
+        assertFalse(jsonArray.isDecimal());
+        assertFalse(jsonArray.isString());
+        assertTrue(jsonArray.isArray());
+        assertFalse(jsonArray.isObject());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
+        assertEquals(jsonArray, jsonArray.asJsonArray());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(0, jsonArray.size());
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(0));
+        assertEquals("[]", jsonArray.toJson());
+        assertEquals("[]", jsonArray.toString());
+        assertEquals(JsonArray.of(), jsonArray);
+    }
+
+    @Test
+    public void testSingle() {
+        final JsonArray jsonArray = JsonArray.of(JsonInteger.of(987));
+        assertEquals(JsonValue.Type.ARRAY, jsonArray.getType());
+        assertFalse(jsonArray.isNull());
+        assertFalse(jsonArray.isBoolean());
+        assertFalse(jsonArray.isInteger());
+        assertFalse(jsonArray.isDecimal());
+        assertFalse(jsonArray.isString());
+        assertTrue(jsonArray.isArray());
+        assertFalse(jsonArray.isObject());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
+        assertEquals(jsonArray, jsonArray.asJsonArray());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(1, jsonArray.size());
+        assertEquals(JsonInteger.of(987), jsonArray.get(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(1));
+        assertEquals("[987]", jsonArray.toJson());
+        assertEquals("[987]", jsonArray.toString());
+        assertEquals(JsonArray.of(JsonInteger.of(987)), jsonArray);
+    }
+
+    @Test
+    public void testMultiOfArray() {
+        final JsonValue[] values = new JsonValue[3];
+        values[0] = JsonInteger.of(987);
+        values[1] = JsonString.of("foo");
+        values[2] = JsonBoolean.TRUE;
+        final JsonArray jsonArray = JsonArray.of(values);
+        assertEquals(JsonValue.Type.ARRAY, jsonArray.getType());
+        assertFalse(jsonArray.isNull());
+        assertFalse(jsonArray.isBoolean());
+        assertFalse(jsonArray.isInteger());
+        assertFalse(jsonArray.isDecimal());
+        assertFalse(jsonArray.isString());
+        assertTrue(jsonArray.isArray());
+        assertFalse(jsonArray.isObject());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
+        assertEquals(jsonArray, jsonArray.asJsonArray());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(3, jsonArray.size());
+        assertEquals(JsonInteger.of(987), jsonArray.get(0));
+        assertEquals(JsonString.of("foo"), jsonArray.get(1));
+        assertEquals(JsonBoolean.TRUE, jsonArray.get(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(3));
+        assertEquals("[987,\"foo\",true]", jsonArray.toJson());
+        assertEquals("[987,\"foo\",true]", jsonArray.toString());
+        assertEquals(JsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
+
+        values[0] = JsonInteger.of(1234);
+
+        assertEquals(3, jsonArray.size());
+        assertEquals(JsonInteger.of(987), jsonArray.get(0));
+        assertEquals(JsonString.of("foo"), jsonArray.get(1));
+        assertEquals(JsonBoolean.TRUE, jsonArray.get(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(3));
+        assertEquals("[987,\"foo\",true]", jsonArray.toJson());
+        assertEquals("[987,\"foo\",true]", jsonArray.toString());
+        assertEquals(JsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
+    }
+
+    @Test
+    public void testMultiOfList() {
+        final ArrayList<JsonValue> values = new ArrayList<>();
+        values.add(JsonInteger.of(987));
+        values.add(JsonString.of("foo"));
+        values.add(JsonBoolean.TRUE);
+        final JsonArray jsonArray = JsonArray.ofList(values);
+        assertEquals(JsonValue.Type.ARRAY, jsonArray.getType());
+        assertFalse(jsonArray.isNull());
+        assertFalse(jsonArray.isBoolean());
+        assertFalse(jsonArray.isInteger());
+        assertFalse(jsonArray.isDecimal());
+        assertFalse(jsonArray.isString());
+        assertTrue(jsonArray.isArray());
+        assertFalse(jsonArray.isObject());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
+        assertEquals(jsonArray, jsonArray.asJsonArray());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(3, jsonArray.size());
+        assertEquals(JsonInteger.of(987), jsonArray.get(0));
+        assertEquals(JsonString.of("foo"), jsonArray.get(1));
+        assertEquals(JsonBoolean.TRUE, jsonArray.get(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(3));
+        assertEquals("[987,\"foo\",true]", jsonArray.toJson());
+        assertEquals("[987,\"foo\",true]", jsonArray.toString());
+        assertEquals(JsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
+
+        values.add(JsonInteger.of(1234));
+
+        assertEquals(3, jsonArray.size());
+        assertEquals(JsonInteger.of(987), jsonArray.get(0));
+        assertEquals(JsonString.of("foo"), jsonArray.get(1));
+        assertEquals(JsonBoolean.TRUE, jsonArray.get(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(3));
+        assertEquals("[987,\"foo\",true]", jsonArray.toJson());
+        assertEquals("[987,\"foo\",true]", jsonArray.toString());
+        assertEquals(JsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
+    }
+
+
+    @Test
+    public void testMultiUnsafe() {
+        final JsonValue[] values = new JsonValue[3];
+        values[0] = JsonInteger.of(987);
+        values[1] = JsonString.of("foo");
+        values[2] = JsonBoolean.TRUE;
+        final JsonArray jsonArray = JsonArray.ofUnsafe(values);
+        assertEquals(JsonValue.Type.ARRAY, jsonArray.getType());
+        assertFalse(jsonArray.isNull());
+        assertFalse(jsonArray.isBoolean());
+        assertFalse(jsonArray.isInteger());
+        assertFalse(jsonArray.isDecimal());
+        assertFalse(jsonArray.isString());
+        assertTrue(jsonArray.isArray());
+        assertFalse(jsonArray.isObject());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
+        assertEquals(jsonArray, jsonArray.asJsonArray());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(3, jsonArray.size());
+        assertEquals(JsonInteger.of(987), jsonArray.get(0));
+        assertEquals(JsonString.of("foo"), jsonArray.get(1));
+        assertEquals(JsonBoolean.TRUE, jsonArray.get(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(3));
+        assertEquals("[987,\"foo\",true]", jsonArray.toJson());
+        assertEquals("[987,\"foo\",true]", jsonArray.toString());
+        assertEquals(JsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
+
+        values[0] = JsonInteger.of(1234);
+
+        assertEquals(3, jsonArray.size());
+        assertEquals(JsonInteger.of(1234), jsonArray.get(0));  // Updated
+        assertEquals(JsonString.of("foo"), jsonArray.get(1));
+        assertEquals(JsonBoolean.TRUE, jsonArray.get(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(3));
+        assertEquals("[1234,\"foo\",true]", jsonArray.toJson());  // Updated
+        assertEquals("[1234,\"foo\",true]", jsonArray.toString());  // Updated
+        assertEquals(JsonArray.of(JsonInteger.of(1234), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);  // Updated
+    }
+
+    @Test
+    public void testNested() {
+        final JsonValue[] values = new JsonValue[3];
+        values[0] = JsonInteger.of(987);
+        values[1] = JsonArray.of(JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz"));
+        values[2] = JsonBoolean.TRUE;
+        final JsonArray jsonArray = JsonArray.of(values);
+        assertEquals(JsonValue.Type.ARRAY, jsonArray.getType());
+        assertFalse(jsonArray.isNull());
+        assertFalse(jsonArray.isBoolean());
+        assertFalse(jsonArray.isInteger());
+        assertFalse(jsonArray.isDecimal());
+        assertFalse(jsonArray.isString());
+        assertTrue(jsonArray.isArray());
+        assertFalse(jsonArray.isObject());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
+        assertEquals(jsonArray, jsonArray.asJsonArray());
+        assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(3, jsonArray.size());
+        assertEquals(JsonInteger.of(987), jsonArray.get(0));
+        assertEquals(JsonArray.of(JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")), jsonArray.get(1));
+        assertEquals(JsonBoolean.TRUE, jsonArray.get(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(3));
+        assertEquals("[987,[\"foo\",\"bar\",\"baz\"],true]", jsonArray.toJson());
+        assertEquals("[987,[\"foo\",\"bar\",\"baz\"],true]", jsonArray.toString());
+        assertEquals(JsonArray.of(JsonInteger.of(987), JsonArray.of(JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")), JsonBoolean.TRUE), jsonArray);
+
+        values[0] = JsonInteger.of(1234);
+
+        assertEquals(3, jsonArray.size());
+        assertEquals(JsonInteger.of(987), jsonArray.get(0));
+        assertEquals(JsonArray.of(JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")), jsonArray.get(1));
+        assertEquals(JsonBoolean.TRUE, jsonArray.get(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(3));
+        assertEquals("[987,[\"foo\",\"bar\",\"baz\"],true]", jsonArray.toJson());
+        assertEquals("[987,[\"foo\",\"bar\",\"baz\"],true]", jsonArray.toString());
+        assertEquals(JsonArray.of(JsonInteger.of(987), JsonArray.of(JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")), JsonBoolean.TRUE), jsonArray);
+    }
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonBoolean.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonBoolean.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TestJsonBoolean {
+    @Test
+    public void testFalse() {
+        final JsonBoolean jsonBoolean = JsonBoolean.of(false);
+        assertEquals(JsonValue.Type.BOOLEAN, jsonBoolean.getType());
+        assertFalse(jsonBoolean.isNull());
+        assertTrue(jsonBoolean.isBoolean());
+        assertFalse(jsonBoolean.isInteger());
+        assertFalse(jsonBoolean.isDecimal());
+        assertFalse(jsonBoolean.isString());
+        assertFalse(jsonBoolean.isArray());
+        assertFalse(jsonBoolean.isObject());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonNull());
+        assertEquals(jsonBoolean, jsonBoolean.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonArray());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonObject());
+        assertEquals(false, jsonBoolean.booleanValue());
+        assertEquals("false", jsonBoolean.toJson());
+        assertEquals("false", jsonBoolean.toString());
+        assertEquals(JsonBoolean.FALSE, jsonBoolean);
+        assertTrue(JsonBoolean.FALSE == jsonBoolean);
+    }
+
+    @Test
+    public void testTrue() {
+        final JsonBoolean jsonBoolean = JsonBoolean.of(true);
+        assertEquals(JsonValue.Type.BOOLEAN, jsonBoolean.getType());
+        assertFalse(jsonBoolean.isNull());
+        assertTrue(jsonBoolean.isBoolean());
+        assertFalse(jsonBoolean.isInteger());
+        assertFalse(jsonBoolean.isDecimal());
+        assertFalse(jsonBoolean.isString());
+        assertFalse(jsonBoolean.isArray());
+        assertFalse(jsonBoolean.isObject());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonNull());
+        assertEquals(jsonBoolean, jsonBoolean.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonArray());
+        assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonObject());
+        assertEquals(true, jsonBoolean.booleanValue());
+        assertEquals("true", jsonBoolean.toJson());
+        assertEquals("true", jsonBoolean.toString());
+        assertEquals(JsonBoolean.TRUE, jsonBoolean);
+        assertTrue(JsonBoolean.TRUE == jsonBoolean);
+    }
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDecimal.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDecimal.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+
+public class TestJsonDecimal {
+    @Test
+    public void testBasicDoubleValue() {
+        final JsonDecimal decimal = JsonDecimal.of(1234567890.123456);
+        assertEquals(JsonValue.Type.DECIMAL, decimal.getType());
+        assertFalse(decimal.isNull());
+        assertFalse(decimal.isBoolean());
+        assertFalse(decimal.isInteger());
+        assertTrue(decimal.isDecimal());
+        assertFalse(decimal.isString());
+        assertFalse(decimal.isArray());
+        assertFalse(decimal.isObject());
+        assertThrows(ClassCastException.class, () -> decimal.asJsonNull());
+        assertThrows(ClassCastException.class, () -> decimal.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> decimal.asJsonInteger());
+        assertEquals(decimal, decimal.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> decimal.asJsonString());
+        assertThrows(ClassCastException.class, () -> decimal.asJsonArray());
+        assertThrows(ClassCastException.class, () -> decimal.asJsonObject());
+        assertFalse(decimal.isIntegral());
+        assertFalse(decimal.isByteValue());
+        assertFalse(decimal.isShortValue());
+        assertFalse(decimal.isIntValue());
+        assertFalse(decimal.isLongValue());
+        assertEquals((byte) -46, decimal.byteValue());  // Overflow & fractional
+        assertThrows(ArithmeticException.class, () -> decimal.byteValueExact());
+        assertEquals((short) 722, decimal.shortValue());  // Overflow & fractional
+        assertThrows(ArithmeticException.class, () -> decimal.shortValueExact());
+        assertEquals((int) 1234567890, decimal.intValue());  // Fractional
+        assertThrows(ArithmeticException.class, () -> decimal.intValueExact());
+        assertEquals(1234567890L, decimal.longValue());  // Fractional
+        assertThrows(ArithmeticException.class, () -> decimal.longValueExact());
+        assertEquals(BigInteger.valueOf(1234567890L), decimal.bigIntegerValue());
+        assertThrows(ArithmeticException.class, () -> decimal.bigIntegerValueExact());
+        assertEquals((float) 1234567890.123456, decimal.floatValue(), 0.001);
+        assertEquals(1234567890.123456, decimal.doubleValue(), 0.001);
+        assertEquals(BigDecimal.valueOf(1234567890.123456), decimal.bigDecimalValue());
+        assertEquals("1.234567890123456E9", decimal.toJson());
+        assertEquals("1.234567890123456E9", decimal.toString());
+        assertEquals(JsonDecimal.of(1234567890.123456), decimal);
+    }
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonInteger.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonInteger.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+
+public class TestJsonInteger {
+    @Test
+    public void testBasicByteValue() {
+        final JsonInteger integer = JsonInteger.of(123L);
+        assertEquals(JsonValue.Type.INTEGER, integer.getType());
+        assertFalse(integer.isNull());
+        assertFalse(integer.isBoolean());
+        assertTrue(integer.isInteger());
+        assertFalse(integer.isDecimal());
+        assertFalse(integer.isString());
+        assertFalse(integer.isArray());
+        assertFalse(integer.isObject());
+        assertThrows(ClassCastException.class, () -> integer.asJsonNull());
+        assertThrows(ClassCastException.class, () -> integer.asJsonBoolean());
+        assertEquals(integer, integer.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> integer.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> integer.asJsonString());
+        assertThrows(ClassCastException.class, () -> integer.asJsonArray());
+        assertThrows(ClassCastException.class, () -> integer.asJsonObject());
+        assertTrue(integer.isIntegral());
+        assertTrue(integer.isByteValue());
+        assertTrue(integer.isShortValue());
+        assertTrue(integer.isIntValue());
+        assertTrue(integer.isLongValue());
+        assertEquals((byte) 123, integer.byteValue());
+        assertEquals((byte) 123, integer.byteValueExact());
+        assertEquals((short) 123, integer.shortValue());
+        assertEquals((short) 123, integer.shortValueExact());
+        assertEquals((int) 123, integer.intValue());
+        assertEquals((int) 123, integer.intValueExact());
+        assertEquals(123L, integer.longValue());
+        assertEquals(123L, integer.longValueExact());
+        assertEquals(BigInteger.valueOf(123L), integer.bigIntegerValue());
+        assertEquals(BigInteger.valueOf(123L), integer.bigIntegerValueExact());
+        assertEquals(123.0, integer.floatValue(), 0.001);
+        assertEquals(123.0, integer.doubleValue(), 0.001);
+        assertEquals(BigDecimal.valueOf(123L), integer.bigDecimalValue());
+        assertEquals("123", integer.toJson());
+        assertEquals("123", integer.toString());
+        assertEquals(JsonInteger.of(123L), integer);
+    }
+
+    @Test
+    public void testBasicShortValue() {
+        final JsonInteger integer = JsonInteger.of(12345L);
+        assertEquals(JsonValue.Type.INTEGER, integer.getType());
+        assertFalse(integer.isNull());
+        assertFalse(integer.isBoolean());
+        assertTrue(integer.isInteger());
+        assertFalse(integer.isDecimal());
+        assertFalse(integer.isString());
+        assertFalse(integer.isArray());
+        assertFalse(integer.isObject());
+        assertThrows(ClassCastException.class, () -> integer.asJsonNull());
+        assertThrows(ClassCastException.class, () -> integer.asJsonBoolean());
+        assertEquals(integer, integer.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> integer.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> integer.asJsonString());
+        assertThrows(ClassCastException.class, () -> integer.asJsonArray());
+        assertThrows(ClassCastException.class, () -> integer.asJsonObject());
+        assertTrue(integer.isIntegral());
+        assertFalse(integer.isByteValue());
+        assertTrue(integer.isShortValue());
+        assertTrue(integer.isIntValue());
+        assertTrue(integer.isLongValue());
+        assertEquals((byte) 57, integer.byteValue());  // Overflow
+        assertThrows(ArithmeticException.class, () -> integer.byteValueExact());
+        assertEquals((short) 12345, integer.shortValue());
+        assertEquals((short) 12345, integer.shortValueExact());
+        assertEquals((int) 12345, integer.intValue());
+        assertEquals((int) 12345, integer.intValueExact());
+        assertEquals(12345L, integer.longValue());
+        assertEquals(12345L, integer.longValueExact());
+        assertEquals(BigInteger.valueOf(12345L), integer.bigIntegerValue());
+        assertEquals(BigInteger.valueOf(12345L), integer.bigIntegerValueExact());
+        assertEquals(12345.0, integer.floatValue(), 0.001);
+        assertEquals(12345.0, integer.doubleValue(), 0.001);
+        assertEquals(BigDecimal.valueOf(12345L), integer.bigDecimalValue());
+        assertEquals("12345", integer.toJson());
+        assertEquals("12345", integer.toString());
+        assertEquals(JsonInteger.of(12345L), integer);
+    }
+
+    @Test
+    public void testBasicIntValue() {
+        final JsonInteger integer = JsonInteger.of(1234567890L);
+        assertEquals(JsonValue.Type.INTEGER, integer.getType());
+        assertFalse(integer.isNull());
+        assertFalse(integer.isBoolean());
+        assertTrue(integer.isInteger());
+        assertFalse(integer.isDecimal());
+        assertFalse(integer.isString());
+        assertFalse(integer.isArray());
+        assertFalse(integer.isObject());
+        assertThrows(ClassCastException.class, () -> integer.asJsonNull());
+        assertThrows(ClassCastException.class, () -> integer.asJsonBoolean());
+        assertEquals(integer, integer.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> integer.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> integer.asJsonString());
+        assertThrows(ClassCastException.class, () -> integer.asJsonArray());
+        assertThrows(ClassCastException.class, () -> integer.asJsonObject());
+        assertTrue(integer.isIntegral());
+        assertFalse(integer.isByteValue());
+        assertFalse(integer.isShortValue());
+        assertTrue(integer.isIntValue());
+        assertTrue(integer.isLongValue());
+        assertEquals((byte) -46, integer.byteValue());  // Overflow
+        assertThrows(ArithmeticException.class, () -> integer.byteValueExact());
+        assertEquals((short) 722, integer.shortValue());  // Overflow
+        assertThrows(ArithmeticException.class, () -> integer.shortValueExact());
+        assertEquals((int) 1234567890, integer.intValue());
+        assertEquals((int) 1234567890, integer.intValueExact());
+        assertEquals(1234567890L, integer.longValue());
+        assertEquals(1234567890L, integer.longValueExact());
+        assertEquals(BigInteger.valueOf(1234567890L), integer.bigIntegerValue());
+        assertEquals(BigInteger.valueOf(1234567890L), integer.bigIntegerValueExact());
+        assertEquals(1234567890.0, integer.floatValue(), 1024.0);  // Large delta
+        assertEquals(1234567890.0, integer.doubleValue(), 0.001);
+        assertEquals(BigDecimal.valueOf(1234567890L), integer.bigDecimalValue());
+        assertEquals("1234567890", integer.toJson());
+        assertEquals("1234567890", integer.toString());
+        assertEquals(JsonInteger.of(1234567890L), integer);
+    }
+
+    @Test
+    public void testBasicLongValue() {
+        final JsonInteger integer = JsonInteger.of(1234567890123456L);
+        assertEquals(JsonValue.Type.INTEGER, integer.getType());
+        assertFalse(integer.isNull());
+        assertFalse(integer.isBoolean());
+        assertTrue(integer.isInteger());
+        assertFalse(integer.isDecimal());
+        assertFalse(integer.isString());
+        assertFalse(integer.isArray());
+        assertFalse(integer.isObject());
+        assertThrows(ClassCastException.class, () -> integer.asJsonNull());
+        assertThrows(ClassCastException.class, () -> integer.asJsonBoolean());
+        assertEquals(integer, integer.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> integer.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> integer.asJsonString());
+        assertThrows(ClassCastException.class, () -> integer.asJsonArray());
+        assertThrows(ClassCastException.class, () -> integer.asJsonObject());
+        assertTrue(integer.isIntegral());
+        assertFalse(integer.isByteValue());
+        assertFalse(integer.isShortValue());
+        assertFalse(integer.isIntValue());
+        assertTrue(integer.isLongValue());
+        assertEquals((byte) -64, integer.byteValue());  // Overflow
+        assertThrows(ArithmeticException.class, () -> integer.byteValueExact());
+        assertEquals((short) -17728, integer.shortValue());  // Overflow
+        assertThrows(ArithmeticException.class, () -> integer.shortValueExact());
+        assertEquals((int) 1015724736, integer.intValue());  // Overflow
+        assertThrows(ArithmeticException.class, () -> integer.intValueExact());
+        assertEquals(1234567890123456L, integer.longValue());
+        assertEquals(1234567890123456L, integer.longValueExact());
+        assertEquals(BigInteger.valueOf(1234567890123456L), integer.bigIntegerValue());
+        assertEquals(BigInteger.valueOf(1234567890123456L), integer.bigIntegerValueExact());
+        assertEquals(1234567890123456.0, integer.floatValue(), 67108864.0);  // Large delta
+        assertEquals(1234567890123456.0, integer.doubleValue(), 0.001);
+        assertEquals(BigDecimal.valueOf(1234567890123456L), integer.bigDecimalValue());
+        assertEquals("1234567890123456", integer.toJson());
+        assertEquals("1234567890123456", integer.toString());
+        assertEquals(JsonInteger.of(1234567890123456L), integer);
+    }
+
+    @Test
+    public void testWithLiteral() {
+        final JsonInteger integer = JsonInteger.withLiteral(1234567890123456L, "999999999999999999991234567890123456");
+        assertEquals(JsonValue.Type.INTEGER, integer.getType());
+        assertFalse(integer.isNull());
+        assertFalse(integer.isBoolean());
+        assertTrue(integer.isInteger());
+        assertFalse(integer.isDecimal());
+        assertFalse(integer.isString());
+        assertFalse(integer.isArray());
+        assertFalse(integer.isObject());
+        assertThrows(ClassCastException.class, () -> integer.asJsonNull());
+        assertThrows(ClassCastException.class, () -> integer.asJsonBoolean());
+        assertEquals(integer, integer.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> integer.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> integer.asJsonString());
+        assertThrows(ClassCastException.class, () -> integer.asJsonArray());
+        assertThrows(ClassCastException.class, () -> integer.asJsonObject());
+        assertTrue(integer.isIntegral());
+        assertFalse(integer.isByteValue());
+        assertFalse(integer.isShortValue());
+        assertFalse(integer.isIntValue());
+        assertTrue(integer.isLongValue());
+        assertEquals((byte) -64, integer.byteValue());  // Overflow
+        assertThrows(ArithmeticException.class, () -> integer.byteValueExact());
+        assertEquals((short) -17728, integer.shortValue());  // Overflow
+        assertThrows(ArithmeticException.class, () -> integer.shortValueExact());
+        assertEquals((int) 1015724736, integer.intValue());  // Overflow
+        assertThrows(ArithmeticException.class, () -> integer.intValueExact());
+        assertEquals(1234567890123456L, integer.longValue());
+        assertEquals(1234567890123456L, integer.longValueExact());
+        assertEquals(BigInteger.valueOf(1234567890123456L), integer.bigIntegerValue());
+        assertEquals(BigInteger.valueOf(1234567890123456L), integer.bigIntegerValueExact());
+        assertEquals(1234567890123456.0, integer.floatValue(), 67108864.0);  // Large delta
+        assertEquals(1234567890123456.0, integer.doubleValue(), 0.001);
+        assertEquals(BigDecimal.valueOf(1234567890123456L), integer.bigDecimalValue());
+        assertEquals("999999999999999999991234567890123456", integer.toJson());
+        assertEquals("1234567890123456", integer.toString());
+        assertEquals(JsonInteger.of(1234567890123456L), integer);
+    }
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TestJsonNull {
+    @Test
+    public void test() {
+        final JsonNull jsonNull = JsonNull.of();
+        assertEquals(JsonValue.Type.NULL, jsonNull.getType());
+        assertTrue(jsonNull.isNull());
+        assertFalse(jsonNull.isBoolean());
+        assertFalse(jsonNull.isInteger());
+        assertFalse(jsonNull.isDecimal());
+        assertFalse(jsonNull.isString());
+        assertFalse(jsonNull.isArray());
+        assertFalse(jsonNull.isObject());
+        assertEquals(jsonNull, jsonNull.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonNull.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonNull.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonNull.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonNull.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonNull.asJsonArray());
+        assertThrows(ClassCastException.class, () -> jsonNull.asJsonObject());
+        assertEquals("null", jsonNull.toJson());
+        assertEquals("null", jsonNull.toString());
+        assertEquals(JsonNull.of(), jsonNull);
+    }
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Test;
+
+public class TestJsonObject {
+    @Test
+    public void testEmpty() {
+        final JsonObject jsonObject = JsonObject.of();
+        assertEquals(JsonValue.Type.OBJECT, jsonObject.getType());
+        assertFalse(jsonObject.isNull());
+        assertFalse(jsonObject.isBoolean());
+        assertFalse(jsonObject.isInteger());
+        assertFalse(jsonObject.isDecimal());
+        assertFalse(jsonObject.isString());
+        assertFalse(jsonObject.isArray());
+        assertTrue(jsonObject.isObject());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
+        assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(0, jsonObject.size());
+        assertEquals(0, jsonObject.entrySet().size());
+        assertEquals(0, jsonObject.getKeyValueArray().length);
+        assertFalse(jsonObject.entrySet().iterator().hasNext());
+        assertThrows(NoSuchElementException.class, () -> jsonObject.entrySet().iterator().next());
+        assertEquals("{}", jsonObject.toJson());
+        assertEquals("{}", jsonObject.toString());
+        assertEquals(JsonObject.of(), jsonObject);
+    }
+
+    @Test
+    public void testOf() {
+        final JsonObject jsonObject = JsonObject.of(
+                JsonString.of("foo"), JsonInteger.of(456), JsonString.of("bar"), JsonInteger.of(456));
+        assertEquals(JsonValue.Type.OBJECT, jsonObject.getType());
+        assertFalse(jsonObject.isNull());
+        assertFalse(jsonObject.isBoolean());
+        assertFalse(jsonObject.isInteger());
+        assertFalse(jsonObject.isDecimal());
+        assertFalse(jsonObject.isString());
+        assertFalse(jsonObject.isArray());
+        assertTrue(jsonObject.isObject());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
+        assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(2, jsonObject.size());
+        assertEquals(2, jsonObject.entrySet().size());
+        assertEquals(4, jsonObject.getKeyValueArray().length);
+        final Iterator<Map.Entry<String, JsonValue>> it = jsonObject.entrySet().iterator();
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("foo", JsonInteger.of(456)), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("bar", JsonInteger.of(456)), it.next());
+        assertFalse(it.hasNext());
+        assertThrows(NoSuchElementException.class, () -> it.next());
+        assertEquals("{\"foo\":456,\"bar\":456}", jsonObject.toJson());
+        assertEquals("{\"foo\":456,\"bar\":456}", jsonObject.toString());
+        assertEquals(JsonObject.of(
+                         JsonString.of("foo"), JsonInteger.of(456),
+                         JsonString.of("bar"), JsonInteger.of(456)),
+                     jsonObject);
+    }
+
+    @Test
+    public void testOfEntries() {
+        final JsonObject jsonObject = JsonObject.ofEntries(
+                new AbstractMap.SimpleEntry<String, JsonValue>("foo", JsonNull.of()),
+                new AbstractMap.SimpleEntry<String, JsonValue>("bar", JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE)),
+                new AbstractMap.SimpleEntry<String, JsonValue>("baz", JsonInteger.of(678)));
+        assertEquals(JsonValue.Type.OBJECT, jsonObject.getType());
+        assertFalse(jsonObject.isNull());
+        assertFalse(jsonObject.isBoolean());
+        assertFalse(jsonObject.isInteger());
+        assertFalse(jsonObject.isDecimal());
+        assertFalse(jsonObject.isString());
+        assertFalse(jsonObject.isArray());
+        assertTrue(jsonObject.isObject());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
+        assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(3, jsonObject.size());
+        assertEquals(3, jsonObject.entrySet().size());
+        assertEquals(6, jsonObject.getKeyValueArray().length);
+        final Iterator<Map.Entry<String, JsonValue>> it = jsonObject.entrySet().iterator();
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("foo", JsonNull.of()), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("bar", JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE)), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("baz", JsonInteger.of(678)), it.next());
+        assertFalse(it.hasNext());
+        assertThrows(NoSuchElementException.class, () -> it.next());
+        assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toJson());
+        assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toString());
+        assertEquals(JsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
+                             JsonString.of("baz"), JsonInteger.of(678)),
+                     jsonObject);
+    }
+
+    @Test
+    public void testSingleOfEntriesWithJsonStringKeys() {
+        final JsonObject jsonObject = JsonObject.ofEntriesWithJsonStringKeys(
+                new AbstractMap.SimpleEntry<JsonString, JsonValue>(JsonString.of("foo"), JsonNull.of()),
+                new AbstractMap.SimpleEntry<JsonString, JsonValue>(JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE)),
+                new AbstractMap.SimpleEntry<JsonString, JsonValue>(JsonString.of("baz"), JsonInteger.of(678)));
+        assertEquals(JsonValue.Type.OBJECT, jsonObject.getType());
+        assertFalse(jsonObject.isNull());
+        assertFalse(jsonObject.isBoolean());
+        assertFalse(jsonObject.isInteger());
+        assertFalse(jsonObject.isDecimal());
+        assertFalse(jsonObject.isString());
+        assertFalse(jsonObject.isArray());
+        assertTrue(jsonObject.isObject());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
+        assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(3, jsonObject.size());
+        assertEquals(3, jsonObject.entrySet().size());
+        assertEquals(6, jsonObject.getKeyValueArray().length);
+        final Iterator<Map.Entry<String, JsonValue>> it = jsonObject.entrySet().iterator();
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("foo", JsonNull.of()), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("bar", JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE)), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("baz", JsonInteger.of(678)), it.next());
+        assertFalse(it.hasNext());
+        assertThrows(NoSuchElementException.class, () -> it.next());
+        assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toJson());
+        assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toString());
+        assertEquals(JsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
+                             JsonString.of("baz"), JsonInteger.of(678)),
+                     jsonObject);
+    }
+
+    @Test
+    public void testOfMap() {
+        final LinkedHashMap<String, JsonValue> map = new LinkedHashMap<>();
+        map.put("foo", JsonNull.of());
+        map.put("bar", JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE));
+        map.put("baz", JsonInteger.of(678));
+        final JsonObject jsonObject = JsonObject.ofMap(map);
+        assertEquals(JsonValue.Type.OBJECT, jsonObject.getType());
+        assertFalse(jsonObject.isNull());
+        assertFalse(jsonObject.isBoolean());
+        assertFalse(jsonObject.isInteger());
+        assertFalse(jsonObject.isDecimal());
+        assertFalse(jsonObject.isString());
+        assertFalse(jsonObject.isArray());
+        assertTrue(jsonObject.isObject());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
+        assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(3, jsonObject.size());
+        assertEquals(3, jsonObject.entrySet().size());
+        assertEquals(6, jsonObject.getKeyValueArray().length);
+        final Iterator<Map.Entry<String, JsonValue>> it = jsonObject.entrySet().iterator();
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("foo", JsonNull.of()), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("bar", JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE)), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("baz", JsonInteger.of(678)), it.next());
+        assertFalse(it.hasNext());
+        assertThrows(NoSuchElementException.class, () -> it.next());
+        assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toJson());
+        assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toString());
+        assertEquals(JsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
+                             JsonString.of("baz"), JsonInteger.of(678)),
+                     jsonObject);
+    }
+
+    @Test
+    public void testOfMapWithJsonStringKeys() {
+        final LinkedHashMap<JsonString, JsonValue> map = new LinkedHashMap<>();
+        map.put(JsonString.of("foo"), JsonNull.of());
+        map.put(JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE));
+        map.put(JsonString.of("baz"), JsonInteger.of(678));
+        final JsonObject jsonObject = JsonObject.ofMapWithJsonStringKeys(map);
+        assertEquals(JsonValue.Type.OBJECT, jsonObject.getType());
+        assertFalse(jsonObject.isNull());
+        assertFalse(jsonObject.isBoolean());
+        assertFalse(jsonObject.isInteger());
+        assertFalse(jsonObject.isDecimal());
+        assertFalse(jsonObject.isString());
+        assertFalse(jsonObject.isArray());
+        assertTrue(jsonObject.isObject());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
+        assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(3, jsonObject.size());
+        assertEquals(3, jsonObject.entrySet().size());
+        assertEquals(6, jsonObject.getKeyValueArray().length);
+        final Iterator<Map.Entry<String, JsonValue>> it = jsonObject.entrySet().iterator();
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("foo", JsonNull.of()), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("bar", JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE)), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("baz", JsonInteger.of(678)), it.next());
+        assertFalse(it.hasNext());
+        assertThrows(NoSuchElementException.class, () -> it.next());
+        assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toJson());
+        assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toString());
+        assertEquals(JsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
+                             JsonString.of("baz"), JsonInteger.of(678)),
+                     jsonObject);
+    }
+
+    @Test
+    public void testBuilder() {
+        final LinkedHashMap<String, JsonValue> map1 = new LinkedHashMap<>();
+        map1.put("hoge", JsonString.withLiteral("foo", "\"\\u0066oo\""));
+        map1.put("fuga", JsonDecimal.of(123.4));
+        final LinkedHashMap<JsonString, JsonValue> map2 = new LinkedHashMap<>();
+        map2.put(JsonString.of("piyo"), JsonInteger.of(345));
+        map2.put(JsonString.of("hogera"), JsonString.of("bar"));
+        final JsonObject jsonObject = JsonObject.builder()
+                .put("foo", JsonNull.of())
+                .put(JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE))
+                .putEntry(new AbstractMap.SimpleEntry<String, JsonValue>("baz", JsonInteger.of(678)))
+                .putEntryWithJsonStringKey(new AbstractMap.SimpleEntry<JsonString, JsonValue>(JsonString.of("qux"), JsonNull.of()))
+                .putAll(map1)
+                .putAllWithJsonStringKeys(map2)
+                .build();
+
+        assertEquals(JsonValue.Type.OBJECT, jsonObject.getType());
+        assertFalse(jsonObject.isNull());
+        assertFalse(jsonObject.isBoolean());
+        assertFalse(jsonObject.isInteger());
+        assertFalse(jsonObject.isDecimal());
+        assertFalse(jsonObject.isString());
+        assertFalse(jsonObject.isArray());
+        assertTrue(jsonObject.isObject());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonDecimal());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
+        assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(8, jsonObject.size());
+        assertEquals(8, jsonObject.entrySet().size());
+        assertEquals(16, jsonObject.getKeyValueArray().length);
+        final Iterator<Map.Entry<String, JsonValue>> it = jsonObject.entrySet().iterator();
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("foo", JsonNull.of()), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("bar", JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE)), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("baz", JsonInteger.of(678)), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("qux", JsonNull.of()), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("hoge", JsonString.of("foo")), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("fuga", JsonDecimal.of(123.4)), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("piyo", JsonInteger.of(345)), it.next());
+        assertTrue(it.hasNext());
+        assertEquals(new AbstractMap.SimpleEntry<String, JsonValue>("hogera", JsonString.of("bar")), it.next());
+        assertFalse(it.hasNext());
+        assertThrows(NoSuchElementException.class, () -> it.next());
+        assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678,\"qux\":null,\"hoge\":\"\\u0066oo\",\"fuga\":123.4,\"piyo\":345,\"hogera\":\"bar\"}", jsonObject.toJson());
+        assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678,\"qux\":null,\"hoge\":\"foo\",\"fuga\":123.4,\"piyo\":345,\"hogera\":\"bar\"}", jsonObject.toString());
+        assertEquals(JsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
+                             JsonString.of("baz"), JsonInteger.of(678),
+                             JsonString.of("qux"), JsonNull.of(),
+                             JsonString.of("hoge"), JsonString.of("foo"),
+                             JsonString.of("fuga"), JsonDecimal.of(123.4),
+                             JsonString.of("piyo"), JsonInteger.of(345),
+                             JsonString.of("hogera"), JsonString.of("bar")),
+                     jsonObject);
+    }
+
+    @Test
+    public void testInvalidOf() {
+        final IllegalArgumentException ex1 = assertThrows(
+                IllegalArgumentException.class, () -> JsonObject.of(JsonString.of("foo")));
+        assertEquals("Even numbers of arguments must be specified to JsonObject#of(...).", ex1.getMessage());
+
+        final IllegalArgumentException ex2 = assertThrows(
+                IllegalArgumentException.class, () -> JsonObject.of(JsonString.of("foo"), JsonBoolean.TRUE, JsonBoolean.TRUE));
+        assertEquals("Even numbers of arguments must be specified to JsonObject#of(...).", ex2.getMessage());
+
+        final IllegalArgumentException ex3 = assertThrows(
+                IllegalArgumentException.class, () -> JsonObject.of(JsonBoolean.TRUE, JsonBoolean.TRUE));
+        assertEquals("JsonString must be specified as a key for JsonObject#of(...).", ex3.getMessage());
+    }
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
@@ -45,14 +45,14 @@ public class TestJsonString {
         assertEquals("hoge", string.getString());
         assertEquals("hoge", string.getChars());
         assertEquals("\"hoge\"", string.toJson());
-        assertEquals("hoge", string.toString());
+        assertEquals("\"hoge\"", string.toString());
         assertEquals(JsonString.of("hoge"), string);
         assertEquals("hoge".hashCode(), string.hashCode());
     }
 
     @Test
     public void testWithLiteral() {
-        final JsonString string = JsonString.withLiteral("hoge\n", "\"hoge\\n\"");
+        final JsonString string = JsonString.withLiteral("hoge\n", "\"\\u0068oge\\n\"");
         assertEquals(JsonValue.Type.STRING, string.getType());
         assertFalse(string.isNull());
         assertFalse(string.isBoolean());
@@ -70,8 +70,8 @@ public class TestJsonString {
         assertThrows(ClassCastException.class, () -> string.asJsonObject());
         assertEquals("hoge\n", string.getString());
         assertEquals("hoge\n", string.getChars());
-        assertEquals("\"hoge\\n\"", string.toJson());
-        assertEquals("hoge\n", string.toString());
+        assertEquals("\"\\u0068oge\\n\"", string.toJson());
+        assertEquals("\"hoge\\n\"", string.toString());
         assertEquals(JsonString.of("hoge\n"), string);
         assertEquals("hoge\n".hashCode(), string.hashCode());
     }
@@ -99,7 +99,9 @@ public class TestJsonString {
         assertEquals(
                 "\"\\\\foo\\\"bar\\nbaz\\bqux\\ffoo\\nbar\\rbaz\\tqux\\u0000foo\\u0001bar\\u0002baz\\u001fqux\"",
                 string.toJson());
-        assertEquals("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux", string.toString());
+        assertEquals(
+                "\"\\\\foo\\\"bar\\nbaz\\bqux\\ffoo\\nbar\\rbaz\\tqux\\u0000foo\\u0001bar\\u0002baz\\u001fqux\"",
+                string.toString());
         assertEquals(JsonString.of("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux"), string);
         assertEquals("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux".hashCode(), string.hashCode());
     }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TestJsonString {
+    @Test
+    public void testBasic() {
+        final JsonString string = JsonString.of("hoge");
+        assertEquals(JsonValue.Type.STRING, string.getType());
+        assertFalse(string.isNull());
+        assertFalse(string.isBoolean());
+        assertFalse(string.isInteger());
+        assertFalse(string.isDecimal());
+        assertTrue(string.isString());
+        assertFalse(string.isArray());
+        assertFalse(string.isObject());
+        assertThrows(ClassCastException.class, () -> string.asJsonNull());
+        assertThrows(ClassCastException.class, () -> string.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> string.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> string.asJsonDecimal());
+        assertEquals(string, string.asJsonString());
+        assertThrows(ClassCastException.class, () -> string.asJsonArray());
+        assertThrows(ClassCastException.class, () -> string.asJsonObject());
+        assertEquals("hoge", string.getString());
+        assertEquals("hoge", string.getChars());
+        assertEquals("\"hoge\"", string.toJson());
+        assertEquals("hoge", string.toString());
+        assertEquals(JsonString.of("hoge"), string);
+        assertEquals("hoge".hashCode(), string.hashCode());
+    }
+
+    @Test
+    public void testWithLiteral() {
+        final JsonString string = JsonString.withLiteral("hoge\n", "\"hoge\\n\"");
+        assertEquals(JsonValue.Type.STRING, string.getType());
+        assertFalse(string.isNull());
+        assertFalse(string.isBoolean());
+        assertFalse(string.isInteger());
+        assertFalse(string.isDecimal());
+        assertTrue(string.isString());
+        assertFalse(string.isArray());
+        assertFalse(string.isObject());
+        assertThrows(ClassCastException.class, () -> string.asJsonNull());
+        assertThrows(ClassCastException.class, () -> string.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> string.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> string.asJsonDecimal());
+        assertEquals(string, string.asJsonString());
+        assertThrows(ClassCastException.class, () -> string.asJsonArray());
+        assertThrows(ClassCastException.class, () -> string.asJsonObject());
+        assertEquals("hoge\n", string.getString());
+        assertEquals("hoge\n", string.getChars());
+        assertEquals("\"hoge\\n\"", string.toJson());
+        assertEquals("hoge\n", string.toString());
+        assertEquals(JsonString.of("hoge\n"), string);
+        assertEquals("hoge\n".hashCode(), string.hashCode());
+    }
+
+    @Test
+    public void testEscape() {
+        final JsonString string = JsonString.of("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux");
+        assertEquals(JsonValue.Type.STRING, string.getType());
+        assertFalse(string.isNull());
+        assertFalse(string.isBoolean());
+        assertFalse(string.isInteger());
+        assertFalse(string.isDecimal());
+        assertTrue(string.isString());
+        assertFalse(string.isArray());
+        assertFalse(string.isObject());
+        assertThrows(ClassCastException.class, () -> string.asJsonNull());
+        assertThrows(ClassCastException.class, () -> string.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> string.asJsonInteger());
+        assertThrows(ClassCastException.class, () -> string.asJsonDecimal());
+        assertEquals(string, string.asJsonString());
+        assertThrows(ClassCastException.class, () -> string.asJsonArray());
+        assertThrows(ClassCastException.class, () -> string.asJsonObject());
+        assertEquals("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux", string.getString());
+        assertEquals("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux", string.getChars());
+        assertEquals(
+                "\"\\\\foo\\\"bar\\nbaz\\bqux\\ffoo\\nbar\\rbaz\\tqux\\u0000foo\\u0001bar\\u0002baz\\u001fqux\"",
+                string.toJson());
+        assertEquals("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux", string.toString());
+        assertEquals(JsonString.of("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux"), string);
+        assertEquals("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux".hashCode(), string.hashCode());
+    }
+}


### PR DESCRIPTION
Embulk's "JSON"-type values have been represented by msgpack-java's `org.msgpack.value.(Immutable)Value` since Embulk v0.7. The msgpack-java has set its roots deep inside Embulk, including its plugin SPI method signatures.

It has brought a heavy dependency hell between Embulk and msgpack-java. We have hesitated even just upgrading `msgpack-core` which can potentially cause a compatibility issue. As a result, a couple of plugins that use `msgpack-core` (such as `embulk-parser-msgpack`) had to stay with older `msgpack-core`.

We upgraded `msgpack-core` to 0.8.24 in #1459, in the Embulk v0.10 "development" series.

However, indeed, the Embulk core has never used `MessagePacker` nor `MessageUnpacker` from `msgpack-core`. Embulk has used only `org.msgpack.value.(Immutable)Value` just as a JSON-like data container. It's nonsense!

----

Then, we plan to drop `msgpack-core` from the Embulk API/SPI in a long term. The plan would be:

1. We upgrade `msgpack-core` to v0.8.24 in Embulk v0.10.42 in the pull request #1459.
2. We introduce another set of classes for "JSON" type (expected to be `org.embulk.spi.json.JsonValue`) in v0.10.42 in this pull request #1462.
    * We'll keep SPI methods for both (`org.msgpack.value.Value` and `org.embulk.spi.json.JsonValue`) for a long time -- even after Embulk v1.0.
    * It'd be similar to "TIMESTAMP" type -- `org.embulk.spi.time.Timestamp` and `java.time.Instant`.
    * Plugins are expected to migrate to use `org.embulk.spi.json.JsonValue` through Embulk v0.11 - v1.0.
3. Tentatively also in Embulk v0.10.42, we modify those `org.embulk.spi.json.*` classes to represent their internal values by msgpack-core classes again. It will allow to keep backward-compatible API/SPI methods for a while.
4. We add new API/SPI methods to handle "JSON" type values with `org.embulk.spi.json.Json*` also in Embulk v0.10.42. In a long term, plugins will have to migrate to use the new methods, instead of `msgpack-core`-based methods.
5. At some point in the future, after Embulk v1.0, `msgpack-core` and API/SPI methods using `msgpack-core` will be removed.

We'll also write up an EEP for this.
