### PR TITLE
Do not look for self-contained JAR files when dependencies are specified separately

### DIFF
--- a/embulk-core/src/main/java/org/embulk/deps/DependencyClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/deps/DependencyClassLoader.java
@@ -10,9 +10,9 @@ import java.util.Collection;
  * Loads classes of embulk-core's hidden dependencies.
  */
 final class DependencyClassLoader extends SelfContainedJarAwareURLClassLoader {
-    DependencyClassLoader(final Collection<Path> jarPaths, final ClassLoader parent) {
+    DependencyClassLoader(final Collection<Path> jarPaths, final ClassLoader parent, final boolean useSelfContainedJarFile) {
         // The delegation parent ClassLoader is processed by the super class URLClassLoader.
-        super(toUrls(jarPaths), parent, EmbulkSelfContainedJarFiles.CORE);
+        super(toUrls(jarPaths), parent, useSelfContainedJarFile ? EmbulkSelfContainedJarFiles.CORE : null);
     }
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
+++ b/embulk-core/src/main/java/org/embulk/deps/EmbulkDependencyClassLoaders.java
@@ -62,7 +62,7 @@ public final class EmbulkDependencyClassLoaders {
                 System.err.println(
                         "Hidden dependencies are uninitialized. Maybe using classes loaded by Embulk's top-level ClassLoader.");
             }
-            DEPENDENCY_CLASS_LOADER = new DependencyClassLoader(DEPENDENCIES, CLASS_LOADER);
+            DEPENDENCY_CLASS_LOADER = new DependencyClassLoader(DEPENDENCIES, CLASS_LOADER, USE_SELF_CONTAINED_JAR_FILES.get());
         }
     }
 


### PR DESCRIPTION
This PR is not to look for self-contained JAR files (labelled `$embulk-deps$`) when dependencies are specified separately from `StaticInitializer.addDependency` or `StaticInitializer.addDependencies`.