### PR TITLE
Remove Guava from embulk-junit4

### DIFF
--- a/embulk-junit4/build.gradle
+++ b/embulk-junit4/build.gradle
@@ -10,10 +10,6 @@ configurations {
 }
 
 dependencies {
-    // TODO: Remove Guava.
-    // It is needed only to use Immutable* in test cases for ease.
-    implementation "com.google.guava:guava:18.0"
-
     api "junit:junit:4.13.2"
     api "org.hamcrest:hamcrest-library:1.3"
 

--- a/embulk-junit4/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-junit4/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.google.guava:guava:18.0
 junit:junit:4.13.2
 org.hamcrest:hamcrest-core:1.3
 org.hamcrest:hamcrest-library:1.3

--- a/embulk-junit4/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-junit4/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,7 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.google.guava:guava:18.0
 junit:junit:4.13.2
 org.hamcrest:hamcrest-core:1.3
 org.hamcrest:hamcrest-library:1.3

--- a/embulk-junit4/src/main/java/org/embulk/test/EmbulkTests.java
+++ b/embulk-junit4/src/main/java/org/embulk/test/EmbulkTests.java
@@ -1,19 +1,16 @@
 package org.embulk.test;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assume.assumeThat;
 
-import com.google.common.io.CharStreams;
-import com.google.common.io.Resources;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.List;
 import org.embulk.config.ConfigLoader;
@@ -25,7 +22,7 @@ public class EmbulkTests {
 
     public static ConfigSource config(String envName) {
         String path = System.getenv(envName);
-        assumeThat(isNullOrEmpty(path), is(false));
+        assumeThat(path == null || path.isEmpty(), is(false));
         try {
             return new ConfigLoader(new ModelManager()).fromYamlFile(new File(path));
         } catch (IOException ex) {
@@ -34,28 +31,28 @@ public class EmbulkTests {
     }
 
     public static String readResource(String name) {
-        try (InputStream in = Resources.getResource(name).openStream()) {
-            return CharStreams.toString(new InputStreamReader(in, UTF_8));
-        } catch (IOException ex) {
+        try (final InputStream in = EmbulkTests.class.getResourceAsStream(name)) {
+            return inputStreamToString(in);
+        } catch (final IOException ex) {
             throw new RuntimeException(ex);
         }
     }
 
     public static void copyResource(String resource, Path dest) throws IOException {
         Files.createDirectories(dest.getParent());
-        try (InputStream input = Resources.getResource(resource).openStream()) {
-            Files.copy(input, dest, REPLACE_EXISTING);
+        try (final InputStream input = EmbulkTests.class.getResourceAsStream(resource)) {
+            Files.copy(input, dest, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 
     public static String readFile(Path path) throws IOException {
         try (InputStream in = Files.newInputStream(path)) {
-            return CharStreams.toString(new InputStreamReader(in, UTF_8));
+            return inputStreamToString(in);
         }
     }
 
     public static String readSortedFile(Path path) throws IOException {
-        List<String> lines = Files.readAllLines(path, UTF_8);
+        List<String> lines = Files.readAllLines(path, StandardCharsets.UTF_8);
         Collections.sort(lines);
         StringBuilder sb = new StringBuilder();
         for (String line : lines) {
@@ -63,5 +60,14 @@ public class EmbulkTests {
             sb.append("\n");
         }
         return sb.toString();
+    }
+
+    private static String inputStreamToString(final InputStream stream) throws IOException {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        final byte[] buffer = new byte[1024];
+        for (int length; (length = stream.read(buffer)) != -1;) {
+            output.write(buffer, 0, length);
+        }
+        return output.toString(StandardCharsets.UTF_8.toString());
     }
 }

--- a/embulk-junit4/src/main/java/org/embulk/test/PreviewResultInputPlugin.java
+++ b/embulk-junit4/src/main/java/org/embulk/test/PreviewResultInputPlugin.java
@@ -1,7 +1,5 @@
 package org.embulk.test;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import java.util.List;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
@@ -27,7 +25,9 @@ public final class PreviewResultInputPlugin implements InputPlugin {
 
     @Override
     public ConfigDiff transaction(ConfigSource config, Control control) {
-        checkState(previewResult != null, "PreviewResult object must be set");
+        if (previewResult == null) {
+            throw new IllegalStateException("PreviewResult object must be set");
+        }
         return resume(config.loadConfig(Task.class).dump(), previewResult.getSchema(), 1, control);
     }
 


### PR DESCRIPTION
Follow-up to #1448 in v0.10.39 to clean up remaining Guava in `embulk-junit4` in a following veresion.