### PR TITLE
Fix SelfContainedJarAwareURLClassLoader against "findResources" for non-self-contained embulk-deps

### DIFF
--- a/embulk-core/src/main/java/org/embulk/deps/SelfContainedJarAwareURLClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/deps/SelfContainedJarAwareURLClassLoader.java
@@ -118,7 +118,7 @@ public class SelfContainedJarAwareURLClassLoader extends URLClassLoader {
             try {
                 resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName, this.selfContainedJarCategory);
             } catch (final IllegalArgumentException ex) {
-                Holder.logger.debug("Unexpected self-contained JAR category is requested: " + this.selfContainedJarCategory, ex);
+                Holder.logger.warn("Unexpected self-contained JAR category is requested: " + this.selfContainedJarCategory, ex);
                 return null;
             }
             if (resource == null) {
@@ -162,7 +162,7 @@ public class SelfContainedJarAwareURLClassLoader extends URLClassLoader {
             try {
                 resources = EmbulkSelfContainedJarFiles.getMultipleResources(resourceName, this.selfContainedJarCategory);
             } catch (final IllegalArgumentException ex) {
-                Holder.logger.debug("Unexpected self-contained JAR category is requested: " + this.selfContainedJarCategory, ex);
+                Holder.logger.warn("Unexpected self-contained JAR category is requested: " + this.selfContainedJarCategory, ex);
                 return resourceUrls.elements();
             }
 
@@ -203,7 +203,7 @@ public class SelfContainedJarAwareURLClassLoader extends URLClassLoader {
         try {
             resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName, this.selfContainedJarCategory);
         } catch (final IllegalArgumentException ex) {
-            Holder.logger.debug("Unexpected self-contained JAR category is requested: " + this.selfContainedJarCategory, ex);
+            Holder.logger.warn("Unexpected self-contained JAR category is requested: " + this.selfContainedJarCategory, ex);
             throw new ClassNotFoundException(className, ex);
         }
         if (resource == null) {


### PR DESCRIPTION
`DependencyClassLoader#findResources` (not `findResource`) could fail when `embulk-deps` was deployed directly on the file system, not embedded as self-contained JARs in Embulk's executable JAR.

* This problem does not affect normal OSS Embulk users. It could affect only for users who deploy JARs by themselves.
* This problem does not affect before v0.10.32 because `embulk-deps` did not include libraries calling `findResources`. It affected only v0.10.32.

This PR is to fix the problem by catching its related Exception(s).