### PR TITLE
Support `override_dependencies` and `exclude_dependencies` in Maven-based `type`

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenExcludeDependency.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenExcludeDependency.java
@@ -1,0 +1,95 @@
+package org.embulk.plugin.maven;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class MavenExcludeDependency {
+    private MavenExcludeDependency(final String groupId, final String artifactId, final String classifier) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        if (classifier != null && classifier.isEmpty()) {
+            this.classifier = null;
+        } else {
+            this.classifier = classifier;
+        }
+    }
+
+    public static MavenExcludeDependency of(
+            final String groupId,
+            final String artifactId,
+            final String classifier) {
+        if (artifactId == null || groupId == null) {
+            throw new NullPointerException("\"groupId\" and \"artifactId\" must be present.");
+        }
+        return new MavenExcludeDependency(groupId, artifactId, classifier);
+    }
+
+    public static MavenExcludeDependency fromString(final String declaration) {
+        if (declaration == null) {
+            throw new NullPointerException("Maven artifact declaration must not be null.");
+        }
+        final String[] parts = declaration.split(":");  // "com.example:name[:classifier]"
+        if (parts.length != 2 && parts.length != 3) {
+            throw new IllegalArgumentException("Invalid Maven artifact declaration: " + declaration);
+        }
+        return new MavenExcludeDependency(parts[0], parts[1], parts.length == 3 ? parts[2] : null);
+    }
+
+    public Map<String, String> asMap() {
+        final LinkedHashMap<String, String> map = new LinkedHashMap<String, String>();
+        map.put("groupId", this.groupId);
+        map.put("artifactId", this.artifactId);
+        if (this.classifier != null) {
+            map.put("classifier", this.classifier);
+        }
+        return Collections.unmodifiableMap(map);
+    }
+
+    public String getGroupId() {
+        return this.groupId;
+    }
+
+    public String getArtifactId() {
+        return this.artifactId;
+    }
+
+    public Optional<String> getClassifier() {
+        return Optional.ofNullable(this.classifier);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(this.groupId, this.artifactId, this.classifier);
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (!(otherObject instanceof MavenExcludeDependency)) {
+            return false;
+        }
+        final MavenExcludeDependency other = (MavenExcludeDependency) otherObject;
+        return Objects.equals(this.groupId, other.groupId)
+                && Objects.equals(this.artifactId, other.artifactId)
+                && Objects.equals(this.classifier, other.classifier);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(this.groupId);
+        builder.append(":");
+        builder.append(this.artifactId);
+        if (this.classifier != null) {
+            builder.append(":");
+            builder.append(this.classifier);
+        }
+        return builder.toString();
+    }
+
+    private final String groupId;
+    private final String artifactId;
+    private final String classifier;  // |classifier| can be null.
+}

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenIncludeDependency.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenIncludeDependency.java
@@ -1,0 +1,110 @@
+package org.embulk.plugin.maven;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class MavenIncludeDependency {
+    private MavenIncludeDependency(final String groupId, final String artifactId, final String version, final String classifier) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        if (classifier != null && classifier.isEmpty()) {
+            this.classifier = null;
+        } else {
+            this.classifier = classifier;
+        }
+    }
+
+    public static MavenIncludeDependency of(
+            final String groupId,
+            final String artifactId,
+            final String version,
+            final String classifier) {
+        if (artifactId == null || groupId == null || version == null) {
+            throw new NullPointerException("\"groupId\", \"artifactId\", and \"version\" must be present.");
+        }
+        return new MavenIncludeDependency(groupId, artifactId, version, classifier);
+    }
+
+    public static MavenIncludeDependency fromString(final String declaration) {
+        if (declaration == null) {
+            throw new NullPointerException("Maven artifact declaration must not be null.");
+        }
+        final String[] parts = declaration.split(":");  // "com.example:name:1.2.3[:classifier]"
+        if (parts.length != 3 && parts.length != 4) {
+            throw new IllegalArgumentException("Invalid Maven artifact declaration: " + declaration);
+        }
+        return new MavenIncludeDependency(parts[0], parts[1], parts[2], parts.length == 4 ? parts[3] : null);
+    }
+
+    public Map<String, String> asMap() {
+        final LinkedHashMap<String, String> map = new LinkedHashMap<String, String>();
+        map.put("groupId", this.groupId);
+        map.put("artifactId", this.artifactId);
+        map.put("version", this.version);
+        if (this.classifier != null) {
+            map.put("classifier", this.classifier);
+        }
+        return Collections.unmodifiableMap(map);
+    }
+
+    public String getGroupId() {
+        return this.groupId;
+    }
+
+    public String getArtifactId() {
+        return this.artifactId;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public Optional<String> getClassifier() {
+        return Optional.ofNullable(this.classifier);
+    }
+
+    public MavenExcludeDependency toMavenExcludeDependency() {
+        return MavenExcludeDependency.of(this.groupId, this.artifactId, this.classifier);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(this.groupId, this.artifactId, this.version, this.classifier);
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (!(otherObject instanceof MavenIncludeDependency)) {
+            return false;
+        }
+        final MavenIncludeDependency other = (MavenIncludeDependency) otherObject;
+        return Objects.equals(this.groupId, other.groupId)
+                && Objects.equals(this.artifactId, other.artifactId)
+                && Objects.equals(this.version, other.version)
+                && Objects.equals(this.classifier, other.classifier);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(this.groupId);
+        builder.append(":");
+        builder.append(this.artifactId);
+        builder.append(":");
+        builder.append(this.version);
+        if (this.classifier != null) {
+            builder.append(":");
+            builder.append(this.classifier);
+        }
+        return builder.toString();
+    }
+
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+    private final String classifier;  // |classifier| can be null.
+}

