### PR TITLE
Remove Guava from embulk-deps

### DIFF
--- a/embulk-deps/build.gradle
+++ b/embulk-deps/build.gradle
@@ -30,12 +30,16 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     api "com.fasterxml.jackson.core:jackson-core:2.6.7"
     api "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    api "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7"
+    api("com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7") {
+        exclude group: "com.google.guava", module: "guava"
+    }
     api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"
 
     api "javax.validation:validation-api:1.1.0.Final"
     api "org.apache.bval:bval-jsr303:0.5"
-    api "org.apache.commons:commons-lang3:3.4"
+
+    // 3.8.1 is required from Apache Maven.
+    api "org.apache.commons:commons-lang3:3.8.1"
 
     // Guess
     api "com.ibm.icu:icu4j:54.1.1"

--- a/embulk-deps/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-deps/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -6,7 +6,6 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
-com.google.guava:guava:15.0
 com.ibm.icu:icu4j:54.1.1
 commons-beanutils:commons-beanutils-core:1.8.3
 commons-cli:commons-cli:1.4


### PR DESCRIPTION
Guava (18.0) is already in the top-level class loader (`embulk-core`), then `embulk-deps` should not have Guava (also, it's 15.0!).

In fact, 0.10.32's `embulk-deps` should not have included Guice, too. (It's anyway removed in 0.10.32 at: https://github.com/embulk/embulk/pull/1444/files#diff-a0a01b2cd5bc9398f71f2c5e71d140d35a353e0a5b72605152be03718f78d971L35)