### PR TITLE
Backport v0.10.32.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "org.embulk"
-version = "0.10.32.1-SNAPSHOT"
+version = "0.10.32.1"
 
 def subprojectNamesOfCoreArtifacts = [
     "embulk-api",

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "org.embulk"
-version = "0.10.32"
+version = "0.10.32.1-SNAPSHOT"
 
 def subprojectNamesOfCoreArtifacts = [
     "embulk-api",

--- a/embulk-core/src/main/java/org/embulk/plugin/DefaultPluginType.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/DefaultPluginType.java
@@ -29,8 +29,8 @@ public final class DefaultPluginType extends PluginType {
             return false;
         }
         final DefaultPluginType other = (DefaultPluginType) objectOther;
-        return (this.getSourceType().equals(other.getSourceType())
-                && this.getName().equals(other.getName()));
+        return Objects.equals(this.getSourceType(), other.getSourceType())
+                && Objects.equals(this.getName(), other.getName());
     }
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/plugin/MavenPluginType.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/MavenPluginType.java
@@ -96,12 +96,11 @@ public final class MavenPluginType extends PluginType {
             return false;
         }
         MavenPluginType other = (MavenPluginType) objectOther;
-        return (this.getSourceType().equals(other.getSourceType())
-                && this.getName().equals(other.getName())
-                && this.getGroup().equals(other.getGroup())
-                && ((this.getClassifier() == null && other.getClassifier() == null)
-                        || (this.getClassifier() != null && this.getClassifier().equals(other.getClassifier())))
-                && this.getVersion().equals(other.getVersion()));
+        return Objects.equals(this.getSourceType(), other.getSourceType())
+                && Objects.equals(this.getName(), other.getName())
+                && Objects.equals(this.group, other.group)
+                && Objects.equals(this.classifier, other.classifier)
+                && Objects.equals(this.version, other.version);
     }
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginRegistry.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginRegistry.java
@@ -1,0 +1,115 @@
+package org.embulk.plugin;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.embulk.EmbulkSystemProperties;
+import org.embulk.deps.EmbulkSelfContainedJarFiles;
+import org.embulk.plugin.DefaultPluginType;
+import org.embulk.plugin.PluginClassLoaderFactory;
+import org.embulk.plugin.PluginSourceNotMatchException;
+import org.embulk.plugin.jar.InvalidJarPluginException;
+import org.embulk.plugin.jar.JarPluginLoader;
+import org.embulk.spi.DecoderPlugin;
+import org.embulk.spi.EncoderPlugin;
+import org.embulk.spi.ExecutorPlugin;
+import org.embulk.spi.FilterPlugin;
+import org.embulk.spi.FormatterPlugin;
+import org.embulk.spi.GuessPlugin;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.ParserPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Caches self-contained plugin's loaded classes such as embulk-ruby's Embulk::PluginRegistry.
+ *
+ * <p>See {@code /embulk-ruby/lib/embulk/plugin_registry.rb}.
+ */
+final class SelfContainedPluginRegistry {
+    private SelfContainedPluginRegistry(
+            final Class<?> pluginInterface,
+            final String category,
+            final EmbulkSystemProperties embulkSystemProperties,
+            final PluginClassLoaderFactory pluginClassLoaderFactory) {
+        this.cacheMap = new HashMap<DefaultPluginType, Class<?>>();
+
+        this.pluginInterface = pluginInterface;
+        this.category = category;
+
+        this.embulkSystemProperties = embulkSystemProperties;
+        this.pluginClassLoaderFactory = pluginClassLoaderFactory;
+    }
+
+    static Map<Class<?>, SelfContainedPluginRegistry> generateRegistries(
+            final EmbulkSystemProperties embulkSystemProperties,
+            final PluginClassLoaderFactory pluginClassLoaderFactory) {
+        final HashMap<Class<?>, SelfContainedPluginRegistry> registries = new HashMap<>();
+        for (final Map.Entry<Class<?>, String> entry : CATEGORIES.entrySet()) {
+            registries.put(
+                    entry.getKey(),
+                    new SelfContainedPluginRegistry(entry.getKey(), entry.getValue(), embulkSystemProperties, pluginClassLoaderFactory));
+        }
+        return Collections.unmodifiableMap(registries);
+    }
+
+    Class<?> lookup(final DefaultPluginType pluginType) throws PluginSourceNotMatchException  {
+        synchronized (this.cacheMap) {  // Synchronize between this.cacheMap.get() and this.cacheMap.put().
+            final Class<?> pluginMainClass = this.cacheMap.get(pluginType);
+            if (pluginMainClass != null) {
+                return pluginMainClass;
+            }
+
+            final Class<?> loadedPluginMainClass = this.search(pluginType);
+            this.cacheMap.put(pluginType, loadedPluginMainClass);
+            return loadedPluginMainClass;
+        }
+    }
+
+    String getCategory() {
+        return this.category;
+    }
+
+    private Class<?> search(final DefaultPluginType pluginType) throws PluginSourceNotMatchException {
+        final String selfContainedPluginName = "embulk-" + this.category + "-" + pluginType.getName();
+        if (!EmbulkSelfContainedJarFiles.has(selfContainedPluginName)) {
+            throw new PluginSourceNotMatchException();
+        }
+
+        final Class<?> pluginMainClass;
+        try (final JarPluginLoader loader = JarPluginLoader.loadSelfContained(selfContainedPluginName, this.pluginClassLoaderFactory)) {
+            final Class<?> loadedClass = loader.getPluginMainClass();
+            logger.info("Loaded plugin {}", selfContainedPluginName);
+            return loadedClass;
+        } catch (final InvalidJarPluginException ex) {
+            throw new PluginSourceNotMatchException(ex);
+        }
+    }
+
+    private static final Map<Class<?>, String> CATEGORIES;
+
+    static {
+        final HashMap<Class<?>, String> categories = new HashMap<>();
+        categories.put(InputPlugin.class, "input");
+        categories.put(OutputPlugin.class, "output");
+        categories.put(ParserPlugin.class, "parser");
+        categories.put(FormatterPlugin.class, "formatter");
+        categories.put(DecoderPlugin.class, "decoder");
+        categories.put(EncoderPlugin.class, "encoder");
+        categories.put(FilterPlugin.class, "filter");
+        categories.put(GuessPlugin.class, "guess");
+        categories.put(ExecutorPlugin.class, "executor");
+        CATEGORIES = Collections.unmodifiableMap(categories);
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(SelfContainedPluginRegistry.class);
+
+    private final HashMap<DefaultPluginType, Class<?>> cacheMap;
+
+    private final Class<?> pluginInterface;  // InputPlugin, OutputPlugin, FilterPlugin, ...
+    private final String category;
+
+    private final EmbulkSystemProperties embulkSystemProperties;
+    private final PluginClassLoaderFactory pluginClassLoaderFactory;
+}

--- a/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginSource.java
@@ -1,27 +1,16 @@
 package org.embulk.plugin;
 
 import com.google.inject.Injector;
+import java.util.Map;
 import org.embulk.EmbulkSystemProperties;
-import org.embulk.deps.EmbulkSelfContainedJarFiles;
 import org.embulk.plugin.PluginClassLoaderFactory;
 import org.embulk.plugin.PluginSource;
 import org.embulk.plugin.PluginSourceNotMatchException;
 import org.embulk.plugin.PluginType;
-import org.embulk.plugin.jar.InvalidJarPluginException;
-import org.embulk.plugin.jar.JarPluginLoader;
-import org.embulk.spi.DecoderPlugin;
-import org.embulk.spi.EncoderPlugin;
-import org.embulk.spi.ExecutorPlugin;
 import org.embulk.spi.FileInputPlugin;
 import org.embulk.spi.FileInputRunner;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.FileOutputRunner;
-import org.embulk.spi.FilterPlugin;
-import org.embulk.spi.FormatterPlugin;
-import org.embulk.spi.GuessPlugin;
-import org.embulk.spi.InputPlugin;
-import org.embulk.spi.OutputPlugin;
-import org.embulk.spi.ParserPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,52 +24,27 @@ public class SelfContainedPluginSource implements PluginSource {
             final PluginClassLoaderFactory pluginClassLoaderFactory) {
         this.injector = injector;
         this.embulkSystemProperties = embulkSystemProperties;
-        this.pluginClassLoaderFactory = pluginClassLoaderFactory;
+        this.registries = SelfContainedPluginRegistry.generateRegistries(embulkSystemProperties, pluginClassLoaderFactory);
     }
 
     @Override
     public <T> T newPlugin(final Class<T> pluginInterface, final PluginType pluginType) throws PluginSourceNotMatchException {
-        final String category;
-        if (InputPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "input";
-        } else if (OutputPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "output";
-        } else if (ParserPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "parser";
-        } else if (FormatterPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "formatter";
-        } else if (DecoderPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "decoder";
-        } else if (EncoderPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "encoder";
-        } else if (FilterPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "filter";
-        } else if (GuessPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "guess";
-        } else if (ExecutorPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "executor";
-        } else {
-            // unsupported plugin category
-            throw new PluginSourceNotMatchException("Plugin interface " + pluginInterface + " is not supported.");
-        }
-
         if (pluginType.getSourceType() != PluginSource.Type.DEFAULT) {
             throw new PluginSourceNotMatchException();
         }
 
+        final DefaultPluginType defaultPluginType = (DefaultPluginType) pluginType;
+
+        final SelfContainedPluginRegistry registry = this.registries.get(pluginInterface);
+        if (registry == null) {
+            // unsupported plugin category
+            throw new PluginSourceNotMatchException("Plugin interface " + pluginInterface + " is not supported.");
+        }
+        final String category = registry.getCategory();
+
         this.rejectTraditionalStandardPluginsFromEmbulkSystemProperties(category, pluginType.getName());
 
-        final String selfContainedPluginName = "embulk-" + category + "-" + pluginType.getName();
-        if (!EmbulkSelfContainedJarFiles.has(selfContainedPluginName)) {
-            throw new PluginSourceNotMatchException();
-        }
-
-        final Class<?> pluginMainClass;
-        try (final JarPluginLoader loader = JarPluginLoader.loadSelfContained(selfContainedPluginName, this.pluginClassLoaderFactory)) {
-            pluginMainClass = loader.getPluginMainClass();
-        } catch (final InvalidJarPluginException ex) {
-            throw new PluginSourceNotMatchException(ex);
-        }
+        final Class<?> pluginMainClass = registry.lookup(defaultPluginType);
 
         final Object pluginMainObject;
         try {
@@ -301,5 +265,5 @@ public class SelfContainedPluginSource implements PluginSource {
 
     private final Injector injector;
     private final EmbulkSystemProperties embulkSystemProperties;
-    private final PluginClassLoaderFactory pluginClassLoaderFactory;
+    private final Map<Class<?>, SelfContainedPluginRegistry> registries;
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginRegistry.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginRegistry.java
@@ -1,0 +1,146 @@
+package org.embulk.plugin.maven;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.embulk.EmbulkSystemProperties;
+import org.embulk.deps.maven.MavenArtifactFinder;
+import org.embulk.deps.maven.MavenPluginPaths;
+import org.embulk.plugin.MavenPluginType;
+import org.embulk.plugin.PluginClassLoaderFactory;
+import org.embulk.plugin.PluginSourceNotMatchException;
+import org.embulk.plugin.jar.InvalidJarPluginException;
+import org.embulk.plugin.jar.JarPluginLoader;
+import org.embulk.spi.DecoderPlugin;
+import org.embulk.spi.EncoderPlugin;
+import org.embulk.spi.ExecutorPlugin;
+import org.embulk.spi.FilterPlugin;
+import org.embulk.spi.FormatterPlugin;
+import org.embulk.spi.GuessPlugin;
+import org.embulk.spi.InputPlugin;
+import org.embulk.spi.OutputPlugin;
+import org.embulk.spi.ParserPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Caches Maven-based plugin's loaded classes such as embulk-ruby's Embulk::PluginRegistry.
+ *
+ * <p>See {@code /embulk-ruby/lib/embulk/plugin_registry.rb}.
+ */
+final class MavenPluginRegistry {
+    private MavenPluginRegistry(
+            final Class<?> pluginInterface,
+            final String category,
+            final EmbulkSystemProperties embulkSystemProperties,
+            final PluginClassLoaderFactory pluginClassLoaderFactory) {
+        this.cacheMap = new HashMap<MavenPluginType, Class<?>>();
+
+        this.pluginInterface = pluginInterface;
+        this.category = category;
+
+        this.embulkSystemProperties = embulkSystemProperties;
+        this.pluginClassLoaderFactory = pluginClassLoaderFactory;
+    }
+
+    static Map<Class<?>, MavenPluginRegistry> generateRegistries(
+            final EmbulkSystemProperties embulkSystemProperties,
+            final PluginClassLoaderFactory pluginClassLoaderFactory) {
+        final HashMap<Class<?>, MavenPluginRegistry> registries = new HashMap<>();
+        for (final Map.Entry<Class<?>, String> entry : CATEGORIES.entrySet()) {
+            registries.put(
+                    entry.getKey(),
+                    new MavenPluginRegistry(entry.getKey(), entry.getValue(), embulkSystemProperties, pluginClassLoaderFactory));
+        }
+        return Collections.unmodifiableMap(registries);
+    }
+
+    Class<?> lookup(final MavenPluginType pluginType) throws PluginSourceNotMatchException  {
+        synchronized (this.cacheMap) {  // Synchronize between this.cacheMap.get() and this.cacheMap.put().
+            final Class<?> pluginMainClass = this.cacheMap.get(pluginType);
+            if (pluginMainClass != null) {
+                return pluginMainClass;
+            }
+
+            final Class<?> loadedPluginMainClass = this.search(pluginType);
+            this.cacheMap.put(pluginType, loadedPluginMainClass);
+            return loadedPluginMainClass;
+        }
+    }
+
+    String getCategory() {
+        return this.category;
+    }
+
+    private Class<?> search(final MavenPluginType pluginType) throws PluginSourceNotMatchException {
+        final MavenArtifactFinder mavenArtifactFinder;
+        try {
+            mavenArtifactFinder = MavenArtifactFinder.create(this.getLocalMavenRepository());
+        } catch (final FileNotFoundException ex) {
+            throw new PluginSourceNotMatchException(ex);
+        }
+
+        final MavenPluginPaths pluginPaths;
+        try {
+            pluginPaths = mavenArtifactFinder.findMavenPluginJarsWithDirectDependencies(
+                    pluginType.getGroup(),
+                    "embulk-" + category + "-" + pluginType.getName(),
+                    pluginType.getClassifier(),
+                    pluginType.getVersion());
+        } catch (final FileNotFoundException ex) {
+            throw new PluginSourceNotMatchException(ex);
+        }
+
+        try (final JarPluginLoader loader = JarPluginLoader.load(
+                 pluginPaths.getPluginJarPath(),
+                 pluginPaths.getPluginDependencyJarPaths(),
+                 this.pluginClassLoaderFactory)) {
+            final Class<?> loadedClass = loader.getPluginMainClass();
+            logger.info("Loaded plugin {} ({})",
+                        "embulk-" + this.category + "-" + pluginType.getName(),
+                        pluginType.getFullName());
+            return loadedClass;
+        } catch (final InvalidJarPluginException ex) {
+            throw new PluginSourceNotMatchException(ex);
+        }
+    }
+
+    private Path getLocalMavenRepository() throws PluginSourceNotMatchException {
+        // It expects the Embulk system property "m2_repo" is set from org.embulk.cli.EmbulkSystemPropertiesBuilder.
+        final String m2Repo = this.embulkSystemProperties.getProperty("m2_repo", null);
+        if (m2Repo == null) {
+            throw new PluginSourceNotMatchException("Embulk system property \"m2_repo\" is not set properly.");
+        }
+
+        return Paths.get(m2Repo);
+    }
+
+    private static final Map<Class<?>, String> CATEGORIES;
+
+    static {
+        final HashMap<Class<?>, String> categories = new HashMap<>();
+        categories.put(InputPlugin.class, "input");
+        categories.put(OutputPlugin.class, "output");
+        categories.put(ParserPlugin.class, "parser");
+        categories.put(FormatterPlugin.class, "formatter");
+        categories.put(DecoderPlugin.class, "decoder");
+        categories.put(EncoderPlugin.class, "encoder");
+        categories.put(FilterPlugin.class, "filter");
+        categories.put(GuessPlugin.class, "guess");
+        categories.put(ExecutorPlugin.class, "executor");
+        CATEGORIES = Collections.unmodifiableMap(categories);
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(MavenPluginRegistry.class);
+
+    private final HashMap<MavenPluginType, Class<?>> cacheMap;
+
+    private final Class<?> pluginInterface;  // InputPlugin, OutputPlugin, FilterPlugin, ...
+    private final String category;
+
+    private final EmbulkSystemProperties embulkSystemProperties;
+    private final PluginClassLoaderFactory pluginClassLoaderFactory;
+}

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
@@ -1,35 +1,18 @@
 package org.embulk.plugin.maven;
 
 import com.google.inject.Injector;
-import java.io.FileNotFoundException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.Map;
 import org.embulk.EmbulkSystemProperties;
-import org.embulk.deps.maven.MavenArtifactFinder;
-import org.embulk.deps.maven.MavenPluginPaths;
 import org.embulk.plugin.DefaultPluginType;
 import org.embulk.plugin.MavenPluginType;
 import org.embulk.plugin.PluginClassLoaderFactory;
 import org.embulk.plugin.PluginSource;
 import org.embulk.plugin.PluginSourceNotMatchException;
 import org.embulk.plugin.PluginType;
-import org.embulk.plugin.jar.InvalidJarPluginException;
-import org.embulk.plugin.jar.JarPluginLoader;
-import org.embulk.spi.DecoderPlugin;
-import org.embulk.spi.EncoderPlugin;
-import org.embulk.spi.ExecutorPlugin;
 import org.embulk.spi.FileInputPlugin;
 import org.embulk.spi.FileInputRunner;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.FileOutputRunner;
-import org.embulk.spi.FilterPlugin;
-import org.embulk.spi.FormatterPlugin;
-import org.embulk.spi.GuessPlugin;
-import org.embulk.spi.InputPlugin;
-import org.embulk.spi.OutputPlugin;
-import org.embulk.spi.ParserPlugin;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MavenPluginSource implements PluginSource {
     public MavenPluginSource(
@@ -38,35 +21,18 @@ public class MavenPluginSource implements PluginSource {
             final PluginClassLoaderFactory pluginClassLoaderFactory) {
         this.injector = injector;
         this.embulkSystemProperties = embulkSystemProperties;
-        this.pluginClassLoaderFactory = pluginClassLoaderFactory;
+        this.registries = MavenPluginRegistry.generateRegistries(embulkSystemProperties, pluginClassLoaderFactory);
     }
 
     @Override
     public <T> T newPlugin(Class<T> pluginInterface, PluginType pluginType)
             throws PluginSourceNotMatchException {
-        final String category;
-        if (InputPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "input";
-        } else if (OutputPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "output";
-        } else if (ParserPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "parser";
-        } else if (FormatterPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "formatter";
-        } else if (DecoderPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "decoder";
-        } else if (EncoderPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "encoder";
-        } else if (FilterPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "filter";
-        } else if (GuessPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "guess";
-        } else if (ExecutorPlugin.class.isAssignableFrom(pluginInterface)) {
-            category = "executor";
-        } else {
+        final MavenPluginRegistry registry = this.registries.get(pluginInterface);
+        if (registry == null) {
             // unsupported plugin category
             throw new PluginSourceNotMatchException("Plugin interface " + pluginInterface + " is not supported.");
         }
+        final String category = registry.getCategory();
 
         final MavenPluginType mavenPluginType;
         switch (pluginType.getSourceType()) {
@@ -83,33 +49,7 @@ public class MavenPluginSource implements PluginSource {
                 throw new PluginSourceNotMatchException();
         }
 
-        final MavenArtifactFinder mavenArtifactFinder;
-        try {
-            mavenArtifactFinder = MavenArtifactFinder.create(getLocalMavenRepository());
-        } catch (final FileNotFoundException ex) {
-            throw new PluginSourceNotMatchException(ex);
-        }
-
-        final MavenPluginPaths pluginPaths;
-        try {
-            pluginPaths = mavenArtifactFinder.findMavenPluginJarsWithDirectDependencies(
-                    mavenPluginType.getGroup(),
-                    "embulk-" + category + "-" + mavenPluginType.getName(),
-                    mavenPluginType.getClassifier(),
-                    mavenPluginType.getVersion());
-        } catch (final FileNotFoundException ex) {
-            throw new PluginSourceNotMatchException(ex);
-        }
-
-        final Class<?> pluginMainClass;
-        try (JarPluginLoader loader = JarPluginLoader.load(
-                 pluginPaths.getPluginJarPath(),
-                 pluginPaths.getPluginDependencyJarPaths(),
-                 this.pluginClassLoaderFactory)) {
-            pluginMainClass = loader.getPluginMainClass();
-        } catch (InvalidJarPluginException ex) {
-            throw new PluginSourceNotMatchException(ex);
-        }
+        final Class<?> pluginMainClass = registry.lookup(mavenPluginType);
 
         final Object pluginMainObject;
         try {
@@ -155,10 +95,6 @@ public class MavenPluginSource implements PluginSource {
                     ex);
         }
 
-        logger.info("Loaded plugin {} ({})",
-                    "embulk-" + category + "-" + mavenPluginType.getName(),
-                    mavenPluginType.getFullName());
-
         try {
             return pluginInterface.cast(pluginMainObject);
         } catch (ClassCastException ex) {
@@ -168,19 +104,7 @@ public class MavenPluginSource implements PluginSource {
         }
     }
 
-    private Path getLocalMavenRepository() throws PluginSourceNotMatchException {
-        // It expects the Embulk system property "m2_repo" is set from org.embulk.cli.EmbulkSystemPropertiesBuilder.
-        final String m2Repo = this.embulkSystemProperties.getProperty("m2_repo", null);
-        if (m2Repo == null) {
-            throw new PluginSourceNotMatchException("Embulk system property \"m2_repo\" is not set properly.");
-        }
-
-        return Paths.get(m2Repo);
-    }
-
-    private static final Logger logger = LoggerFactory.getLogger(MavenPluginSource.class);
-
     private final Injector injector;
     private final EmbulkSystemProperties embulkSystemProperties;
-    private final PluginClassLoaderFactory pluginClassLoaderFactory;
+    private final Map<Class<?>, MavenPluginRegistry> registries;
 }


### PR DESCRIPTION
The same as v0.10.29.1 and v0.10.31.1, we need to backport #1484 and #1486 for v0.10.32.

* https://github.com/embulk/embulk/releases/tag/v0.10.29.1
* https://github.com/embulk/embulk/releases/tag/v0.10.31.1

On the other hand, another backport such as v0.10.31.2 is not needed. 

* https://github.com/embulk/embulk/releases/tag/v0.10.31.2

It is because Jackson has already been cleaned up in v0.10.32.

* https://github.com/embulk/embulk/releases/tag/v0.10.32