### PR TITLE
Load/require 'jruby' explicitly in JRuby 9.3+ (Fix #1501)

### DIFF
--- a/embulk-ruby/lib/embulk/java/imports.rb
+++ b/embulk-ruby/lib/embulk/java/imports.rb
@@ -1,4 +1,19 @@
+# Required to use "Java features" from the Ruby side.
 require 'java'
+
+# Required to access JRuby-specific internal features, such as `JRuby.runtime`.
+require 'jruby' if Gem::Version.new(JRUBY_VERSION) >= Gem::Version.new('9.3')
+
+# Both of 'java' and 'jruby' should be loaded in Embulk's use-case in nature.
+#
+# Embulk had loaded only 'java' explicitly until Embulk v0.10.35.
+# It was because loading 'java' automatically loaded also 'jruby' until JRuby 9.2.
+# But, it has changed since JRuby 9.3. JRuby 9.3+ needs loading 'jruby' explicitly.
+#
+# See also: https://github.com/jruby/jruby/issues/7221#issuecomment-1133646241
+#
+# Here, Embulk limits loading 'jruby' only in JRuby 9.3+ to ensure compatibility.
+# We may remove the limitation in the future.
 
 #
 # this file is loaded by embulk/java/bootstrap.rb


### PR DESCRIPTION
This PR fixes #1501.

JRuby 9.3.0.0 `require 'jruby'` statement for plugin initialization.

This change doesn't change the current behavior.

#### test config

```
embulk_test=# select * from inc_test;
 id | name
----+-------
  1 | apple
(1 row)
```

```yaml
in:
  type: postgresql
  host: localhost
  user: user
  password: password
  database: embulk_test
  table: inc_test
out:
  type: stdout
```

#### with JRuby 9.1.15.0

```
% ./exe/multi-embulk -j 9.1.15.0 -e 0.10.36-SNAPSHOT run /tmp/test.yml
#####################################################
#
# Embulk: /path/to/embulk/embulk/embulk-0.10.36-SNAPSHOT.jar
# JRuby: /path/to/embulk/jruby/jruby-complete-9.1.15.0.jar
# EmbulkHome: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.1.15.0
# CMD: run /tmp/test.yml
#
#####################################################
2022-04-22 21:14:23.514 +0900 [INFO] (main): embulk_home is set from command-line: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.1.15.0
2022-04-22 21:14:23.518 +0900 [INFO] (main): m2_repo is set as a sub directory of embulk_home: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.1.15.0/lib/m2/repository
2022-04-22 21:14:23.518 +0900 [INFO] (main): gem_home is set as a sub directory of embulk_home: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.1.15.0/lib/gems
2022-04-22 21:14:23.518 +0900 [INFO] (main): gem_path is set empty.
2022-04-22 21:14:23.876 +0900 [INFO] (main): Started Embulk v0.10.36-SNAPSHOT
2022-04-22 21:14:27.100 +0900 [INFO] (0001:transaction): Gem's home and path are set by system configs "gem_home": "/path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.1.15.0/lib/gems", "gem_path": ""
2022-04-22 21:14:28.311 +0900 [INFO] (0001:transaction): Loaded plugin embulk-input-postgresql (0.12.3)
2022-04-22 21:14:28.580 +0900 [INFO] (0001:transaction): Loaded plugin embulk-output-stdout
2022-04-22 21:14:28.831 +0900 [WARN] (0001:transaction): "UTC" is recognized as "Z" to be compatible with the legacy style.
2022-04-22 21:14:28.879 +0900 [INFO] (0001:transaction): JDBC Driver = /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.1.15.0/lib/gems/gems/embulk-input-postgresql-0.12.3-java/default_jdbc_driver/postgresql-9.4-1205-jdbc41.jar
2022-04-22 21:14:28.896 +0900 [INFO] (0001:transaction): Connecting to jdbc:postgresql://localhost:5432/embulk_test options {ApplicationName=embulk-input-postgresql, user=user, password=***, tcpKeepAlive=true, loginTimeout=300, socketTimeout=1800}
2022-04-22 21:14:28.976 +0900 [INFO] (0001:transaction): SQL: SET search_path TO "public"
2022-04-22 21:14:28.987 +0900 [INFO] (0001:transaction): Using JDBC Driver PostgreSQL 9.4 JDBC4.1 (build 1205)
2022-04-22 21:14:29.058 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 4 = input tasks 1 * 4
2022-04-22 21:14:29.105 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2022-04-22 21:14:29.157 +0900 [WARN] (0014:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2022-04-22 21:14:29.157 +0900 [WARN] (0014:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2022-04-22 21:14:29.227 +0900 [INFO] (0014:task-0000): Connecting to jdbc:postgresql://localhost:5432/embulk_test options {ApplicationName=embulk-input-postgresql, user=user, password=***, tcpKeepAlive=true, loginTimeout=300, socketTimeout=1800}
2022-04-22 21:14:29.238 +0900 [INFO] (0014:task-0000): SQL: SET search_path TO "public"
2022-04-22 21:14:29.247 +0900 [INFO] (0014:task-0000): SQL: DECLARE cur NO SCROLL CURSOR FOR SELECT * FROM "inc_test"
2022-04-22 21:14:29.249 +0900 [INFO] (0014:task-0000): SQL: FETCH FORWARD 10000 FROM cur
2022-04-22 21:14:29.252 +0900 [INFO] (0014:task-0000): > 0.00 seconds
2022-04-22 21:14:29.259 +0900 [INFO] (0014:task-0000): SQL: FETCH FORWARD 10000 FROM cur
2022-04-22 21:14:29.262 +0900 [INFO] (0014:task-0000): > 0.00 seconds
1,apple
2022-04-22 21:14:29.272 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2022-04-22 21:14:29.280 +0900 [INFO] (main): Committed.
2022-04-22 21:14:29.280 +0900 [INFO] (main): Next config diff: {"in":{},"out":{}}
```

#### with JRuby 9.2.20.1

```
% ./exe/multi-embulk -j 9.2.20.1 -e 0.10.36-SNAPSHOT run /tmp/test.yml
#####################################################
#
# Embulk: /path/to/embulk/embulk/embulk-0.10.36-SNAPSHOT.jar
# JRuby: /path/to/embulk/jruby/jruby-complete-9.2.20.1.jar
# EmbulkHome: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.2.20.1
# CMD: run /tmp/test.yml
#
#####################################################
2022-04-22 21:14:38.387 +0900 [INFO] (main): embulk_home is set from command-line: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.2.20.1
2022-04-22 21:14:38.391 +0900 [INFO] (main): m2_repo is set as a sub directory of embulk_home: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.2.20.1/lib/m2/repository
2022-04-22 21:14:38.391 +0900 [INFO] (main): gem_home is set as a sub directory of embulk_home: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.2.20.1/lib/gems
2022-04-22 21:14:38.391 +0900 [INFO] (main): gem_path is set empty.
2022-04-22 21:14:38.761 +0900 [INFO] (main): Started Embulk v0.10.36-SNAPSHOT
2022-04-22 21:14:42.234 +0900 [INFO] (0001:transaction): Gem's home and path are set by system configs "gem_home": "/path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.2.20.1/lib/gems", "gem_path": ""
2022-04-22 21:14:43.116 +0900 [INFO] (0001:transaction): Loaded plugin embulk-input-postgresql (0.12.3)
2022-04-22 21:14:43.351 +0900 [INFO] (0001:transaction): Loaded plugin embulk-output-stdout
2022-04-22 21:14:43.573 +0900 [WARN] (0001:transaction): "UTC" is recognized as "Z" to be compatible with the legacy style.
2022-04-22 21:14:43.614 +0900 [INFO] (0001:transaction): JDBC Driver = /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.2.20.1/lib/gems/gems/embulk-input-postgresql-0.12.3-java/default_jdbc_driver/postgresql-9.4-1205-jdbc41.jar
2022-04-22 21:14:43.626 +0900 [INFO] (0001:transaction): Connecting to jdbc:postgresql://localhost:5432/embulk_test options {ApplicationName=embulk-input-postgresql, user=user, password=***, tcpKeepAlive=true, loginTimeout=300, socketTimeout=1800}
2022-04-22 21:14:43.748 +0900 [INFO] (0001:transaction): SQL: SET search_path TO "public"
2022-04-22 21:14:43.765 +0900 [INFO] (0001:transaction): Using JDBC Driver PostgreSQL 9.4 JDBC4.1 (build 1205)
2022-04-22 21:14:43.862 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 4 = input tasks 1 * 4
2022-04-22 21:14:43.922 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2022-04-22 21:14:43.980 +0900 [WARN] (0014:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2022-04-22 21:14:43.980 +0900 [WARN] (0014:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2022-04-22 21:14:44.050 +0900 [INFO] (0014:task-0000): Connecting to jdbc:postgresql://localhost:5432/embulk_test options {ApplicationName=embulk-input-postgresql, user=user, password=***, tcpKeepAlive=true, loginTimeout=300, socketTimeout=1800}
2022-04-22 21:14:44.062 +0900 [INFO] (0014:task-0000): SQL: SET search_path TO "public"
2022-04-22 21:14:44.070 +0900 [INFO] (0014:task-0000): SQL: DECLARE cur NO SCROLL CURSOR FOR SELECT * FROM "inc_test"
2022-04-22 21:14:44.080 +0900 [INFO] (0014:task-0000): SQL: FETCH FORWARD 10000 FROM cur
2022-04-22 21:14:44.083 +0900 [INFO] (0014:task-0000): > 0.00 seconds
2022-04-22 21:14:44.087 +0900 [INFO] (0014:task-0000): SQL: FETCH FORWARD 10000 FROM cur
2022-04-22 21:14:44.095 +0900 [INFO] (0014:task-0000): > 0.01 seconds
1,apple
2022-04-22 21:14:44.103 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2022-04-22 21:14:44.118 +0900 [INFO] (main): Committed.
2022-04-22 21:14:44.118 +0900 [INFO] (main): Next config diff: {"in":{},"out":{}}
```

#### with JRuby 9.3.4.0

```
% ./exe/multi-embulk -j 9.3.4.0 -e 0.10.36-SNAPSHOT run /tmp/test.yml
#####################################################
#
# Embulk: /path/to/embulk/embulk/embulk-0.10.36-SNAPSHOT.jar
# JRuby: /path/to/embulk/jruby/jruby-complete-9.3.4.0.jar
# EmbulkHome: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.3.4.0
# CMD: run /tmp/test.yml
#
#####################################################
2022-04-22 21:14:58.488 +0900 [INFO] (main): embulk_home is set from command-line: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.3.4.0
2022-04-22 21:14:58.491 +0900 [INFO] (main): m2_repo is set as a sub directory of embulk_home: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.3.4.0/lib/m2/repository
2022-04-22 21:14:58.491 +0900 [INFO] (main): gem_home is set as a sub directory of embulk_home: /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.3.4.0/lib/gems
2022-04-22 21:14:58.492 +0900 [INFO] (main): gem_path is set empty.
2022-04-22 21:14:58.880 +0900 [INFO] (main): Started Embulk v0.10.36-SNAPSHOT
2022-04-22 21:15:03.079 +0900 [INFO] (0001:transaction): Gem's home and path are set by system configs "gem_home": "/path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.3.4.0/lib/gems", "gem_path": ""
2022-04-22 21:15:04.321 +0900 [INFO] (0001:transaction): Loaded plugin embulk-input-postgresql (0.12.3)
2022-04-22 21:15:04.581 +0900 [INFO] (0001:transaction): Loaded plugin embulk-output-stdout
2022-04-22 21:15:04.819 +0900 [WARN] (0001:transaction): "UTC" is recognized as "Z" to be compatible with the legacy style.
2022-04-22 21:15:04.868 +0900 [INFO] (0001:transaction): JDBC Driver = /path/to/embulk/embulk_0.10.36-SNAPSHOT_jruby_9.3.4.0/lib/gems/gems/embulk-input-postgresql-0.12.3-java/default_jdbc_driver/postgresql-9.4-1205-jdbc41.jar
2022-04-22 21:15:04.890 +0900 [INFO] (0001:transaction): Connecting to jdbc:postgresql://localhost:5432/embulk_test options {ApplicationName=embulk-input-postgresql, user=user, password=***, tcpKeepAlive=true, loginTimeout=300, socketTimeout=1800}
2022-04-22 21:15:05.012 +0900 [INFO] (0001:transaction): SQL: SET search_path TO "public"
2022-04-22 21:15:05.028 +0900 [INFO] (0001:transaction): Using JDBC Driver PostgreSQL 9.4 JDBC4.1 (build 1205)
2022-04-22 21:15:05.157 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 4 = input tasks 1 * 4
2022-04-22 21:15:05.230 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2022-04-22 21:15:05.281 +0900 [WARN] (0014:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2022-04-22 21:15:05.282 +0900 [WARN] (0014:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2022-04-22 21:15:05.373 +0900 [INFO] (0014:task-0000): Connecting to jdbc:postgresql://localhost:5432/embulk_test options {ApplicationName=embulk-input-postgresql, user=user, password=***, tcpKeepAlive=true, loginTimeout=300, socketTimeout=1800}
2022-04-22 21:15:05.384 +0900 [INFO] (0014:task-0000): SQL: SET search_path TO "public"
2022-04-22 21:15:05.392 +0900 [INFO] (0014:task-0000): SQL: DECLARE cur NO SCROLL CURSOR FOR SELECT * FROM "inc_test"
2022-04-22 21:15:05.396 +0900 [INFO] (0014:task-0000): SQL: FETCH FORWARD 10000 FROM cur
2022-04-22 21:15:05.398 +0900 [INFO] (0014:task-0000): > 0.00 seconds
2022-04-22 21:15:05.402 +0900 [INFO] (0014:task-0000): SQL: FETCH FORWARD 10000 FROM cur
2022-04-22 21:15:05.404 +0900 [INFO] (0014:task-0000): > 0.00 seconds
1,apple
2022-04-22 21:15:05.413 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2022-04-22 21:15:05.426 +0900 [INFO] (main): Committed.
2022-04-22 21:15:05.427 +0900 [INFO] (main): Next config diff: {"in":{},"out":{}}
```

