### PR TITLE
Bump up to v0.10.39-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "org.embulk"
-version = "0.10.38-SNAPSHOT"
+version = "0.10.39-SNAPSHOT"
 
 def subprojectNamesOfCoreArtifacts = [
     "embulk-api",


### PR DESCRIPTION
After a fix #1523 at v0.10.38, we're planning to release v0.10.39 with removing Guava #1448, finally!
