### PR TITLE
Fallback to "plugins.default.<category>.<type>" if no plugin is found from "plugins.<category>.<type>"

### DIFF
--- a/embulk-core/src/main/java/org/embulk/deps/maven/MavenArtifactFinder.java
+++ b/embulk-core/src/main/java/org/embulk/deps/maven/MavenArtifactFinder.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import org.embulk.deps.EmbulkDependencyClassLoaders;
+import org.embulk.plugin.MavenPluginType;
 
 public abstract class MavenArtifactFinder {
     public static MavenArtifactFinder create(final Path localMavenRepositoryPath) throws FileNotFoundException {
@@ -32,10 +33,8 @@ public abstract class MavenArtifactFinder {
      * @see <a href="https://github.com/eclipse/aether-demo/blob/322fa556494335faaf3ad3b7dbe8f89aaaf6222d/aether-demo-snippets/src/main/java/org/eclipse/aether/examples/GetDirectDependencies.java">aether-demo's GetDirectDependencies.java</a>
      */
     public abstract MavenPluginPaths findMavenPluginJarsWithDirectDependencies(
-            final String groupId,
-            final String artifactId,
-            final String classifier,
-            final String version)
+            final MavenPluginType pluginType,
+            final String category)
             throws FileNotFoundException;
 
     @SuppressWarnings("unchecked")

--- a/embulk-core/src/main/java/org/embulk/deps/maven/MavenPluginPaths.java
+++ b/embulk-core/src/main/java/org/embulk/deps/maven/MavenPluginPaths.java
@@ -4,9 +4,11 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.embulk.plugin.MavenPluginType;
 
 public class MavenPluginPaths {
-    private MavenPluginPaths(final Path pluginJarPath, final List<Path> pluginDependencyJarPaths) {
+    private MavenPluginPaths(final MavenPluginType pluginType, final Path pluginJarPath, final List<Path> pluginDependencyJarPaths) {
+        this.pluginType = pluginType;
         this.pluginJarPath = pluginJarPath;
         if (pluginDependencyJarPaths == null) {
             this.pluginDependencyJarPaths = Collections.emptyList();
@@ -15,16 +17,20 @@ public class MavenPluginPaths {
         }
     }
 
-    public static MavenPluginPaths of(final Path pluginJarPath) {
-        return new MavenPluginPaths(pluginJarPath, null);
+    public static MavenPluginPaths of(final MavenPluginType pluginType, final Path pluginJarPath) {
+        return new MavenPluginPaths(pluginType, pluginJarPath, null);
     }
 
-    public static MavenPluginPaths of(final Path pluginJarPath, final Path... pluginDependencyJarPaths) {
-        return new MavenPluginPaths(pluginJarPath, Arrays.asList(pluginDependencyJarPaths));
+    public static MavenPluginPaths of(final MavenPluginType pluginType, final Path pluginJarPath, final Path... pluginDependencyJarPaths) {
+        return new MavenPluginPaths(pluginType, pluginJarPath, Arrays.asList(pluginDependencyJarPaths));
     }
 
-    public static MavenPluginPaths of(final Path pluginJarPath, final List<Path> pluginDependencyJarPaths) {
-        return new MavenPluginPaths(pluginJarPath, pluginDependencyJarPaths);
+    public static MavenPluginPaths of(final MavenPluginType pluginType, final Path pluginJarPath, final List<Path> pluginDependencyJarPaths) {
+        return new MavenPluginPaths(pluginType, pluginJarPath, pluginDependencyJarPaths);
+    }
+
+    public MavenPluginType getPluginType() {
+        return this.pluginType;
     }
 
     public Path getPluginJarPath() {
@@ -35,6 +41,7 @@ public class MavenPluginPaths {
         return this.pluginDependencyJarPaths;
     }
 
+    private final MavenPluginType pluginType;
     private final Path pluginJarPath;
     private final List<Path> pluginDependencyJarPaths;
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/MavenPluginType.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/MavenPluginType.java
@@ -73,6 +73,10 @@ public final class MavenPluginType extends PluginType {
         return this.group;
     }
 
+    public final String getArtifactId(final String category) {
+        return "embulk-" + category + "-" + this.getName();
+    }
+
     public final String getClassifier() {
         return this.classifier;
     }

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginRegistry.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginRegistry.java
@@ -85,11 +85,7 @@ final class MavenPluginRegistry {
 
         final MavenPluginPaths pluginPaths;
         try {
-            pluginPaths = mavenArtifactFinder.findMavenPluginJarsWithDirectDependencies(
-                    pluginType.getGroup(),
-                    "embulk-" + category + "-" + pluginType.getName(),
-                    pluginType.getClassifier(),
-                    pluginType.getVersion());
+            pluginPaths = mavenArtifactFinder.findMavenPluginJarsWithDirectDependencies(pluginType, category);
         } catch (final FileNotFoundException ex) {
             throw new PluginSourceNotMatchException(ex);
         }

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
@@ -2,8 +2,6 @@ package org.embulk.plugin.maven;
 
 import java.util.Map;
 import org.embulk.EmbulkSystemProperties;
-import org.embulk.plugin.DefaultPluginType;
-import org.embulk.plugin.MavenPluginType;
 import org.embulk.plugin.PluginClassLoaderFactory;
 import org.embulk.plugin.PluginManager;
 import org.embulk.plugin.PluginSource;
@@ -32,22 +30,7 @@ public class MavenPluginSource implements PluginSource {
         }
         final String category = registry.getCategory();
 
-        final MavenPluginType mavenPluginType;
-        switch (pluginType.getSourceType()) {
-            case DEFAULT:
-                mavenPluginType = MavenPluginType.createFromDefaultPluginType(
-                        category, (DefaultPluginType) pluginType, this.embulkSystemProperties);
-                break;
-
-            case MAVEN:
-                mavenPluginType = (MavenPluginType) pluginType;
-                break;
-
-            default:
-                throw new PluginSourceNotMatchException();
-        }
-
-        final Class<?> pluginMainClass = registry.lookup(mavenPluginType);
+        final Class<?> pluginMainClass = registry.lookup(pluginType);
 
         final Object pluginMainObject;
         try {

--- a/embulk-deps/src/main/java/org/embulk/deps/maven/MavenArtifactFinderImpl.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/maven/MavenArtifactFinderImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.embulk.plugin.MavenPluginType;
 
 public class MavenArtifactFinderImpl extends MavenArtifactFinder {
     public MavenArtifactFinderImpl(final Path localMavenRepositoryPath) throws FileNotFoundException {
@@ -54,12 +55,12 @@ public class MavenArtifactFinderImpl extends MavenArtifactFinder {
     }
 
     @Override
-    public final MavenPluginPaths findMavenPluginJarsWithDirectDependencies(
-            final String groupId,
-            final String artifactId,
-            final String classifier,
-            final String version)
+    public final MavenPluginPaths findMavenPluginJarsWithDirectDependencies(final MavenPluginType pluginType, final String category)
             throws FileNotFoundException {
+        final String groupId = pluginType.getGroup();
+        final String artifactId = pluginType.getArtifactId(category);
+        final String classifier = pluginType.getClassifier();
+        final String version = pluginType.getVersion();
         final ArtifactDescriptorResult result;
         try {
             result = this.describeMavenArtifact(groupId, artifactId, classifier, "jar", version);
@@ -78,7 +79,7 @@ public class MavenArtifactFinderImpl extends MavenArtifactFinder {
             }
         }
         final Path artifactPath = this.findMavenArtifact(result.getArtifact());
-        return MavenPluginPaths.of(artifactPath, dependencyPaths);
+        return MavenPluginPaths.of(pluginType, artifactPath, dependencyPaths);
     }
 
     private Path findMavenArtifact(final Artifact artifact) throws MavenArtifactNotFoundException {

--- a/embulk-deps/src/test/java/org/embulk/deps/config/TestPluginType.java
+++ b/embulk-deps/src/test/java/org/embulk/deps/config/TestPluginType.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.HashMap;
 import java.util.Properties;
@@ -88,45 +87,33 @@ public class TestPluginType {
     public void testMavenFail1() {
         final DefaultPluginType type = (DefaultPluginType) PluginTypeJacksonModule.createFromStringForTesting("qux");
 
-        try {
-            MavenPluginType.createFromDefaultPluginType("input", type, EmbulkSystemProperties.of(new Properties()));
-        } catch (final PluginSourceNotMatchException ex) {
-            assertEquals("Embulk system property \"plugins.input.qux\" is not set.", ex.getMessage());
-            return;
-        }
-        fail("PluginSourceNotMatchException is not thrown.");
+        assertEquals(
+                null,
+                MavenPluginType.createFromDefaultPluginType("plugins.", "input", type, EmbulkSystemProperties.of(new Properties())));
     }
 
     @Test
     public void testMavenFail2() {
         final DefaultPluginType type = (DefaultPluginType) PluginTypeJacksonModule.createFromStringForTesting("foo");
 
-        try {
-            final Properties properties = new Properties();
-            properties.setProperty("plugins.filter.foo", "maven:foo");
-            MavenPluginType.createFromDefaultPluginType("filter", type, EmbulkSystemProperties.of(properties));
-        } catch (final PluginSourceNotMatchException ex) {
-            assertEquals("Embulk system property \"plugins.filter.foo\" is invalid: \"maven:foo\"",
-                         ex.getMessage());
-            return;
-        }
-        fail("PluginSourceNotMatchException is not thrown.");
+        final Properties properties = new Properties();
+        properties.setProperty("plugins.filter.foo", "maven:foo");
+
+        assertEquals(
+                null,
+                MavenPluginType.createFromDefaultPluginType("plugins.", "filter", type, EmbulkSystemProperties.of(properties)));
     }
 
     @Test
     public void testMavenFail3() {
         final DefaultPluginType type = (DefaultPluginType) PluginTypeJacksonModule.createFromStringForTesting("test");
 
-        try {
-            final Properties properties = new Properties();
-            properties.setProperty("plugins.output.test", "nonmaven:org.embulk.foo:test:0.2.4");
-            MavenPluginType.createFromDefaultPluginType("output", type, EmbulkSystemProperties.of(properties));
-        } catch (final PluginSourceNotMatchException ex) {
-            assertEquals("Embulk system property \"plugins.output.test\" is invalid: \"nonmaven:org.embulk.foo:test:0.2.4\"",
-                         ex.getMessage());
-            return;
-        }
-        fail("PluginSourceNotMatchException is not thrown.");
+        final Properties properties = new Properties();
+        properties.setProperty("plugins.output.test", "nonmaven:org.embulk.foo:test:0.2.4");
+
+        assertEquals(
+                null,
+                MavenPluginType.createFromDefaultPluginType("plugins.", "output", type, EmbulkSystemProperties.of(properties)));
     }
 
     @Test
@@ -138,7 +125,7 @@ public class TestPluginType {
         properties1.setProperty("plugins.filter.some", "maven:com.example:some:0.4.1:alpha");
 
         final MavenPluginType mavenType1 =
-                MavenPluginType.createFromDefaultPluginType("input", type, EmbulkSystemProperties.of(properties1));
+                MavenPluginType.createFromDefaultPluginType("plugins.", "input", type, EmbulkSystemProperties.of(properties1));
         assertEquals("some", mavenType1.getName());
         assertEquals("org.embulk.baz", mavenType1.getGroup());
         assertEquals("0.2.3", mavenType1.getVersion());
@@ -146,7 +133,7 @@ public class TestPluginType {
         assertEquals("maven:org.embulk.baz:some:0.2.3", mavenType1.getFullName());
 
         final MavenPluginType mavenType2 =
-                MavenPluginType.createFromDefaultPluginType("filter", type, EmbulkSystemProperties.of(properties1));
+                MavenPluginType.createFromDefaultPluginType("plugins.", "filter", type, EmbulkSystemProperties.of(properties1));
         assertEquals("some", mavenType2.getName());
         assertEquals("com.example", mavenType2.getGroup());
         assertEquals("0.4.1", mavenType2.getVersion());

--- a/embulk-deps/src/test/java/org/embulk/deps/maven/TestMavenArtifactFinder.java
+++ b/embulk-deps/src/test/java/org/embulk/deps/maven/TestMavenArtifactFinder.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.embulk.plugin.MavenPluginType;
 import org.junit.Test;
 
 public class TestMavenArtifactFinder {
@@ -13,7 +14,7 @@ public class TestMavenArtifactFinder {
         final Path basePath = getMavenPath();
         final MavenArtifactFinderImpl finder = new MavenArtifactFinderImpl(basePath);
         final MavenPluginPaths paths = finder.findMavenPluginJarsWithDirectDependencies(
-                "org.embulk.example", "embulk-example-maven-artifact", null, "0.1.2");
+                MavenPluginType.create("maven-artifact", "org.embulk.example", null, "0.1.2"), "example");
         assertEquals(buildExpectedPath(basePath, GROUP_DIRECTORY, "embulk-example-maven-artifact", "0.1.2"),
                      paths.getPluginJarPath());
 


### PR DESCRIPTION
Users (especially ourselves) sometimes want to set a "default" plugin version from Embulk System Properties, while sometimes wanted to override the default version with another version.

Users can just override the default Properties, of course, but it often happens that their deployment tests things only with the "default" version, while the "overridden" version is not tested very well.

Even if they fail to load the overridden version, they often want to fallback to the default version, which is well tested.

----

This pull-request is realize such a want. For example, a user may set `plugins.default.input.s3=maven:org.embulk:0.5.2` and `plugins.input.s3=maven:org.embulk:0.6.0`.

Then, `0.6.0` is loaded if `maven:org.embulk:embulk-input-s3:0.6.0` exists in the deployment.

Otherwise if `maven:org.embulk:embulk-input-s3:0.6.0` does not exist, `0.5.2` is loaded.