### PR TITLE
Remove ConfigSource tests for jackson-datatype-guava

### DIFF
--- a/embulk-deps/build.gradle
+++ b/embulk-deps/build.gradle
@@ -68,5 +68,4 @@ dependencies {
     testImplementation project(":embulk-core")
     testImplementation project(":embulk-junit4")
     testImplementation "junit:junit:4.13.2"
-    testImplementation "com.google.guava:guava:18.0"
 }

--- a/embulk-deps/src/test/java/org/embulk/deps/config/TestConfigSource.java
+++ b/embulk-deps/src/test/java/org/embulk/deps/config/TestConfigSource.java
@@ -50,10 +50,6 @@ public class TestConfigSource {
     }
 
     private static interface OptionalFields extends Task {
-        @Config("guava_optional")
-        @ConfigDefault("null")
-        public com.google.common.base.Optional<String> getGuavaOptional();
-
         @Config("java_util_optional")
         @ConfigDefault("null")
         public java.util.Optional<String> getJavaUtilOptional();
@@ -121,12 +117,9 @@ public class TestConfigSource {
 
     @Test
     public void testOptionalPresent() {
-        config.set("guava_optional", "Guava");
         config.set("java_util_optional", "JavaUtil");
 
         final OptionalFields loaded = config.loadConfig(OptionalFields.class);
-        assertTrue(loaded.getGuavaOptional().isPresent());
-        assertEquals("Guava", loaded.getGuavaOptional().get());
         assertTrue(loaded.getJavaUtilOptional().isPresent());
         assertEquals("JavaUtil", loaded.getJavaUtilOptional().get());
     }
@@ -134,7 +127,6 @@ public class TestConfigSource {
     @Test
     public void testOptionalAbsent() {
         final OptionalFields loaded = config.loadConfig(OptionalFields.class);
-        assertFalse(loaded.getGuavaOptional().isPresent());
         assertFalse(loaded.getJavaUtilOptional().isPresent());
     }
 


### PR DESCRIPTION
Those test cases will no longer work because Guava was removed, then they should have been removed.

It was not detected in https://github.com/embulk/embulk/pull/1448 because EmbulkTestRuntime was not working well at the base of the pull request.

EmbulkTestRuntime got fixed in https://github.com/embulk/embulk/pull/1518 for v0.10.37, then the issue was revealed after merging the pull request.