### PR TITLE
Clarify the equality of JsonValue implementations

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonArray.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonArray.java
@@ -189,6 +189,9 @@ public final class JsonArray extends AbstractList<JsonValue> implements JsonValu
     /**
      * Compares the specified object with this JSON array for equality.
      *
+     * <p>Note that it can return {@code true} only when {@link JsonArray} is given. It checks the equality as a JSON array.
+     * It does not return {@code true} for a general {@link java.util.List} even though the given list contains the same elements.
+     *
      * @return {@code true} if the specified object is equal to this JSON array
      *
      * @since 0.10.42
@@ -198,30 +201,16 @@ public final class JsonArray extends AbstractList<JsonValue> implements JsonValu
         if (otherObject == this) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
-            return false;
-        }
-        final JsonValue otherValue = (JsonValue) otherObject;
 
-        if (otherValue instanceof JsonArray) {
-            final JsonArray other = (JsonArray) otherValue;
-            return Arrays.equals(this.values, other.values);
-        }
-
-        if (!otherValue.isJsonArray()) {
-            return false;
-        }
-        final JsonArray other = otherValue.asJsonArray();
-        if (this.size() != other.size()) {
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (!(otherObject instanceof JsonArray)) {
             return false;
         }
 
-        for (int i = 0; i < this.size(); i++) {
-            if (!this.get(i).equals(other.get(i))) {
-                return false;
-            }
-        }
-        return true;
+        final JsonArray other = (JsonArray) otherObject;
+
+        // The equality of JsonArray should be checked exactly as Java arrays, unlike JsonObject.
+        return Arrays.equals(this.values, other.values);
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonBoolean.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonBoolean.java
@@ -131,18 +131,8 @@ public final class JsonBoolean implements JsonValue {
      */
     @Override
     public boolean equals(final Object otherObject) {
-        if (otherObject == this) {
-            return true;
-        }
-        if (!(otherObject instanceof JsonValue)) {
-            return false;
-        }
-
-        final JsonValue other = (JsonValue) otherObject;
-        if (!other.isJsonBoolean()) {
-            return false;
-        }
-        return value == other.asJsonBoolean().booleanValue();
+        // Only the singleton instances FALSE and TRUE are accepted. No arbitrary instantiation.
+        return ((this == FALSE && otherObject == FALSE) || (this == TRUE && otherObject == TRUE));
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonDecimal.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonDecimal.java
@@ -404,15 +404,15 @@ rrowing Primitive Conversion</a>
         if (otherObject == this) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
-            return false;
-        }
-        final JsonValue otherValue = (JsonValue) otherObject;
 