--- a/embulk-deps/src/main/java/org/embulk/deps/config/PluginTypeJacksonModule.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/config/PluginTypeJacksonModule.java
@@ -12,13 +12,19 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.embulk.plugin.DefaultPluginType;
 import org.embulk.plugin.MavenPluginType;
 import org.embulk.plugin.PluginSource;
 import org.embulk.plugin.PluginType;
+import org.embulk.plugin.maven.MavenExcludeDependency;
+import org.embulk.plugin.maven.MavenIncludeDependency;
 
 final class PluginTypeJacksonModule extends SimpleModule {
     public PluginTypeJacksonModule() {
@@ -113,7 +119,9 @@ final class PluginTypeJacksonModule extends SimpleModule {
                 final String group = getTextual(typeObject, "group", "type");
                 final String classifier = getTextual(typeObject, "classifier", "type");
                 final String version = getTextual(typeObject, "version", "type");
-                return MavenPluginType.create(name, group, classifier, version);
+                final Set<MavenExcludeDependency> excludeDependencies = getExcludeDependencies(typeObject, "type");
+                final Set<MavenIncludeDependency> includeDependencies = getIncludeDependencies(typeObject, "type");
+                return MavenPluginType.create(name, group, classifier, version, excludeDependencies, includeDependencies);
             }
             default:
                 throw new IllegalArgumentException("\"source\" must be one of: [\"default\", \"maven\"]");
@@ -126,6 +134,77 @@ final class PluginTypeJacksonModule extends SimpleModule {
 
     static PluginType createFromObjectNodeForTesting(final ObjectNode typeObject) {
         return createFromObjectNode(typeObject);
+    }
+
+    private static Set<MavenExcludeDependency> getExcludeDependencies(final ObjectNode object, final String parent) {
+        final LinkedHashSet<MavenExcludeDependency> excludeDependencies = new LinkedHashSet<>();
+
+        final JsonNode excludeDependenciesJson = object.get("exclude_dependencies");
+        if (excludeDependenciesJson != null) {
+            if (!excludeDependenciesJson.isArray()) {
+                throw new IllegalArgumentException("\"exclude_dependencies\" in \"" + parent + "\" must be an array.");
+            }
+            for (final JsonNode excludeDependencyJson : (ArrayNode) excludeDependenciesJson) {
+                excludeDependencies.add(getExcludeDependency(excludeDependencyJson));
+            }
+        }
+
+        final JsonNode overrideDependenciesJson = object.get("override_dependencies");
+        if (overrideDependenciesJson != null) {
+            if (!overrideDependenciesJson.isArray()) {
+                throw new IllegalArgumentException("\"override_dependencies\" in \"" + parent + "\" must be an array.");
+            }
+            for (final JsonNode overrideDependencyJson : (ArrayNode) overrideDependenciesJson) {
+                excludeDependencies.add(getOverrideDependency(overrideDependencyJson).toMavenExcludeDependency());
+            }
+        }
+
+        return Collections.unmodifiableSet(excludeDependencies);
+    }
+
+    private static Set<MavenIncludeDependency> getIncludeDependencies(final ObjectNode object, final String parent) {
+        final LinkedHashSet<MavenIncludeDependency> includeDependencies = new LinkedHashSet<>();
+
+        final JsonNode overrideDependenciesJson = object.get("override_dependencies");
+        if (overrideDependenciesJson != null) {
+            if (!overrideDependenciesJson.isArray()) {
+                throw new IllegalArgumentException("\"override_dependencies\" in \"" + parent + "\" must be an array.");
+            }
+            for (final JsonNode overrideDependencyJson : (ArrayNode) overrideDependenciesJson) {
+                includeDependencies.add(getOverrideDependency(overrideDependencyJson));
+            }
+        }
+
+        return Collections.unmodifiableSet(includeDependencies);
+    }
+
+    private static MavenExcludeDependency getExcludeDependency(final JsonNode json) {
+        if (json.isArray()) {
+            throw new IllegalArgumentException("Elements in \"exclude_dependencies\" must not be an array.");
+        }
+        if (json.isObject()) {
+            final ObjectNode excludeDependencyObject = (ObjectNode) json;
+            final String artifactId = getTextual(excludeDependencyObject, "artifactId", "exclude_dependencies");
+            final String groupId = getTextual(excludeDependencyObject, "groupId", "exclude_dependencies");
+            final String classifier = getTextual(excludeDependencyObject, "classifier", "exclude_dependencies");
+            return MavenExcludeDependency.of(groupId, artifactId, classifier);
+        }
+        return MavenExcludeDependency.fromString(json.asText());
+    }
+
+    private static MavenIncludeDependency getOverrideDependency(final JsonNode json) {
+        if (json.isArray()) {
+            throw new IllegalArgumentException("Elements in \"override_dependencies\" must not be an array.");
+        }
+        if (json.isObject()) {
+            final ObjectNode overrideDependencyObject = (ObjectNode) json;
+            final String artifactId = getTextual(overrideDependencyObject, "artifactId", "override_dependencies");
+            final String groupId = getTextual(overrideDependencyObject, "groupId", "override_dependencies");
+            final String version = getTextual(overrideDependencyObject, "version", "override_dependencies");
+            final String classifier = getTextual(overrideDependencyObject, "classifier", "override_dependencies");
+            return MavenIncludeDependency.of(groupId, artifactId, version, classifier);
+        }
+        return MavenIncludeDependency.fromString(json.asText());
     }
 
     private static String getTextual(final ObjectNode object, final String fieldName, final String parent) {

--- a/embulk-deps/src/test/java/org/embulk/deps/config/TestPluginType.java
+++ b/embulk-deps/src/test/java/org/embulk/deps/config/TestPluginType.java
@@ -5,7 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.HashMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Properties;
 import org.embulk.EmbulkSystemProperties;
 import org.embulk.plugin.DefaultPluginType;
@@ -29,11 +30,11 @@ public class TestPluginType {
 
     @Test
     public void testMapping1() {
-        HashMap<String, String> mapping = new HashMap<String, String>();
+        final ObjectNode mapping = OBJECT_MAPPER.createObjectNode();
         mapping.put("source", "default");
         mapping.put("name", "c");
 
-        PluginType type = PluginTypeJacksonModule.createFromStringMapForTesting(mapping);
+        PluginType type = PluginTypeJacksonModule.createFromObjectNodeForTesting(mapping);
         assertTrue(type instanceof DefaultPluginType);
         assertEquals(PluginSource.Type.DEFAULT, type.getSourceType());
         assertTrue(type.equals(type));
@@ -44,13 +45,13 @@ public class TestPluginType {
 
     @Test
     public void testMapping2() {
-        HashMap<String, String> mapping = new HashMap<String, String>();
+        final ObjectNode mapping = OBJECT_MAPPER.createObjectNode();
         mapping.put("source", "maven");
         mapping.put("name", "e");
         mapping.put("group", "org.embulk.foobar");
         mapping.put("version", "0.1.2");
 
-        PluginType type = PluginTypeJacksonModule.createFromStringMapForTesting(mapping);
+        PluginType type = PluginTypeJacksonModule.createFromObjectNodeForTesting(mapping);
         assertTrue(type instanceof MavenPluginType);
         assertEquals(PluginSource.Type.MAVEN, type.getSourceType());
         MavenPluginType mavenType = (MavenPluginType) type;
@@ -64,14 +65,14 @@ public class TestPluginType {
 
     @Test
     public void testMappingMavenWithClassifier() {
-        HashMap<String, String> mapping = new HashMap<String, String>();
+        final ObjectNode mapping = OBJECT_MAPPER.createObjectNode();
         mapping.put("source", "maven");
         mapping.put("name", "e");
         mapping.put("group", "org.embulk.foobar");
         mapping.put("version", "0.1.2");
         mapping.put("classifier", "bar");
 
-        PluginType type = PluginTypeJacksonModule.createFromStringMapForTesting(mapping);
+        PluginType type = PluginTypeJacksonModule.createFromObjectNodeForTesting(mapping);
         assertTrue(type instanceof MavenPluginType);
         assertEquals(PluginSource.Type.MAVEN, type.getSourceType());
         MavenPluginType mavenType = (MavenPluginType) type;
@@ -140,4 +141,6 @@ public class TestPluginType {
         assertEquals("alpha", mavenType2.getClassifier());
         assertEquals("maven:com.example:some:0.4.1:alpha", mavenType2.getFullName());
     }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 }


### PR DESCRIPTION
This is an alternative to JDBC plugins' `driver_path` configuration built in Embulk's core.

Users sometimes want to switch plugin's dependencies at runtime, without hacking the plugin. This configuration allows users to switch with Maven artifact names.

For example,

```
type:
  source: maven
  group: org.embulk
  name: mysql
  version: 0.10.2
  override_dependencies:
    - mysql:mysql-connector-java:8.0.11
    # Overrides existing mysql:mysql-connector-java:5.1.44 which has the same groupId and artifactId.
```

```
type:
  source: maven
  group: org.embulk
  name: sqlserver
  version: 0.10.2
  exclude_dependencies:
    - com.microsoft.sqlserver:mssql-jdbc
  override_dependencies:
    - net.sourceforge.jtds:jtds:1.3.1
    # It cannot override existing com.microsoft.sqlserver:mssql-jdbc, so excluding explicitly above.
```
