### PR TITLE
Hotfix v0.10.31.3: Add an option for EmbulkEmbed to keep MavenPluginSource through EmbulkEmbed's lifetime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "org.embulk"
-version = "0.10.31.2"
+version = "0.10.31.3"
 
 def subprojectNamesOfCoreArtifacts = [
     "embulk-api",

--- a/embulk-core/src/main/java/org/embulk/spi/ExecSessionInternal.java
+++ b/embulk-core/src/main/java/org/embulk/spi/ExecSessionInternal.java
@@ -246,10 +246,10 @@ public class ExecSessionInternal extends ExecSession {
                 embulkSystemProperties,
                 builtinPluginSource,
                 (mavenPluginSource == null)
-                        ? new MavenPluginSource(injector, embulkSystemProperties, pluginClassLoaderFactory)
+                        ? new MavenPluginSource(injector, embulkSystemProperties, this.pluginClassLoaderFactory)
                         : mavenPluginSource,
-                new SelfContainedPluginSource(injector, embulkSystemProperties, pluginClassLoaderFactory),
-                new JRubyPluginSource(injector.getInstance(ScriptingContainerDelegate.class), pluginClassLoaderFactory));
+                new SelfContainedPluginSource(injector, embulkSystemProperties, this.pluginClassLoaderFactory),
+                new JRubyPluginSource(injector.getInstance(ScriptingContainerDelegate.class), this.pluginClassLoaderFactory));
 
         this.bufferAllocator = injector.getInstance(BufferAllocator.class);
 


### PR DESCRIPTION
This is an ad-hoc hotfix only for v0.10.31.3 to provide an option `EmbulkEmbed.Builder#keepMavenPluginSource()` so that Maven-based plugin classes are cached through multiple `EmbulkEmbed#guess,run,preview` calls.