### PR TITLE
Remove Guava from embulk-core tests

### DIFF
--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -21,10 +21,6 @@ dependencies {
     testImplementation project(":embulk-junit4")
     testImplementation "ch.qos.logback:logback-classic:1.1.3"
 
-    // TODO: Remove Guava.
-    // It is needed only to use Immutable* in test cases for ease.
-    testImplementation "com.google.guava:guava:18.0"
-
     // TODO: Remove this, and load it with the proper DependencyClassLoader.
     // This statement gets it loaded by the top-level ClassLoader.
     testImplementation project(":embulk-deps")

--- a/embulk-core/src/test/java/org/embulk/spi/TestFileInputRunner.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestFileInputRunner.java
@@ -2,8 +2,6 @@ package org.embulk.spi;
 
 import static org.junit.Assert.assertEquals;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -98,13 +96,13 @@ public class TestFileInputRunner {
 
         ConfigSource config = Exec.newConfigSource().set(
                 "parser",
-                ImmutableMap.of("type", "mock", "columns", ImmutableList.of(
-                        ImmutableMap.of("name", "col1", "type", "boolean", "option", ImmutableMap.of()),
-                        ImmutableMap.of("name", "col2", "type", "long", "option", ImmutableMap.of()),
-                        ImmutableMap.of("name", "col3", "type", "double", "option", ImmutableMap.of()),
-                        ImmutableMap.of("name", "col4", "type", "string", "option", ImmutableMap.of()),
-                        ImmutableMap.of("name", "col5", "type", "timestamp", "option", ImmutableMap.of()),
-                        ImmutableMap.of("name", "col6", "type", "json", "option", ImmutableMap.of()))));
+                TestUtils.mapOf("type", "mock", "columns", TestUtils.listOf(
+                        TestUtils.mapOf("name", "col1", "type", "boolean", "option", TestUtils.mapOf()),
+                        TestUtils.mapOf("name", "col2", "type", "long", "option", TestUtils.mapOf()),
+                        TestUtils.mapOf("name", "col3", "type", "double", "option", TestUtils.mapOf()),
+                        TestUtils.mapOf("name", "col4", "type", "string", "option", TestUtils.mapOf()),
+                        TestUtils.mapOf("name", "col5", "type", "timestamp", "option", TestUtils.mapOf()),
+                        TestUtils.mapOf("name", "col6", "type", "json", "option", TestUtils.mapOf()))));
 
         final MockPageOutput output = new MockPageOutput();
         runner.transaction(config, new InputPlugin.Control() {
@@ -147,13 +145,13 @@ public class TestFileInputRunner {
 
         ConfigSource config = Exec.newConfigSource().set(
                 "parser",
-                ImmutableMap.of("type", "mock", "columns", ImmutableList.of(
-                        ImmutableMap.of("name", "col1", "type", "boolean", "option", ImmutableMap.of()),
-                        ImmutableMap.of("name", "col2", "type", "long", "option", ImmutableMap.of()),
-                        ImmutableMap.of("name", "col3", "type", "double", "option", ImmutableMap.of()),
-                        ImmutableMap.of("name", "col4", "type", "string", "option", ImmutableMap.of()),
-                        ImmutableMap.of("name", "col5", "type", "timestamp", "option", ImmutableMap.of()),
-                        ImmutableMap.of("name", "col6", "type", "json", "option", ImmutableMap.of()))));
+                TestUtils.mapOf("type", "mock", "columns", TestUtils.listOf(
+                        TestUtils.mapOf("name", "col1", "type", "boolean", "option", TestUtils.mapOf()),
+                        TestUtils.mapOf("name", "col2", "type", "long", "option", TestUtils.mapOf()),
+                        TestUtils.mapOf("name", "col3", "type", "double", "option", TestUtils.mapOf()),
+                        TestUtils.mapOf("name", "col4", "type", "string", "option", TestUtils.mapOf()),
+                        TestUtils.mapOf("name", "col5", "type", "timestamp", "option", TestUtils.mapOf()),
+                        TestUtils.mapOf("name", "col6", "type", "json", "option", TestUtils.mapOf()))));
 
         final MockPageOutput output = new MockPageOutput();
 

--- a/embulk-core/src/test/java/org/embulk/spi/TestFileOutputRunner.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestFileOutputRunner.java
@@ -6,8 +6,6 @@ import static org.msgpack.value.ValueFactory.newInteger;
 import static org.msgpack.value.ValueFactory.newMap;
 import static org.msgpack.value.ValueFactory.newString;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -86,18 +84,18 @@ public class TestFileOutputRunner {
         MockFileOutputPlugin fileOutputPlugin = new MockFileOutputPlugin();
         final FileOutputRunner runner = new FileOutputRunner(fileOutputPlugin);
 
-        ImmutableList<ImmutableMap<String, Object>> columns = ImmutableList.of(
-                ImmutableMap.<String,Object>of("name", "col1", "type", "boolean", "option", ImmutableMap.of()),
-                ImmutableMap.<String,Object>of("name", "col2", "type", "long", "option", ImmutableMap.of()),
-                ImmutableMap.<String,Object>of("name", "col3", "type", "double", "option", ImmutableMap.of()),
-                ImmutableMap.<String,Object>of("name", "col4", "type", "string", "option", ImmutableMap.of()),
-                ImmutableMap.<String,Object>of("name", "col5", "type", "timestamp", "option", ImmutableMap.of()),
-                ImmutableMap.<String,Object>of("name", "col6", "type", "json", "option", ImmutableMap.of()));
+        final List<?> columns = TestUtils.listOf(
+                TestUtils.mapOf("name", "col1", "type", "boolean", "option", TestUtils.mapOf()),
+                TestUtils.mapOf("name", "col2", "type", "long", "option", TestUtils.mapOf()),
+                TestUtils.mapOf("name", "col3", "type", "double", "option", TestUtils.mapOf()),
+                TestUtils.mapOf("name", "col4", "type", "string", "option", TestUtils.mapOf()),
+                TestUtils.mapOf("name", "col5", "type", "timestamp", "option", TestUtils.mapOf()),
+                TestUtils.mapOf("name", "col6", "type", "json", "option", TestUtils.mapOf()));
         ConfigSource config = Exec
                 .newConfigSource()
                 .set("type", "unused?")
                 .set("formatter",
-                        ImmutableMap.of("type", "mock", "columns", columns));
+                        TestUtils.mapOf("type", "mock", "columns", columns));
         final Schema schema = config.getNested("formatter")
                 .loadConfig(MockParserPlugin.PluginTask.class)
                 .getSchemaConfig().toSchema();
@@ -149,18 +147,18 @@ public class TestFileOutputRunner {
         MockFileOutputPlugin fileOutputPlugin = new MockFileOutputPlugin();
         final FileOutputRunner runner = new FileOutputRunner(fileOutputPlugin);
 
-        ImmutableList<ImmutableMap<String, Object>> columns = ImmutableList.of(
-                ImmutableMap.<String,Object>of("name", "col1", "type", "boolean", "option", ImmutableMap.of()),
-                ImmutableMap.<String,Object>of("name", "col2", "type", "long", "option", ImmutableMap.of()),
-                ImmutableMap.<String,Object>of("name", "col3", "type", "double", "option", ImmutableMap.of()),
-                ImmutableMap.<String,Object>of("name", "col4", "type", "string", "option", ImmutableMap.of()),
-                ImmutableMap.<String,Object>of("name", "col5", "type", "timestamp", "option", ImmutableMap.of()),
-                ImmutableMap.<String,Object>of("name", "col6", "type", "json", "option", ImmutableMap.of()));
+        final List<?> columns = TestUtils.listOf(
+                TestUtils.mapOf("name", "col1", "type", "boolean", "option", TestUtils.mapOf()),
+                TestUtils.mapOf("name", "col2", "type", "long", "option", TestUtils.mapOf()),
+                TestUtils.mapOf("name", "col3", "type", "double", "option", TestUtils.mapOf()),
+                TestUtils.mapOf("name", "col4", "type", "string", "option", TestUtils.mapOf()),
+                TestUtils.mapOf("name", "col5", "type", "timestamp", "option", TestUtils.mapOf()),
+                TestUtils.mapOf("name", "col6", "type", "json", "option", TestUtils.mapOf()));
         ConfigSource config = Exec
                 .newConfigSource()
                 .set("type", "unused?")
                 .set("formatter",
-                        ImmutableMap.of("type", "mock", "columns", columns));
+                        TestUtils.mapOf("type", "mock", "columns", columns));
         final Schema schema = config.getNested("formatter")
                 .loadConfig(MockParserPlugin.PluginTask.class)
                 .getSchemaConfig().toSchema();

--- a/embulk-core/src/test/java/org/embulk/spi/TestInputStreamFileInput.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestInputStreamFileInput.java
@@ -3,10 +3,10 @@ package org.embulk.spi;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.spi.util.InputStreamFileInput;
 import org.junit.Rule;
@@ -153,10 +153,11 @@ public class TestInputStreamFileInput {
         subject.close();
     }
 
+    @SuppressWarnings("unchecked")
     private InputStreamFileInput.IteratorProvider provider(
             InputStream... inputStreams) throws IOException {
         return new InputStreamFileInput.IteratorProvider(
-                ImmutableList.copyOf(inputStreams));
+                (List<InputStream>) TestUtils.copyListOf(inputStreams));
     }
 
     private String bufferToString(Buffer buffer) throws IOException {

--- a/embulk-core/src/test/java/org/embulk/spi/TestUtils.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestUtils.java
@@ -1,0 +1,355 @@
+package org.embulk.spi;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class TestUtils {
+    private TestUtils() {
+        // No instantiation.
+    }
+
+    public static List<?> copyListOf(final Object[] original) {
+        return Collections.unmodifiableList(Arrays.asList(original));
+    }
+
+    public static List<?> listOf() {
+        return Collections.emptyList();
+    }
+
+    public static List<?> listOf(
+            final Object e1) {
+        final ArrayList<Object> inner = new ArrayList<>();
+        inner.add(e1);
+        return Collections.unmodifiableList(inner);
+    }
+
+    public static List<?> listOf(
+            final Object e1,
+            final Object e2) {
+        final ArrayList<Object> inner = new ArrayList<>();
+        inner.add(e1);
+        inner.add(e2);
+        return Collections.unmodifiableList(inner);
+    }
+
+    public static List<?> listOf(
+            final Object e1,
+            final Object e2,
+            final Object e3) {
+        final ArrayList<Object> inner = new ArrayList<>();
+        inner.add(e1);
+        inner.add(e2);
+        inner.add(e3);
+        return Collections.unmodifiableList(inner);
+    }
+
+    public static List<?> listOf(
+            final Object e1,
+            final Object e2,
+            final Object e3,
+            final Object e4) {
+        final ArrayList<Object> inner = new ArrayList<>();
+        inner.add(e1);
+        inner.add(e2);
+        inner.add(e3);
+        inner.add(e4);
+        return Collections.unmodifiableList(inner);
+    }
+
+    public static List<?> listOf(
+            final Object e1,
+            final Object e2,
+            final Object e3,
+            final Object e4,
+            final Object e5) {
+        final ArrayList<Object> inner = new ArrayList<>();
+        inner.add(e1);
+        inner.add(e2);
+        inner.add(e3);
+        inner.add(e4);
+        inner.add(e5);
+        return Collections.unmodifiableList(inner);
+    }
+
+    public static List<?> listOf(
+            final Object e1,
+            final Object e2,
+            final Object e3,
+            final Object e4,
+            final Object e5,
+            final Object e6) {
+        final ArrayList<Object> inner = new ArrayList<>();
+        inner.add(e1);
+        inner.add(e2);
+        inner.add(e3);
+        inner.add(e4);
+        inner.add(e5);
+        inner.add(e6);
+        return Collections.unmodifiableList(inner);
+    }
+
+    public static List<?> listOf(
+            final Object e1,
+            final Object e2,
+            final Object e3,
+            final Object e4,
+            final Object e5,
+            final Object e6,
+            final Object e7) {
+        final ArrayList<Object> inner = new ArrayList<>();
+        inner.add(e1);
+        inner.add(e2);
+        inner.add(e3);
+        inner.add(e4);
+        inner.add(e5);
+        inner.add(e6);
+        inner.add(e7);
+        return Collections.unmodifiableList(inner);
+    }
+
+    public static List<?> listOf(
+            final Object e1,
+            final Object e2,
+            final Object e3,
+            final Object e4,
+            final Object e5,
+            final Object e6,
+            final Object e7,
+            final Object e8) {
+        final ArrayList<Object> inner = new ArrayList<>();
+        inner.add(e1);
+        inner.add(e2);
+        inner.add(e3);
+        inner.add(e4);
+        inner.add(e5);
+        inner.add(e6);
+        inner.add(e7);
+        inner.add(e8);
+        return Collections.unmodifiableList(inner);
+    }
+
+    public static List<?> listOf(
+            final Object e1,
+            final Object e2,
+            final Object e3,
+            final Object e4,
+            final Object e5,
+            final Object e6,
+            final Object e7,
+            final Object e8,
+            final Object e9) {
+        final ArrayList<Object> inner = new ArrayList<>();
+        inner.add(e1);
+        inner.add(e2);
+        inner.add(e3);
+        inner.add(e4);
+        inner.add(e5);
+        inner.add(e6);
+        inner.add(e7);
+        inner.add(e8);
+        inner.add(e9);
+        return Collections.unmodifiableList(inner);
+    }
+
+    public static List<?> listOf(
+            final Object e1,
+            final Object e2,
+            final Object e3,
+            final Object e4,
+            final Object e5,
+            final Object e6,
+            final Object e7,
+            final Object e8,
+            final Object e9,
+            final Object e10) {
+        final ArrayList<Object> inner = new ArrayList<>();
+        inner.add(e1);
+        inner.add(e2);
+        inner.add(e3);
+        inner.add(e4);
+        inner.add(e5);
+        inner.add(e6);
+        inner.add(e7);
+        inner.add(e8);
+        inner.add(e9);
+        inner.add(e10);
+        return Collections.unmodifiableList(inner);
+    }
+
+    public static Map<String, Object> mapOf() {
+        return Collections.emptyMap();
+    }
+
+    public static Map<String, Object> mapOf(
+            final String k1, final Object v1) {
+        final LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        putMapSafe(inner, k1, v1);
+        return Collections.unmodifiableMap(inner);
+    }
+
+    public static Map<String, Object> mapOf(
+            final String k1, final Object v1,
+            final String k2, final Object v2) {
+        final LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        putMapSafe(inner, k1, v1);
+        putMapSafe(inner, k2, v2);
+        return Collections.unmodifiableMap(inner);
+    }
+
+    public static Map<String, Object> mapOf(
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3) {
+        final LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        putMapSafe(inner, k1, v1);
+        putMapSafe(inner, k2, v2);
+        putMapSafe(inner, k3, v3);
+        return Collections.unmodifiableMap(inner);
+    }
+
+    public static Map<String, Object> mapOf(
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4) {
+        final LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        putMapSafe(inner, k1, v1);
+        putMapSafe(inner, k2, v2);
+        putMapSafe(inner, k3, v3);
+        putMapSafe(inner, k4, v4);
+        return Collections.unmodifiableMap(inner);
+    }
+
+    public static Map<String, Object> mapOf(
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5) {
+        final LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        putMapSafe(inner, k1, v1);
+        putMapSafe(inner, k2, v2);
+        putMapSafe(inner, k3, v3);
+        putMapSafe(inner, k4, v4);
+        putMapSafe(inner, k5, v5);
+        return Collections.unmodifiableMap(inner);
+    }
+
+    public static Map<String, Object> mapOf(
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6) {
+        final LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        putMapSafe(inner, k1, v1);
+        putMapSafe(inner, k2, v2);
+        putMapSafe(inner, k3, v3);
+        putMapSafe(inner, k4, v4);
+        putMapSafe(inner, k5, v5);
+        putMapSafe(inner, k6, v6);
+        return Collections.unmodifiableMap(inner);
+    }
+
+    public static Map<String, Object> mapOf(
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6,
+            final String k7, final Object v7) {
+        final LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        putMapSafe(inner, k1, v1);
+        putMapSafe(inner, k2, v2);
+        putMapSafe(inner, k3, v3);
+        putMapSafe(inner, k4, v4);
+        putMapSafe(inner, k5, v5);
+        putMapSafe(inner, k6, v6);
+        putMapSafe(inner, k7, v7);
+        return Collections.unmodifiableMap(inner);
+    }
+
+    public static Map<String, Object> mapOf(
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6,
+            final String k7, final Object v7,
+            final String k8, final Object v8) {
+        final LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        putMapSafe(inner, k1, v1);
+        putMapSafe(inner, k2, v2);
+        putMapSafe(inner, k3, v3);
+        putMapSafe(inner, k4, v4);
+        putMapSafe(inner, k5, v5);
+        putMapSafe(inner, k6, v6);
+        putMapSafe(inner, k7, v7);
+        putMapSafe(inner, k8, v8);
+        return Collections.unmodifiableMap(inner);
+    }
+
+    public static Map<String, Object> mapOf(
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6,
+            final String k7, final Object v7,
+            final String k8, final Object v8,
+            final String k9, final Object v9) {
+        final LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        putMapSafe(inner, k1, v1);
+        putMapSafe(inner, k2, v2);
+        putMapSafe(inner, k3, v3);
+        putMapSafe(inner, k4, v4);
+        putMapSafe(inner, k5, v5);
+        putMapSafe(inner, k6, v6);
+        putMapSafe(inner, k7, v7);
+        putMapSafe(inner, k8, v8);
+        putMapSafe(inner, k9, v9);
+        return Collections.unmodifiableMap(inner);
+    }
+
+    public static Map<String, Object> mapOf(
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6,
+            final String k7, final Object v7,
+            final String k8, final Object v8,
+            final String k9, final Object v9,
+            final String k10, final Object v10) {
+        final LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        putMapSafe(inner, k1, v1);
+        putMapSafe(inner, k2, v2);
+        putMapSafe(inner, k3, v3);
+        putMapSafe(inner, k4, v4);
+        putMapSafe(inner, k5, v5);
+        putMapSafe(inner, k6, v6);
+        putMapSafe(inner, k7, v7);
+        putMapSafe(inner, k8, v8);
+        putMapSafe(inner, k9, v9);
+        putMapSafe(inner, k10, v10);
+        return Collections.unmodifiableMap(inner);
+    }
+
+    private static void putMapSafe(final LinkedHashMap<String, Object> map, final String key, final Object value) {
+        Objects.requireNonNull(key, "A key is null.");
+        if (map.containsKey(key)) {
+            throw new IllegalArgumentException("A key is duplicated: " + key);
+        }
+        map.put(key, value);
+    }
+}


### PR DESCRIPTION
Follow-up to #1448 in v0.10.39 to clean up remaining Guava in `embulk-core:tests` in a following veresion.