### PR TITLE
[Draft] add new spi ParserPlugin method - runThenReturnTaskReport 

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkRunner.java
@@ -328,6 +328,8 @@ public class EmbulkRunner {
 
         final ConfigDiff configDiff = executionResult.getConfigDiff();
         rootLogger.info("Committed.");
+        rootLogger.info("Input Reports: " + executionResult.getInputTaskReports());
+        rootLogger.info("Output Reports: " + executionResult.getOutputTaskReports());
         rootLogger.info("Next config diff: " + configDiff.toString());
 
         writeConfig(configDiffPath, configDiff);

--- a/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
+++ b/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
@@ -313,7 +313,8 @@ public class BulkLoader {
                 ignoredExceptions.add(ex);
             }
 
-            return new ExecutionResult(configDiff, false, Collections.unmodifiableList(ignoredExceptions));
+            return new ExecutionResult(configDiff, false, Collections.unmodifiableList(ignoredExceptions),
+                    this.getAllInputTaskReports(), this.getAllOutputTaskReports());
         }
 
         public ExecutionResult buildExecuteResultOfSkippedExecution(ConfigDiff configDiff) {
@@ -322,7 +323,8 @@ public class BulkLoader {
                 ignoredExceptions.add(e);
             }
 
-            return new ExecutionResult(configDiff, true, Collections.unmodifiableList(ignoredExceptions));
+            return new ExecutionResult(configDiff, true, Collections.unmodifiableList(ignoredExceptions),
+                    this.getAllInputTaskReports(), this.getAllOutputTaskReports());
         }
 
         public ResumeState buildResumeState(ExecSessionInternal exec) {

--- a/embulk-core/src/main/java/org/embulk/exec/ExecutionResult.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecutionResult.java
@@ -2,16 +2,22 @@ package org.embulk.exec;
 
 import java.util.List;
 import org.embulk.config.ConfigDiff;
+import org.embulk.config.TaskReport;
 
 public class ExecutionResult {
-    private final ConfigDiff configDiff;
-    private final boolean skipped;
-    private final List<Throwable> ignoredExceptions;
+    private  ConfigDiff configDiff;
+    private  boolean skipped;
+    private  List<Throwable> ignoredExceptions;
+    private  List<TaskReport> inputTaskReports;
+    private  List<TaskReport> outputTaskReports;
 
-    public ExecutionResult(ConfigDiff configDiff, boolean skipped, List<Throwable> ignoredExceptions) {
+    public ExecutionResult(ConfigDiff configDiff,  boolean skipped,  List<Throwable> ignoredExceptions,
+                            List<TaskReport> inputTaskReports,  List<TaskReport> outputTaskReports) {
         this.configDiff = configDiff;
         this.skipped = skipped;
         this.ignoredExceptions = ignoredExceptions;
+        this.inputTaskReports = inputTaskReports;
+        this.outputTaskReports = outputTaskReports;
     }
 
     public ConfigDiff getConfigDiff() {
@@ -24,5 +30,13 @@ public class ExecutionResult {
 
     public List<Throwable> getIgnoredExceptions() {
         return ignoredExceptions;
+    }
+
+    public List<TaskReport> getOutputTaskReports() {
+        return outputTaskReports;
+    }
+
+    public List<TaskReport> getInputTaskReports() {
+        return inputTaskReports;
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
@@ -4,6 +4,8 @@ import static org.embulk.exec.GuessExecutor.createSampleBufferConfigFromExecConf
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -135,11 +137,11 @@ public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugi
             try (AbortTransactionResource aborter = new AbortTransactionResource(tran)) {
                 FileInput fileInput = DecodersInternal.open(decoderPlugins, task.getDecoderTaskSources(), tran);
                 closer.closeThis(fileInput);
-                parserPlugin.run(task.getParserTaskSource(), schema, fileInput, output);
+                final Optional<TaskReport> optionalParserTaskReport = parserPlugin.runThenReturnTaskReport(task.getParserTaskSource(), schema, fileInput, output);
 
                 TaskReport report = tran.commit();  // TODO check output.finish() is called. wrap
                 aborter.dontAbort();
-                return report;
+                return optionalParserTaskReport.orElse(report);
             }
         }
     }

--- a/embulk-junit4/src/main/java/org/embulk/test/TestingBulkLoader.java
+++ b/embulk-junit4/src/main/java/org/embulk/test/TestingBulkLoader.java
@@ -44,7 +44,7 @@ class TestingBulkLoader extends BulkLoader {
 
         public TestingExecutionResult(ExecutionResult orig,
                 ResumeState resumeState, ExecSessionInternal session) {
-            super(orig.getConfigDiff(), orig.isSkipped(), orig.getIgnoredExceptions());
+            super(orig.getConfigDiff(), orig.isSkipped(), orig.getIgnoredExceptions(), new ArrayList<>(), new ArrayList<>());
             this.inputSchema = resumeState.getInputSchema();
             this.outputSchema = resumeState.getOutputSchema();
             this.inputTaskReports = buildReports(resumeState.getInputTaskReports(), session);

--- a/embulk-spi/src/main/java/org/embulk/spi/ParserPlugin.java
+++ b/embulk-spi/src/main/java/org/embulk/spi/ParserPlugin.java
@@ -16,7 +16,9 @@
 
 package org.embulk.spi;
 
+import java.util.Optional;
 import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 
 /**
@@ -69,4 +71,19 @@ public interface ParserPlugin {
      * @since 0.4.0
      */
     void run(TaskSource taskSource, Schema schema, FileInput input, PageOutput output);
+
+    /**
+     * Runs each parsing task and return TaskReport
+     *
+     * @param taskSource  a configuration processed for the task from {@link org.embulk.config.ConfigSource}
+     * @param schema  {@link org.embulk.spi.Schema} to be parsed to
+     * @param input  {@link org.embulk.spi.FileOutput} that is read from a File Input Plugin, or a Decoder Plugin
+     * @param output  {@link org.embulk.spi.PageOutput} to write parsed input so that the input is read from an Output Plugin, or
+     *     another Filter Plugin
+     * @return the {@link TaskReport} in {@link java.util.Optional}
+     */
+    default Optional<TaskReport> runThenReturnTaskReport(TaskSource taskSource, Schema schema, FileInput input, PageOutput output) {
+        this.run(taskSource, schema, input, output);
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
This PR not to merge, this just shows the idea to get advice or a discussion

The current `PaserPlugin` method `void run(TaskSource taskSource, Schema schema, FileInput input, PageOutput output);` return nothing, then when executing a File Input Plugin, we have no way to know the result of an execution 
- number of success lines?
- number of warning lines and which lines warning happens?

The idea is adding new spi parser method same behavior with `run` method and return TaskReport
By default, this new method will callback to `run` method, so it will compatible with current parser plugins

 