### PR TITLE
Clean up and comment on Guava dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,9 +224,7 @@ dependencies {
     implementation "ch.qos.logback:logback-classic:1.2.3"
     implementation "org.fusesource.jansi:jansi:1.18"
 
-    embed(project(':embulk-deps')) {
-        exclude group: 'com.google.guava', module: 'guava'  // Included in embulk-core.
-    }
+    embed project(":embulk-deps")
 
     embeddedPlugins.each { pluginArtifact ->
         embed pluginArtifact

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -20,6 +20,9 @@ dependencies {
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":embulk-junit4")
     testImplementation "ch.qos.logback:logback-classic:1.1.3"
+
+    // TODO: Remove Guava.
+    // It is needed only to use Immutable* in test cases for ease.
     testImplementation "com.google.guava:guava:18.0"
 
     // TODO: Remove this, and load it with the proper DependencyClassLoader.

--- a/embulk-junit4/build.gradle
+++ b/embulk-junit4/build.gradle
@@ -10,11 +10,14 @@ configurations {
 }
 
 dependencies {
+    // TODO: Remove Guava.
+    // It is needed only to use Immutable* in test cases for ease.
+    implementation "com.google.guava:guava:18.0"
+
     api "junit:junit:4.13.2"
     api "org.hamcrest:hamcrest-library:1.3"
 
     api project(":embulk-api")
     api project(":embulk-core")
     compileOnly "org.slf4j:slf4j-api:1.7.12"
-    compileOnly "com.google.guava:guava:18.0"
 }


### PR DESCRIPTION
* Removing "exclude guava" in a dependency to "embulk-deps" for the executable binary.
* Commenting to remove Guava from "embulk-core" test dependencies.
* Re-adding Guava in "embulk-junit4" dependencies, which was just "compileOnly" because "embulk-core" had Guava.