-        if (!otherValue.isJsonDecimal()) {
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (!(otherObject instanceof JsonDecimal)) {
             return false;
         }
-        return value == otherValue.asJsonDecimal().doubleValue();
+
+        final JsonDecimal other = (JsonDecimal) otherObject;
+
+        return this.value == other.value;
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonInteger.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonInteger.java
@@ -371,20 +371,15 @@ public final class JsonInteger implements JsonValue {
         if (otherObject == this) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
+
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (!(otherObject instanceof JsonInteger)) {
             return false;
         }
 
-        final JsonValue otherValue = (JsonValue) otherObject;
-        if (!otherValue.isJsonInteger()) {
-            return false;
-        }
+        final JsonInteger other = (JsonInteger) otherObject;
 
-        final JsonInteger other = otherValue.asJsonInteger();
-        if (!other.isLongValue()) {
-            return false;
-        }
-        return this.value == other.longValue();
+        return this.value == other.value;
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
@@ -96,13 +96,8 @@ public final class JsonNull implements JsonValue {
      */
     @Override
     public boolean equals(final Object otherObject) {
-        if (otherObject == this) {
-            return true;
-        }
-        if (!(otherObject instanceof JsonValue)) {
-            return false;
-        }
-        return ((JsonValue) otherObject).isJsonNull();
+        // Only the singleton instance is accepted. No arbitrary instantiation.
+        return this == INSTANCE && otherObject == INSTANCE;
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -448,6 +449,9 @@ public final class JsonObject extends AbstractMap<String, JsonValue> implements 
     /**
      * Compares the specified object with this JSON object for equality.
      *
+     * <p>Note that it can return {@code true} only when {@link JsonObject} is given. It checks the equality as a JSON object.
+     * It does not return {@code true} for a general {@link java.util.Map} even though the given map contains the same mapping.
+     *
      * @return {@code true} if the specified object is equal to this JSON object
      *
      * @since 0.10.42
@@ -457,16 +461,17 @@ public final class JsonObject extends AbstractMap<String, JsonValue> implements 
         if (otherObject == this) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
+
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (!(otherObject instanceof JsonObject)) {
             return false;
         }
 
-        final JsonValue otherValue = (JsonValue) otherObject;
-        if (!otherValue.isJsonObject()) {
-            return false;
-        }
+        final JsonObject other = (JsonObject) otherObject;
 
-        return this.entrySet().equals(otherValue.asJsonObject().entrySet());
+        // The equality of JsonObject should be checked like a Map, not by the internal key-value array.
+        // For example, the order of the internal key-value array should not impact the equality of JsonObject.
+        return Objects.equals(this.entrySet(), other.entrySet());
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
@@ -152,20 +152,15 @@ public final class JsonString implements JsonValue {
         if (this == otherObject) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
+
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (!(otherObject instanceof JsonString)) {
             return false;
         }
 
-        final JsonValue other = (JsonValue) otherObject;
-        if (!other.isJsonString()) {
-            return false;
-        }
+        final JsonString other = (JsonString) otherObject;
 
-        if (otherObject instanceof JsonString) {
-            final JsonString otherString = (JsonString) otherObject;
-            return Objects.equals(this.value, otherString.value);
-        }
-        return false;
+        return Objects.equals(this.value, other.value);
     }
 
     /**

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonArray.java
@@ -18,7 +18,6 @@ package org.embulk.spi.json;
 
 import java.util.AbstractList;
 import java.util.Arrays;
-import java.util.List;
 
 public final class FakeJsonArray extends AbstractList<JsonValue> implements JsonValue {
     private FakeJsonArray(final JsonValue[] values) {
@@ -86,30 +85,22 @@ public final class FakeJsonArray extends AbstractList<JsonValue> implements Json
         if (otherObject == this) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
-            return false;
-        }
-        final JsonValue otherValue = (JsonValue) otherObject;
 
-        if (otherValue instanceof FakeJsonArray) {
-            final FakeJsonArray other = (FakeJsonArray) otherValue;
-            return Arrays.equals(this.values, other.values);
+        // Fake!
+        if (otherObject instanceof JsonArray) {
+            final JsonArray other = (JsonArray) otherObject;
+            return Arrays.equals(this.values, other.toArray(new JsonValue[other.size()]));
         }
 
-        if (!otherValue.isJsonArray()) {
-            return false;
-        }
-        final JsonArray other = otherValue.asJsonArray();
-        if (this.size() != other.size()) {
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (!(otherObject instanceof FakeJsonArray)) {
             return false;
         }
 
-        for (int i = 0; i < this.size(); i++) {
-            if (!this.get(i).equals(other.get(i))) {
-                return false;
-            }
-        }
-        return true;
+        final FakeJsonArray other = (FakeJsonArray) otherObject;
+
+        // The equality of FakeJsonArray should be checked exactly as Java arrays, unlike JsonObject.
+        return Arrays.equals(this.values, other.values);
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonArray.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.List;
+
+public final class FakeJsonArray extends AbstractList<JsonValue> implements JsonValue {
+    private FakeJsonArray(final JsonValue[] values) {
+        this.values = values;
+    }
+
+    public static FakeJsonArray of(final JsonValue... values) {
+        if (values.length == 0) {
+            return EMPTY;
+        }
+        return new FakeJsonArray(Arrays.copyOf(values, values.length));
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.ARRAY;
+    }
+
+    @Override
+    public int size() {
+        return this.values.length;
+    }
+
+    @Override
+    public JsonValue get(final int index) {
+        return this.values[index];
+    }
+
+    @Override
+    public String toJson() {
+        if (this.values.length == 0) {
+            return "[]";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        builder.append("[");
+        builder.append(this.values[0].toJson());
+        for (int i = 1; i < this.values.length; i++) {
+            builder.append(",");
+            builder.append(this.values[i].toJson());
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+
+    @Override
+    public String toString() {
+        if (this.values.length == 0) {
+            return "[]";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        builder.append("[");
+        builder.append(this.values[0].toString());
+        for (int i = 1; i < this.values.length; i++) {
+            builder.append(",");
+            builder.append(this.values[i].toString());
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+        final JsonValue otherValue = (JsonValue) otherObject;
+
+        if (otherValue instanceof FakeJsonArray) {
+            final FakeJsonArray other = (FakeJsonArray) otherValue;
+            return Arrays.equals(this.values, other.values);
+        }
+
+        if (!otherValue.isJsonArray()) {
+            return false;
+        }
+        final JsonArray other = otherValue.asJsonArray();
+        if (this.size() != other.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < this.size(); i++) {
+            if (!this.get(i).equals(other.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 1;
+        for (int i = 0; i < this.values.length; i++) {
+            final JsonValue value = this.values[i];
+            hash = 31 * hash + value.hashCode();
+        }
+        return hash;
+    }
+
+    private static final FakeJsonArray EMPTY = new FakeJsonArray(new JsonValue[0]);
+
+    private final JsonValue[] values;
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonBoolean.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonBoolean.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+public final class FakeJsonBoolean implements JsonValue {
+    private FakeJsonBoolean(final boolean value) {
+        this.value = value;
+    }
+
+    public static final FakeJsonBoolean FAKE_FALSE = new FakeJsonBoolean(false);
+
+    public static final FakeJsonBoolean FAKE_TRUE = new FakeJsonBoolean(true);
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.BOOLEAN;
+    }
+
+    public boolean booleanValue() {
+        return this.value;
+    }
+
+    @Override
+    public String toJson() {
+        if (this.value) {
+            return "true";
+        }
+        return "false";
+    }
+
+    @Override
+    public String toString() {
+        if (this.value) {
+            return "true";
+        }
+        return "false";
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+
+        final JsonValue other = (JsonValue) otherObject;
+        if (!other.isJsonBoolean()) {
+            return false;
+        }
+        return value == other.asJsonBoolean().booleanValue();
+    }
+
+    @Override
+    public int hashCode() {
+        if (this.value) {
+            return 1231;
+        }
+        return 1237;
+    }
+
+    private final boolean value;
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonBoolean.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonBoolean.java
@@ -52,18 +52,13 @@ public final class FakeJsonBoolean implements JsonValue {
 
     @Override
     public boolean equals(final Object otherObject) {
-        if (otherObject == this) {
-            return true;
-        }
-        if (!(otherObject instanceof JsonValue)) {
-            return false;
+        // Fake!
+        if (otherObject instanceof JsonBoolean) {
+            return this.value == ((JsonBoolean) otherObject).booleanValue();
         }
 
-        final JsonValue other = (JsonValue) otherObject;
-        if (!other.isJsonBoolean()) {
-            return false;
-        }
-        return value == other.asJsonBoolean().booleanValue();
+        // Only the singleton instances FAKE_FALSE and FAKE_TRUE are accepted. No arbitrary instantiation.
+        return ((this == FAKE_FALSE && otherObject == FAKE_FALSE) || (this == FAKE_TRUE && otherObject == FAKE_TRUE));
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonDecimal.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonDecimal.java
@@ -147,15 +147,21 @@ public final class FakeJsonDecimal implements JsonValue {
         if (otherObject == this) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
-            return false;
-        }
-        final JsonValue otherValue = (JsonValue) otherObject;
 
-        if (!otherValue.isJsonDecimal()) {
+        // Fake!
+        if (otherObject instanceof JsonDecimal) {
+            final JsonDecimal other = (JsonDecimal) otherObject;
+            return this.value == other.doubleValue();
+        }
+
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (!(otherObject instanceof FakeJsonDecimal)) {
             return false;
         }
-        return value == otherValue.asJsonDecimal().doubleValue();
+
+        final FakeJsonDecimal other = (FakeJsonDecimal) otherObject;
+
+        return this.value == other.value;
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonDecimal.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonDecimal.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public final class FakeJsonDecimal implements JsonValue {
+    private FakeJsonDecimal(final double value) {
+        this.value = value;
+    }
+
+    public static FakeJsonDecimal of(final double value) {
+        return new FakeJsonDecimal(value);
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.DECIMAL;
+    }
+
+    public boolean isIntegral() {
+        return !Double.isNaN(this.value) && !Double.isInfinite(this.value) && this.value == Math.rint(this.value);
+    }
+
+    public boolean isByteValue() {
+        return this.isIntegral() && ((double) Byte.MIN_VALUE) <= this.value && this.value <= ((double) Byte.MAX_VALUE);
+    }
+
+    public boolean isShortValue() {
+        return this.isIntegral() && ((double) Short.MIN_VALUE) <= this.value && this.value <= ((double) Short.MAX_VALUE);
+    }
+
+    public boolean isIntValue() {
+        return this.isIntegral() && ((double) Integer.MIN_VALUE) <= this.value && this.value <= ((double) Integer.MAX_VALUE);
+    }
+
+    public boolean isLongValue() {
+        return this.isIntegral() && ((double) Long.MIN_VALUE) <= this.value && this.value <= ((double) Long.MAX_VALUE);
+    }
+
+    public byte byteValue() {
+        return (byte) this.value;
+    }
+
+    public byte byteValueExact() {
+        if (!this.isIntegral()) {
+            throw new ArithmeticException("Not an integer: " + this.value);
+        }
+        if (((double) Byte.MIN_VALUE) <= this.value && this.value <= ((double) Byte.MAX_VALUE)) {
+            throw new ArithmeticException("Out of the range of byte: " + this.value);
+        }
+        return (byte) this.value;
+    }
+
+    public short shortValue() {
+        return (short) this.value;
+    }
+
+    public short shortValueExact() {
+        if (!this.isIntegral()) {
+            throw new ArithmeticException("Not an integer: " + this.value);
+        }
+        if (((double) Short.MIN_VALUE) <= this.value && this.value <= ((double) Short.MAX_VALUE)) {
+            throw new ArithmeticException("Out of the range of short: " + this.value);
+        }
+        return (short) this.value;
+    }
+
+    public int intValue() {
+        return (int) this.value;
+    }
+
+    public int intValueExact() {
+        if (!this.isIntegral()) {
+            throw new ArithmeticException("Not an integer: " + this.value);
+        }
+        if (((double) Integer.MIN_VALUE) <= this.value && this.value <= ((double) Integer.MAX_VALUE)) {
+            throw new ArithmeticException("Out of the range of int: " + this.value);
+        }
+        return (int) this.value;
+    }
+
+    public long longValue() {
+        return (long) this.value;
+    }
+
+    public long longValueExact() {
+        if (!this.isIntegral()) {
+            throw new ArithmeticException("Not an integer: " + this.value);
+        }
+        if (((double) Long.MIN_VALUE) <= this.value && this.value <= ((double) Long.MAX_VALUE)) {
+            throw new ArithmeticException("Out of the range of long: " + this.value);
+        }
+        return (long) this.value;
+    }
+
+    public BigInteger bigIntegerValue() {
+        return BigDecimal.valueOf(this.value).toBigInteger();
+    }
+
+    public BigInteger bigIntegerValueExact() {
+        return BigDecimal.valueOf(this.value).toBigIntegerExact();
+    }
+
+    public float floatValue() {
+        return (float) this.value;
+    }
+
+    public double doubleValue() {
+        return this.value;
+    }
+
+    public BigDecimal bigDecimalValue() {
+        return BigDecimal.valueOf(this.value);
+    }
+
+    @Override
+    public String toJson() {
+        if (Double.isNaN(this.value) || Double.isInfinite(this.value)) {
+            return "null";
+        }
+        return Double.toString(this.value);
+    }
+
+    @Override
+    public String toString() {
+        return Double.toString(this.value);
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+        final JsonValue otherValue = (JsonValue) otherObject;
+
+        if (!otherValue.isJsonDecimal()) {
+            return false;
+        }
+        return value == otherValue.asJsonDecimal().doubleValue();
+    }
+
+    @Override
+    public int hashCode() {
+        final long bits = Double.doubleToLongBits(this.value);
+        return (int) (bits ^ (bits >>> 32));
+    }
+
+    private final double value;
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonInteger.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonInteger.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public final class FakeJsonInteger implements JsonValue {
+    private FakeJsonInteger(final long value) {
+        this.value = value;
+    }
+
+    public static FakeJsonInteger of(final long value) {
+        return new FakeJsonInteger(value);
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.INTEGER;
+    }
+
+    public boolean isIntegral() {
+        return true;
+    }
+
+    public boolean isByteValue() {
+        return ((long) Byte.MIN_VALUE) <= this.value && this.value <= ((long) Byte.MAX_VALUE);
+    }
+
+    public boolean isShortValue() {
+        return ((long) Short.MIN_VALUE) <= this.value && this.value <= ((long) Short.MAX_VALUE);
+    }
+
+    public boolean isIntValue() {
+        return ((long) Integer.MIN_VALUE) <= this.value && this.value <= ((long) Integer.MAX_VALUE);
+    }
+
+    public boolean isLongValue() {
+        return true;
+    }
+
+    public byte byteValue() {
+        return (byte) this.value;
+    }
+
+    public byte byteValueExact() {
+        if (!this.isByteValue()) {
+            throw new ArithmeticException("Out of the range of byte: " + this.value);
+        }
+        return (byte) this.value;
+    }
+
+    public short shortValue() {
+        return (short) this.value;
+    }
+
+    public short shortValueExact() {
+        if (!this.isShortValue()) {
+            throw new ArithmeticException("Out of the range of short: " + this.value);
+        }
+        return (short) this.value;
+    }
+
+    public int intValue() {
+        return (int) this.value;
+    }
+
+    public int intValueExact() {
+        if (!this.isIntValue()) {
+            throw new ArithmeticException("Out of the range of int: " + this.value);
+        }
+        return (int) this.value;
+    }
+
+    public long longValue() {
+        return (long) this.value;
+    }
+
+    public long longValueExact() {
+        return (long) this.value;
+    }
+
+    public BigInteger bigIntegerValue() {
+        return BigInteger.valueOf(this.value);
+    }
+
+    public BigInteger bigIntegerValueExact() {
+        return BigInteger.valueOf(this.value);
+    }
+
+    public float floatValue() {
+        return (float) this.value;
+    }
+
+    public double doubleValue() {
+        return (double) this.value;
+    }
+
+    public BigDecimal bigDecimalValue() {
+        return BigDecimal.valueOf(this.value);
+    }
+
+    @Override
+    public String toJson() {
+        return Long.toString(this.value);
+    }
+
+    @Override
+    public String toString() {
+        return Long.toString(this.value);
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+
+        final JsonValue otherValue = (JsonValue) otherObject;
+        if (!otherValue.isJsonInteger()) {
+            return false;
+        }
+
+        final JsonInteger other = otherValue.asJsonInteger();
+        if (!other.isLongValue()) {
+            return false;
+        }
+        return this.value == other.longValue();
+    }
+
+    @Override
+    public int hashCode() {
+        if (((long) Integer.MIN_VALUE) <= this.value && this.value <= ((long) Integer.MAX_VALUE)) {
+            return (int) value;
+        }
+        return (int) (value ^ (value >>> 32));
+    }
+
+    private final long value;
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonInteger.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonInteger.java
@@ -129,20 +129,21 @@ public final class FakeJsonInteger implements JsonValue {
         if (otherObject == this) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
+
+        // Fake!
+        if (otherObject instanceof JsonInteger) {
+            final JsonInteger other = (JsonInteger) otherObject;
+            return this.value == other.longValue();
+        }
+
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (!(otherObject instanceof FakeJsonInteger)) {
             return false;
         }
 
-        final JsonValue otherValue = (JsonValue) otherObject;
-        if (!otherValue.isJsonInteger()) {
-            return false;
-        }
+        final FakeJsonInteger other = (FakeJsonInteger) otherObject;
 
-        final JsonInteger other = otherValue.asJsonInteger();
-        if (!other.isLongValue()) {
-            return false;
-        }
-        return this.value == other.longValue();
+        return this.value == other.value;
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonNull.java
@@ -42,13 +42,13 @@ public final class FakeJsonNull implements JsonValue {
 
     @Override
     public boolean equals(final Object otherObject) {
-        if (otherObject == this) {
+        // Fake!
+        if (otherObject instanceof JsonNull) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
-            return false;
-        }
-        return ((JsonValue) otherObject).isJsonNull();
+
+        // Only the singleton instance is accepted. No arbitrary instantiation.
+        return this == INSTANCE && otherObject == INSTANCE;
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonNull.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+public final class FakeJsonNull implements JsonValue {
+    private FakeJsonNull() {
+        // No direct instantiation.
+    }
+
+    public static FakeJsonNull ofFake() {
+        return INSTANCE;
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.NULL;
+    }
+
+    @Override
+    public String toJson() {
+        return "null";
+    }
+
+    @Override
+    public String toString() {
+        return "null";
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+        return ((JsonValue) otherObject).isJsonNull();
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    private static final FakeJsonNull INSTANCE = new FakeJsonNull();
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonObject.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+
+public final class FakeJsonObject extends AbstractMap<String, JsonValue> implements JsonValue {
+    private FakeJsonObject(final JsonValue[] values) {
+        this.values = values;
+    }
+
+    public static FakeJsonObject of(final JsonValue... values) {
+        if (values.length == 0) {
+            return EMPTY;
+        }
+        if (values.length % 2 != 0) {
+            throw new IllegalArgumentException("Even numbers of arguments must be specified to FakeJsonObject#of(...).");
+        }
+        for (int i = 0; i < values.length; i += 2) {
+            if (!(values[i] instanceof JsonString)) {
+                throw new IllegalArgumentException("JsonString must be specified as a key for FakeJsonObject#of(...).");
+            }
+        }
+        return new FakeJsonObject(Arrays.copyOf(values, values.length));
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.OBJECT;
+    }
+
+    @Override
+    public int size() {
+        return this.values.length / 2;
+    }
+
+    @Override
+    public Set<Map.Entry<String, JsonValue>> entrySet() {
+        return new EntrySet(this.values);
+    }
+
+    public JsonValue[] getKeyValueArray() {
+        return Arrays.copyOf(this.values, this.values.length);
+    }
+
+    @Override
+    public String toJson() {
+        if (this.values.length == 0) {
+            return "{}";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        if (this.values[0].isJsonString()) {
+            builder.append(this.values[0].toJson());
+        } else {
+            throw new IllegalStateException("Keys in FakeJsonObject must be String.");
+        }
+        builder.append(":");
+        builder.append(this.values[1].toJson());
+        for (int i = 2; i < this.values.length; i += 2) {
+            builder.append(",");
+            if (this.values[i].isJsonString()) {
+                builder.append(this.values[i].toJson());
+            } else {
+                throw new IllegalStateException("Keys in FakeJsonObject must be String.");
+            }
+            builder.append(":");
+            builder.append(this.values[i + 1].toJson());
+        }
+        builder.append("}");
+        return builder.toString();
+    }
+
+    @Override
+    public String toString() {
+        if (this.values.length == 0) {
+            return "{}";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        builder.append(this.values[0].toString());
+        builder.append(":");
+        builder.append(this.values[1].toString());
+        for (int i = 2; i < this.values.length; i += 2) {
+            builder.append(",");
+            builder.append(this.values[i].toString());
+            builder.append(":");
+            builder.append(this.values[i + 1].toString());
+        }
+        builder.append("}");
+        return builder.toString();
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+
+        final JsonValue otherValue = (JsonValue) otherObject;
+        if (!otherValue.isJsonObject()) {
+            return false;
+        }
+
+        return this.entrySet().equals(otherValue.asJsonObject().entrySet());
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        for (int i = 0; i < this.values.length; i += 2) {
+            hash += this.values[i].hashCode() ^ this.values[i + 1].hashCode();
+        }
+        return hash;
+    }
+
+    private static class EntrySet extends AbstractSet<Map.Entry<String, JsonValue>> {
+        EntrySet(final JsonValue[] values) {
+            this.values = values;
+        }
+
+        @Override
+        public int size() {
+            return this.values.length / 2;
+        }
+
+        @Override
+        public Iterator<Map.Entry<String, JsonValue>> iterator() {
+            return new EntryIterator(this.values);
+        }
+
+        private final JsonValue[] values;
+    }
+
+    private static class EntryIterator implements Iterator<Map.Entry<String, JsonValue>> {
+        EntryIterator(final JsonValue[] values) {
+            this.values = values;
+            this.index = 0;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return this.index < this.values.length;
+        }
+
+        @Override
+        public Map.Entry<String, JsonValue> next() {
+            if (this.index >= this.values.length) {
+                throw new NoSuchElementException();
+            }
+
+            if (!this.values[this.index].isJsonString()) {
+                throw new IllegalStateException("Keys in FakeJsonObject must be String.");
+            }
+            final String key = ((JsonString) this.values[index]).getString();
+            final JsonValue value = this.values[index + 1];
+            final Map.Entry<String, JsonValue> pair = new AbstractMap.SimpleImmutableEntry<>(key, value);
+
+            this.index += 2;
+            return pair;
+        }
+
+        private final JsonValue[] values;
+
+        private int index;
+    }
+
+    private static final FakeJsonObject EMPTY = new FakeJsonObject(new JsonValue[0]);
+
+    private final JsonValue[] values;
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonObject.java
@@ -20,7 +20,6 @@ import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -120,16 +119,23 @@ public final class FakeJsonObject extends AbstractMap<String, JsonValue> impleme
         if (otherObject == this) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
+
+        // Fake!
+        if (otherObject instanceof JsonObject) {
+            final JsonObject other = (JsonObject) otherObject;
+            return Objects.equals(this.entrySet(), other.entrySet());
+        }
+
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (!(otherObject instanceof FakeJsonObject)) {
             return false;
         }
 
-        final JsonValue otherValue = (JsonValue) otherObject;
-        if (!otherValue.isJsonObject()) {
-            return false;
-        }
+        final FakeJsonObject other = (FakeJsonObject) otherObject;
 
-        return this.entrySet().equals(otherValue.asJsonObject().entrySet());
+        // The equality of JsonObject should be checked like a Map, not by the internal key-value array.
+        // For example, the order of the internal key-value array should not impact the equality of JsonObject.
+        return Objects.equals(this.entrySet(), other.entrySet());
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonString.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.spi.json;
+
+import java.util.Objects;
+
+public final class FakeJsonString implements JsonValue {
+    private FakeJsonString(final String value) {
+        this.value = value;
+    }
+
+    public static FakeJsonString of(final String value) {
+        return new FakeJsonString(value.intern());
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.STRING;
+    }
+
+    public String getString() {
+        return this.value;
+    }
+
+    public CharSequence getChars() {
+        return this.value;
+    }
+
+    @Override
+    public String toJson() {
+        return escapeStringForJsonLiteral(this.value).toString();
+    }
+
+    @Override
+    public String toString() {
+        return escapeStringForJsonLiteral(this.value).toString();
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (this == otherObject) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonValue)) {
+            return false;
+        }
+
+        final JsonValue other = (JsonValue) otherObject;
+        if (!other.isJsonString()) {
+            return false;
+        }
+
+        if (otherObject instanceof FakeJsonString) {
+            final FakeJsonString otherString = (FakeJsonString) otherObject;
+            return Objects.equals(this.value, otherString.value);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.value);
+    }
+
+    static void appendEscapedStringForJsonLiteral(final String original, final StringBuilder builder) {
+        if (original == null) {
+            return;
+        }
+        if (original.isEmpty()) {
+            builder.append("\"\"");
+            return;
+        }
+
+        builder.append("\"");
+
+        final int length = original.length();
+        for (int i = 0; i < length; i++) {
+            final char current = original.charAt(i);
+            switch (current) {
+                case '\\':
+                    builder.append("\\\\");
+                    break;
+                case '"':
+                    builder.append("\\\"");
+                    break;
+                case '\b':  // 0008
+                    builder.append("\\b");
+                    break;
+                case '\f':  // 000c
+                    builder.append("\\f");
+                    break;
+                case '\n':  // 000a
+                    builder.append("\\n");
+                    break;
+                case '\r':  // 000d
+                    builder.append("\\r");
+                    break;
+                case '\t':  // 0009
+                    builder.append("\\t");
+                    break;
+                case '\0':
+                case '\u0001':
+                case '\u0002':
+                case '\u0003':
+                case '\u0004':
+                case '\u0005':
+                case '\u0006':
+                case '\u0007':
+                case '\u000b':
+                case '\u000e':
+                case '\u000f':
+                case '\u0010':
+                case '\u0011':
+                case '\u0012':
+                case '\u0013':
+                case '\u0014':
+                case '\u0015':
+                case '\u0016':
+                case '\u0017':
+                case '\u0018':
+                case '\u0019':
+                case '\u001a':
+                case '\u001b':
+                case '\u001c':
+                case '\u001d':
+                case '\u001e':
+                case '\u001f':
+                    builder.append("\\u00");
+                    final String hex = Integer.toHexString(current);
+                    builder.append("00", 0, 2 - hex.length());
+                    builder.append(hex);
+                    break;
+                default:
+                    builder.append(current);
+            }
+        }
+
+        builder.append("\"");
+    }
+
+    private static String escapeStringForJsonLiteral(final String original) {
+        final StringBuilder builder = new StringBuilder();
+        appendEscapedStringForJsonLiteral(original, builder);
+        return builder.toString();
+    }
+
+    private final String value;
+}

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonString.java
@@ -55,20 +55,20 @@ public final class FakeJsonString implements JsonValue {
         if (this == otherObject) {
             return true;
         }
-        if (!(otherObject instanceof JsonValue)) {
+
+        // Fake!
+        if (otherObject instanceof JsonString) {
+            return Objects.equals(this.value, ((JsonString) otherObject).getString());
+        }
+
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (!(otherObject instanceof FakeJsonString)) {
             return false;
         }
 
-        final JsonValue other = (JsonValue) otherObject;
-        if (!other.isJsonString()) {
-            return false;
-        }
+        final FakeJsonString other = (FakeJsonString) otherObject;
 
-        if (otherObject instanceof FakeJsonString) {
-            final FakeJsonString otherString = (FakeJsonString) otherObject;
-            return Objects.equals(this.value, otherString.value);
-        }
-        return false;
+        return Objects.equals(this.value, other.value);
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
@@ -21,10 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 public class TestJsonArray {
+    @Test
+    public void testFinal() {
+        // JsonArray must be final.
+        assertTrue(Modifier.isFinal(JsonArray.class.getModifiers()));
+    }
+
     @Test
     public void testEmpty() {
         final JsonArray jsonArray = JsonArray.of();
@@ -48,6 +55,9 @@ public class TestJsonArray {
         assertEquals("[]", jsonArray.toJson());
         assertEquals("[]", jsonArray.toString());
         assertEquals(JsonArray.of(), jsonArray);
+
+        // JsonArray#equals must normally reject a fake imitation of JsonArray.
+        assertFalse(jsonArray.equals(FakeJsonArray.of()));
     }
 
     @Test
@@ -74,6 +84,9 @@ public class TestJsonArray {
         assertEquals("[987]", jsonArray.toJson());
         assertEquals("[987]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonInteger.of(987)), jsonArray);
+
+        // JsonArray#equals must normally reject a fake imitation of JsonArray.
+        assertFalse(jsonArray.equals(FakeJsonArray.of(JsonInteger.of(987))));
     }
 
     @Test
@@ -120,6 +133,9 @@ public class TestJsonArray {
         assertEquals("[987,\"foo\",true]", jsonArray.toJson());
         assertEquals("[987,\"foo\",true]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
+
+        // JsonArray#equals must normally reject a fake imitation of JsonArray.
+        assertFalse(jsonArray.equals(FakeJsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE)));
     }
 
     @Test
@@ -166,6 +182,9 @@ public class TestJsonArray {
         assertEquals("[987,\"foo\",true]", jsonArray.toJson());
         assertEquals("[987,\"foo\",true]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
+
+        // JsonArray#equals must normally reject a fake imitation of JsonArray.
+        assertFalse(jsonArray.equals(FakeJsonArray.of(JsonInteger.of(987), JsonString.of("foo"), JsonBoolean.TRUE)));
     }
 
 
@@ -213,6 +232,9 @@ public class TestJsonArray {
         assertEquals("[1234,\"foo\",true]", jsonArray.toJson());  // Updated
         assertEquals("[1234,\"foo\",true]", jsonArray.toString());  // Updated
         assertEquals(JsonArray.of(JsonInteger.of(1234), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);  // Updated
+
+        // JsonArray#equals must normally reject a fake imitation of JsonArray.
+        assertFalse(jsonArray.equals(FakeJsonArray.of(JsonInteger.of(1234), JsonString.of("foo"), JsonBoolean.TRUE)));
     }
 
     @Test
@@ -258,5 +280,12 @@ public class TestJsonArray {
         assertEquals("[987,[\"foo\",\"bar\",\"baz\"],true]", jsonArray.toJson());
         assertEquals("[987,[\"foo\",\"bar\",\"baz\"],true]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonInteger.of(987), JsonArray.of(JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")), JsonBoolean.TRUE), jsonArray);
+
+        // JsonArray#equals must normally reject a fake imitation of JsonArray.
+        assertFalse(jsonArray.equals(
+                            FakeJsonArray.of(
+                                    JsonInteger.of(987),
+                                    JsonArray.of(JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")),
+                                    JsonBoolean.TRUE)));
     }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonBoolean.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonBoolean.java
@@ -21,9 +21,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
 
 public class TestJsonBoolean {
+    @Test
+    public void testFinal() {
+        // JsonBoolean must be final.
+        assertTrue(Modifier.isFinal(JsonBoolean.class.getModifiers()));
+    }
+
     @Test
     public void testFalse() {
         final JsonBoolean jsonBoolean = JsonBoolean.of(false);
@@ -47,6 +54,10 @@ public class TestJsonBoolean {
         assertEquals("false", jsonBoolean.toString());
         assertEquals(JsonBoolean.FALSE, jsonBoolean);
         assertTrue(JsonBoolean.FALSE == jsonBoolean);
+
+        // JsonBoolean#equals must normally reject a fake imitation of JsonBoolean.
+        assertFalse(jsonBoolean.equals(FakeJsonBoolean.FAKE_FALSE));
+        assertFalse(jsonBoolean.equals(FakeJsonBoolean.FAKE_TRUE));
     }
 
     @Test
@@ -72,5 +83,9 @@ public class TestJsonBoolean {
         assertEquals("true", jsonBoolean.toString());
         assertEquals(JsonBoolean.TRUE, jsonBoolean);
         assertTrue(JsonBoolean.TRUE == jsonBoolean);
+
+        // JsonBoolean#equals must normally reject a fake imitation of JsonBoolean.
+        assertFalse(jsonBoolean.equals(FakeJsonBoolean.FAKE_FALSE));
+        assertFalse(jsonBoolean.equals(FakeJsonBoolean.FAKE_TRUE));
     }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDecimal.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDecimal.java
@@ -21,11 +21,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
 
 public class TestJsonDecimal {
+    @Test
+    public void testFinal() {
+        // JsonDecimal must be final.
+        assertTrue(Modifier.isFinal(JsonDecimal.class.getModifiers()));
+    }
+
     @Test
     public void testBasicDoubleValue() {
         final JsonDecimal decimal = JsonDecimal.of(1234567890.123456);
@@ -65,5 +72,8 @@ public class TestJsonDecimal {
         assertEquals("1.234567890123456E9", decimal.toJson());
         assertEquals("1.234567890123456E9", decimal.toString());
         assertEquals(JsonDecimal.of(1234567890.123456), decimal);
+
+        // JsonDecimal#equals must normally reject a fake imitation of JsonDecimal.
+        assertFalse(decimal.equals(FakeJsonDecimal.of(decimal.doubleValue())));
     }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonInteger.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonInteger.java
@@ -21,11 +21,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
 
 public class TestJsonInteger {
+    @Test
+    public void testFinal() {
+        // JsonInteger must be final.
+        assertTrue(Modifier.isFinal(JsonInteger.class.getModifiers()));
+    }
+
     @Test
     public void testBasicByteValue() {
         final JsonInteger integer = JsonInteger.of(123L);
@@ -65,6 +72,9 @@ public class TestJsonInteger {
         assertEquals("123", integer.toJson());
         assertEquals("123", integer.toString());
         assertEquals(JsonInteger.of(123L), integer);
+
+        // JsonInteger#equals must normally reject a fake imitation of JsonInteger.
+        assertFalse(integer.equals(FakeJsonInteger.of(integer.longValue())));
     }
 
     @Test
@@ -106,6 +116,9 @@ public class TestJsonInteger {
         assertEquals("12345", integer.toJson());
         assertEquals("12345", integer.toString());
         assertEquals(JsonInteger.of(12345L), integer);
+
+        // JsonInteger#equals must normally reject a fake imitation of JsonInteger.
+        assertFalse(integer.equals(FakeJsonInteger.of(integer.longValue())));
     }
 
     @Test
@@ -147,6 +160,9 @@ public class TestJsonInteger {
         assertEquals("1234567890", integer.toJson());
         assertEquals("1234567890", integer.toString());
         assertEquals(JsonInteger.of(1234567890L), integer);
+
+        // JsonInteger#equals must normally reject a fake imitation of JsonInteger.
+        assertFalse(integer.equals(FakeJsonInteger.of(integer.longValue())));
     }
 
     @Test
@@ -188,6 +204,9 @@ public class TestJsonInteger {
         assertEquals("1234567890123456", integer.toJson());
         assertEquals("1234567890123456", integer.toString());
         assertEquals(JsonInteger.of(1234567890123456L), integer);
+
+        // JsonInteger#equals must normally reject a fake imitation of JsonInteger.
+        assertFalse(integer.equals(FakeJsonInteger.of(integer.longValue())));
     }
 
     @Test
@@ -229,5 +248,8 @@ public class TestJsonInteger {
         assertEquals("999999999999999999991234567890123456", integer.toJson());
         assertEquals("1234567890123456", integer.toString());
         assertEquals(JsonInteger.of(1234567890123456L), integer);
+
+        // JsonInteger#equals must normally reject a fake imitation of JsonInteger.
+        assertFalse(integer.equals(FakeJsonInteger.of(integer.longValue())));
     }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
@@ -21,9 +21,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
 
 public class TestJsonNull {
+    @Test
+    public void testFinal() {
+        // JsonNull must be final.
+        assertTrue(Modifier.isFinal(JsonNull.class.getModifiers()));
+    }
+
     @Test
     public void test() {
         final JsonNull jsonNull = JsonNull.of();
@@ -45,5 +52,8 @@ public class TestJsonNull {
         assertEquals("null", jsonNull.toJson());
         assertEquals("null", jsonNull.toString());
         assertEquals(JsonNull.of(), jsonNull);
+
+        // JsonNull#equals must normally reject a fake imitation of JsonNull.
+        assertFalse(jsonNull.equals(FakeJsonNull.ofFake()));
     }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
@@ -18,6 +18,7 @@ package org.embulk.spi.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -214,11 +215,26 @@ public class TestJsonObject {
         assertThrows(NoSuchElementException.class, () -> it.next());
         assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toJson());
         assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toString());
+
         assertEquals(JsonObject.of(
                              JsonString.of("foo"), JsonNull.of(),
                              JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
                              JsonString.of("baz"), JsonInteger.of(678)),
                      jsonObject);
+
+        // Ordered differently.
+        assertEquals(JsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("baz"), JsonInteger.of(678),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE)),
+                     jsonObject);
+
+        // Different value.
+        assertNotEquals(JsonObject.of(
+                                JsonString.of("foo"), JsonNull.of(),
+                                JsonString.of("baz"), JsonInteger.of(789),
+                                JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE)),
+                        jsonObject);
     }
 
     @Test
@@ -257,11 +273,26 @@ public class TestJsonObject {
         assertThrows(NoSuchElementException.class, () -> it.next());
         assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toJson());
         assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toString());
+
         assertEquals(JsonObject.of(
                              JsonString.of("foo"), JsonNull.of(),
                              JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
                              JsonString.of("baz"), JsonInteger.of(678)),
                      jsonObject);
+
+        // Ordered differently.
+        assertEquals(JsonObject.of(
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
+                             JsonString.of("baz"), JsonInteger.of(678),
+                             JsonString.of("foo"), JsonNull.of()),
+                     jsonObject);
+
+        // Different value.
+        assertNotEquals(JsonObject.of(
+                               JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
+                               JsonString.of("baz"), JsonInteger.of(234),
+                               JsonString.of("foo"), JsonNull.of()),
+                        jsonObject);
     }
 
     @Test

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import java.util.AbstractMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -30,6 +31,12 @@ import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
 
 public class TestJsonObject {
+    @Test
+    public void testFinal() {
+        // JsonObject must be final.
+        assertTrue(Modifier.isFinal(JsonObject.class.getModifiers()));
+    }
+
     @Test
     public void testEmpty() {
         final JsonObject jsonObject = JsonObject.of();
@@ -56,6 +63,9 @@ public class TestJsonObject {
         assertEquals("{}", jsonObject.toJson());
         assertEquals("{}", jsonObject.toString());
         assertEquals(JsonObject.of(), jsonObject);
+
+        // JsonObject#equals must normally reject a fake imitation of JsonObject.
+        assertFalse(jsonObject.equals(FakeJsonObject.of()));
     }
 
     @Test
@@ -89,10 +99,16 @@ public class TestJsonObject {
         assertThrows(NoSuchElementException.class, () -> it.next());
         assertEquals("{\"foo\":456,\"bar\":456}", jsonObject.toJson());
         assertEquals("{\"foo\":456,\"bar\":456}", jsonObject.toString());
+
         assertEquals(JsonObject.of(
                          JsonString.of("foo"), JsonInteger.of(456),
                          JsonString.of("bar"), JsonInteger.of(456)),
                      jsonObject);
+
+        // JsonObject#equals must normally reject a fake imitation of JsonObject.
+        assertFalse(jsonObject.equals(FakeJsonObject.of(
+                         JsonString.of("foo"), JsonInteger.of(456),
+                         JsonString.of("bar"), JsonInteger.of(456))));
     }
 
     @Test
@@ -135,6 +151,12 @@ public class TestJsonObject {
                              JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
                              JsonString.of("baz"), JsonInteger.of(678)),
                      jsonObject);
+
+        // JsonObject#equals must normally reject a fake imitation of JsonObject.
+        assertFalse(jsonObject.equals(FakeJsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
+                             JsonString.of("baz"), JsonInteger.of(678))));
     }
 
     @Test
@@ -172,11 +194,18 @@ public class TestJsonObject {
         assertThrows(NoSuchElementException.class, () -> it.next());
         assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toJson());
         assertEquals("{\"foo\":null,\"bar\":[123,true],\"baz\":678}", jsonObject.toString());
+
         assertEquals(JsonObject.of(
                              JsonString.of("foo"), JsonNull.of(),
                              JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
                              JsonString.of("baz"), JsonInteger.of(678)),
                      jsonObject);
+
+        // JsonObject#equals must normally reject a fake imitation of JsonObject.
+        assertFalse(jsonObject.equals(FakeJsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
+                             JsonString.of("baz"), JsonInteger.of(678))));
     }
 
     @Test
@@ -235,6 +264,12 @@ public class TestJsonObject {
                                 JsonString.of("baz"), JsonInteger.of(789),
                                 JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE)),
                         jsonObject);
+
+        // JsonObject#equals must normally reject a fake imitation of JsonObject.
+        assertFalse(jsonObject.equals(FakeJsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("baz"), JsonInteger.of(678),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE))));
     }
 
     @Test
@@ -293,6 +328,12 @@ public class TestJsonObject {
                                JsonString.of("baz"), JsonInteger.of(234),
                                JsonString.of("foo"), JsonNull.of()),
                         jsonObject);
+
+        // JsonObject#equals must normally reject a fake imitation of JsonObject.
+        assertFalse(jsonObject.equals(FakeJsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("baz"), JsonInteger.of(678),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE))));
     }
 
     @Test
@@ -361,6 +402,17 @@ public class TestJsonObject {
                              JsonString.of("piyo"), JsonInteger.of(345),
                              JsonString.of("hogera"), JsonString.of("bar")),
                      jsonObject);
+
+        // JsonObject#equals must normally reject a fake imitation of JsonObject.
+        assertFalse(jsonObject.equals(FakeJsonObject.of(
+                             JsonString.of("foo"), JsonNull.of(),
+                             JsonString.of("bar"), JsonArray.of(JsonInteger.of(123), JsonBoolean.TRUE),
+                             JsonString.of("baz"), JsonInteger.of(678),
+                             JsonString.of("qux"), JsonNull.of(),
+                             JsonString.of("hoge"), JsonString.of("foo"),
+                             JsonString.of("fuga"), JsonDecimal.of(123.4),
+                             JsonString.of("piyo"), JsonInteger.of(345),
+                             JsonString.of("hogera"), JsonString.of("bar"))));
     }
 
     @Test

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
@@ -21,9 +21,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
 
 public class TestJsonString {
+    @Test
+    public void testFinal() {
+        // JsonString must be final.
+        assertTrue(Modifier.isFinal(JsonString.class.getModifiers()));
+    }
+
     @Test
     public void testBasic() {
         final JsonString string = JsonString.of("hoge");
@@ -48,6 +55,9 @@ public class TestJsonString {
         assertEquals("\"hoge\"", string.toString());
         assertEquals(JsonString.of("hoge"), string);
         assertEquals("hoge".hashCode(), string.hashCode());
+
+        // JsonString#equals must normally reject a fake imitation of JsonString.
+        assertFalse(string.equals(FakeJsonString.of(string.getString())));
     }
 
     @Test
@@ -74,6 +84,9 @@ public class TestJsonString {
         assertEquals("\"hoge\\n\"", string.toString());
         assertEquals(JsonString.of("hoge\n"), string);
         assertEquals("hoge\n".hashCode(), string.hashCode());
+
+        // JsonString#equals must normally reject a fake imitation of JsonString.
+        assertFalse(string.equals(FakeJsonString.of(string.getString())));
     }
 
     @Test
@@ -104,5 +117,8 @@ public class TestJsonString {
                 string.toString());
         assertEquals(JsonString.of("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux"), string);
         assertEquals("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux".hashCode(), string.hashCode());
+
+        // JsonString#equals must normally reject a fake imitation of JsonString.
+        assertFalse(string.equals(FakeJsonString.of(string.getString())));
     }
 }


### PR DESCRIPTION
It is a follow-up to: #1462

#1462 was not very clear about equality (`#equals(Object)`). If a developer defines their own `JsonValue` subclass, the new class may behave inconsistent with the "standard" `JsonValue` classes. Some are `true`, some are `false`, and some throw an Exception. The second commit 1f248a9c59e8bceb7b78c3e4b79459399968bc0d tests it, and confirms it fails.

This pull request clarifies the behavior of `#equals(Object)`. The standard `JsonValue` classes should not be "equal" to any non-standard `JsonValue` subclass. The third commit bb3f497bf155ae788c8a4f4a3a43490617a96d70 fixes `#equals(Object)`, and confirms it passes.

Its corresponding EEP is draft at https://github.com/embulk/embulk/pull/1538.