### PR TITLE
Disable publishing a Gradle Module Metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
         options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
     }
 
+    // It should not publish a `.module` file in Maven Central.
+    // https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html#sub:disabling-gmm-publication
+    tasks.withType(GenerateModuleMetadata) {
+        enabled = false
+    }
+
     java {
         withJavadocJar()
         withSourcesJar()


### PR DESCRIPTION
Similar to https://github.com/embulk/embulk-input-gcs/pull/52. We basically trust Maven `.pom` files. Having two types of dependency declarations would cause confusions.

See: https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html#sub:disabling-gmm-publication