### PR TITLE
Fix the TestingEmbulk#runOutput problem of not skipping the header even though the column name:type needs to be defined in the header.

### DIFF
--- a/embulk-junit4/src/main/java/org/embulk/test/TestingEmbulk.java
+++ b/embulk-junit4/src/main/java/org/embulk/test/TestingEmbulk.java
@@ -521,6 +521,7 @@ public class TestingEmbulk implements TestRule {
                     .set("delimiter", ",")
                     .set("quote", "\"")
                     .set("escape", "\"")
+                    .set("skip_header_lines", 1)  // Skip the header because the input csv must have "columnName:columnType" defined in the header.
                     .set("columns", newSchemaConfig());
         }
 


### PR DESCRIPTION
`TestingEmbulk#runOutput` requires a CSV file as an input data source and the CSV file must have the header like `columnName:columnType,columnName:columnType,...`, but the csv parser setting does not include `skip_header_lines=1`, so I added.