### PR TITLE
Fix caching in MavenPluginRegistry

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginRegistry.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginRegistry.java
@@ -61,15 +61,15 @@ final class MavenPluginRegistry {
         return Collections.unmodifiableMap(registries);
     }
 
-    Class<?> lookup(final PluginType pluginType) throws PluginSourceNotMatchException  {
+    Class<?> lookup(final PluginType pluginType) throws PluginSourceNotMatchException {
+        final MavenPluginPaths pluginPaths = this.findPluginPaths(pluginType);
+        final MavenPluginType mavenPluginType = pluginPaths.getPluginType();
+
         synchronized (this.cacheMap) {  // Synchronize between this.cacheMap.get() and this.cacheMap.put().
-            final Class<?> pluginMainClass = this.cacheMap.get(pluginType);
+            final Class<?> pluginMainClass = this.cacheMap.get(mavenPluginType);
             if (pluginMainClass != null) {
                 return pluginMainClass;
             }
-
-            final MavenPluginPaths pluginPaths = this.findPluginPaths(pluginType);
-            final MavenPluginType mavenPluginType = pluginPaths.getPluginType();
 
             final Class<?> loadedPluginMainClass;
             try (final JarPluginLoader loader = JarPluginLoader.load(


### PR DESCRIPTION
We found that #1481 (v0.10.35) broke the plugin class cache by #1484 (v0.10.34).

I believe that the plugin lookup mechanism should be totally refactored as filed in #1485, so that we can avoid this kind of bugs in the future. But as of now, let me fix just this before #1448, the planned next big removal.