### PR TITLE
Add JsonValue#presumeReferenceSizeInBytes to presume an approximate size to be occupied in Page

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonArray.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonArray.java
@@ -115,11 +115,24 @@ public final class JsonArray extends AbstractList<JsonValue> implements JsonValu
     /**
      * Returns the approximate size of this JSON array in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
      *
+     * <p>This approximate size is used only as a threshold whether {@link org.embulk.spi.PageBuilder} is flushed, or not.
+     * It is not accurate, it does not need to be accurate, and it is impossible in general to tell an accurate size that
+     * a Java object occupies in the Java heap. But, a reasonable approximate would help to keep {@link org.embulk.spi.Page}
+     * performant in the Java heap.
+     *
+     * <p>It is better to flush more frequently for bigger JSON value objects, less often for smaller JSON value objects,
+     * but no infinite accumulation even for empty JSON value objects.
+     *
      * @return the approximate size of this JSON array in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference
+     *
+     * @see "org.embulk.spi.PageBuilderImpl#addRecord"
      */
     @Override
     public int presumeReferenceSizeInBytes() {
+        // No clear reason for the number 4.
+        // But at least, it should not be 0 so that the approximate size of an empty array would not be 0.
         int sum = 4;
+
         for (int i = 0; i < this.values.length; i++) {
             sum += this.values[i].presumeReferenceSizeInBytes();
         }

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonArray.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonArray.java
@@ -113,6 +113,20 @@ public final class JsonArray extends AbstractList<JsonValue> implements JsonValu
     }
 
     /**
+     * Returns the approximate size of this JSON array in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
+     *
+     * @return the approximate size of this JSON array in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference
+     */
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        int sum = 4;
+        for (int i = 0; i < this.values.length; i++) {
+            sum += this.values[i].presumeReferenceSizeInBytes();
+        }
+        return sum;
+    }
+
+    /**
      * Returns the number of JSON values in this array.
      *
      * @return the number of JSON values in this array

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonBoolean.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonBoolean.java
@@ -84,7 +84,17 @@ public final class JsonBoolean implements JsonValue {
     /**
      * Returns {@code 1} for the size of {@code byte} in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
      *
+     * <p>This approximate size is used only as a threshold whether {@link org.embulk.spi.PageBuilder} is flushed, or not.
+     * It is not accurate, it does not need to be accurate, and it is impossible in general to tell an accurate size that
+     * a Java object occupies in the Java heap. But, a reasonable approximate would help to keep {@link org.embulk.spi.Page}
+     * performant in the Java heap.
+     *
+     * <p>It is better to flush more frequently for bigger JSON value objects, less often for smaller JSON value objects,
+     * but no infinite accumulation even for empty JSON value objects.
+     *
      * @return {@code 1}
+     *
+     * @see "org.embulk.spi.PageBuilderImpl#addRecord"
      *
      * @see <a href="https://github.com/airlift/slice/blob/0.9/src/main/java/io/airlift/slice/SizeOf.java#L37">SIZE_OF_BYTE in Airlift's Slice</a>
      */

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonBoolean.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonBoolean.java
@@ -82,6 +82,19 @@ public final class JsonBoolean implements JsonValue {
     }
 
     /**
+     * Returns {@code 1} for the size of {@code byte} in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
+     *
+     * @return {@code 1}
+     *
+     * @see <a href="https://github.com/airlift/slice/blob/0.9/src/main/java/io/airlift/slice/SizeOf.java#L37">SIZE_OF_BYTE in Airlift's Slice</a>
+     */
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        // BOOLEAN is stored in Page as a byte.
+        return 1;
+    }
+
+    /**
      * Returns this JSON {@code true} or {@code false} as a primitive {@code boolean}.
      *
      * @return the {@code boolean} representation of this JSON {@code true} or {@code false}

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
@@ -86,7 +86,17 @@ public final class JsonDouble implements JsonNumber {
     /**
      * Returns {@code 8} for the size of {@code double} in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
      *
+     * <p>This approximate size is used only as a threshold whether {@link org.embulk.spi.PageBuilder} is flushed, or not.
+     * It is not accurate, it does not need to be accurate, and it is impossible in general to tell an accurate size that
+     * a Java object occupies in the Java heap. But, a reasonable approximate would help to keep {@link org.embulk.spi.Page}
+     * performant in the Java heap.
+     *
+     * <p>It is better to flush more frequently for bigger JSON value objects, less often for smaller JSON value objects,
+     * but no infinite accumulation even for empty JSON value objects.
+     *
      * @return {@code 8}
+     *
+     * @see "org.embulk.spi.PageBuilderImpl#addRecord"
      *
      * @see <a href="https://github.com/airlift/slice/blob/0.9/src/main/java/io/airlift/slice/SizeOf.java#L42">SIZE_OF_DOUBLE in Airlift's Slice</a>
      */

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
@@ -84,6 +84,18 @@ public final class JsonDouble implements JsonNumber {
     }
 
     /**
+     * Returns {@code 8} for the size of {@code double} in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
+     *
+     * @return {@code 8}
+     *
+     * @see <a href="https://github.com/airlift/slice/blob/0.9/src/main/java/io/airlift/slice/SizeOf.java#L42">SIZE_OF_DOUBLE in Airlift's Slice</a>
+     */
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        return 8;
+    }
+
+    /**
      * Returns {@code true} if this JSON number is integral.
      *
      * <p>Note that it does not guarantee this JSON number can be represented as a Java primitive exact {@code long}.

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonLong.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonLong.java
@@ -86,6 +86,18 @@ public final class JsonLong implements JsonNumber {
     }
 
     /**
+     * Returns {@code 8} for the size of {@code long} in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
+     *
+     * @return {@code 8}
+     *
+     * @see <a href="https://github.com/airlift/slice/blob/0.9/src/main/java/io/airlift/slice/SizeOf.java#L40">SIZE_OF_LONG in Airlift's Slice</a>
+     */
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        return 8;
+    }
+
+    /**
      * Returns {@code true} to represent this JSON number is integral.
      *
      * @return {@code true}

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonLong.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonLong.java
@@ -88,7 +88,17 @@ public final class JsonLong implements JsonNumber {
     /**
      * Returns {@code 8} for the size of {@code long} in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
      *
+     * <p>This approximate size is used only as a threshold whether {@link org.embulk.spi.PageBuilder} is flushed, or not.
+     * It is not accurate, it does not need to be accurate, and it is impossible in general to tell an accurate size that
+     * a Java object occupies in the Java heap. But, a reasonable approximate would help to keep {@link org.embulk.spi.Page}
+     * performant in the Java heap.
+     *
+     * <p>It is better to flush more frequently for bigger JSON value objects, less often for smaller JSON value objects,
+     * but no infinite accumulation even for empty JSON value objects.
+     *
      * @return {@code 8}
+     *
+     * @see "org.embulk.spi.PageBuilderImpl#addRecord"
      *
      * @see <a href="https://github.com/airlift/slice/blob/0.9/src/main/java/io/airlift/slice/SizeOf.java#L40">SIZE_OF_LONG in Airlift's Slice</a>
      */

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
@@ -66,7 +66,17 @@ public final class JsonNull implements JsonValue {
     /**
      * Returns {@code 1} for the size of {@code null} in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
      *
+     * <p>This approximate size is used only as a threshold whether {@link org.embulk.spi.PageBuilder} is flushed, or not.
+     * It is not accurate, it does not need to be accurate, and it is impossible in general to tell an accurate size that
+     * a Java object occupies in the Java heap. But, a reasonable approximate would help to keep {@link org.embulk.spi.Page}
+     * performant in the Java heap.
+     *
+     * <p>It is better to flush more frequently for bigger JSON value objects, less often for smaller JSON value objects,
+     * but no infinite accumulation even for empty JSON value objects.
+     *
      * @return {@code 1}
+     *
+     * @see "org.embulk.spi.PageBuilderImpl#addRecord"
      *
      * @see <a href="https://github.com/airlift/slice/blob/0.9/src/main/java/io/airlift/slice/SizeOf.java#L37">SIZE_OF_BYTE in Airlift's Slice</a>
      */

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
@@ -64,6 +64,19 @@ public final class JsonNull implements JsonValue {
     }
 
     /**
+     * Returns {@code 1} for the size of {@code null} in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
+     *
+     * @return {@code 1}
+     *
+     * @see <a href="https://github.com/airlift/slice/blob/0.9/src/main/java/io/airlift/slice/SizeOf.java#L37">SIZE_OF_BYTE in Airlift's Slice</a>
+     */
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        // Indeed, null is stored in Page as a special form as |nullBitSet|, but considered as 1 here in JsonValue just for ease.
+        return 1;
+    }
+
+    /**
      * Returns the stringified JSON representation of this JSON {@code null}.
      *
      * @return {@code "null"}

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
@@ -346,6 +346,20 @@ public final class JsonObject extends AbstractMap<String, JsonValue> implements 
     }
 
     /**
+     * Returns the approximate size of this JSON object in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
+     *
+     * @return the approximate size of this JSON object in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference
+     */
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        int sum = 4;
+        for (int i = 0; i < this.values.length; i++) {
+            sum += this.values[i].presumeReferenceSizeInBytes();
+        }
+        return sum;
+    }
+
+    /**
      * Returns the number of JSON key-value mappings in this object.
      *
      * @return the number of JSON key-value mappings in this object

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
@@ -348,11 +348,24 @@ public final class JsonObject extends AbstractMap<String, JsonValue> implements 
     /**
      * Returns the approximate size of this JSON object in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
      *
+     * <p>This approximate size is used only as a threshold whether {@link org.embulk.spi.PageBuilder} is flushed, or not.
+     * It is not accurate, it does not need to be accurate, and it is impossible in general to tell an accurate size that
+     * a Java object occupies in the Java heap. But, a reasonable approximate would help to keep {@link org.embulk.spi.Page}
+     * performant in the Java heap.
+     *
+     * <p>It is better to flush more frequently for bigger JSON value objects, less often for smaller JSON value objects,
+     * but no infinite accumulation even for empty JSON value objects.
+     *
      * @return the approximate size of this JSON object in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference
+     *
+     * @see "org.embulk.spi.PageBuilderImpl#addRecord"
      */
     @Override
     public int presumeReferenceSizeInBytes() {
+        // No clear reason for the number 4.
+        // But at least, it should not be 0 so that the approximate size of an empty object would not be 0.
         int sum = 4;
+
         for (int i = 0; i < this.values.length; i++) {
             sum += this.values[i].presumeReferenceSizeInBytes();
         }

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
@@ -85,6 +85,17 @@ public final class JsonString implements JsonValue {
     }
 
     /**
+     * Returns the approximate size of this JSON string in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
+     *
+     * @return the approximate size of this JSON string in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference
+     */
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        // Indeed, null is stored in Page as a special form as |nullBitSet|, but considered as 1 here in JsonValue just for ease.
+        return this.value.length() * 2 + 4;
+    }
+
+    /**
      * Returns this JSON string as {@link String}.
      *
      * @return the {@link String} representation of this JSON string

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
@@ -87,7 +87,17 @@ public final class JsonString implements JsonValue {
     /**
      * Returns the approximate size of this JSON string in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
      *
+     * <p>This approximate size is used only as a threshold whether {@link org.embulk.spi.PageBuilder} is flushed, or not.
+     * It is not accurate, it does not need to be accurate, and it is impossible in general to tell an accurate size that
+     * a Java object occupies in the Java heap. But, a reasonable approximate would help to keep {@link org.embulk.spi.Page}
+     * performant in the Java heap.
+     *
+     * <p>It is better to flush more frequently for bigger JSON value objects, less often for smaller JSON value objects,
+     * but no infinite accumulation even for empty JSON value objects.
+     *
      * @return the approximate size of this JSON string in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference
+     *
+     * @see "org.embulk.spi.PageBuilderImpl#addRecord"
      */
     @Override
     public int presumeReferenceSizeInBytes() {

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonValue.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonValue.java
@@ -351,7 +351,17 @@ public interface JsonValue {
     /**
      * Returns the approximate size of this JSON value in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
      *
+     * <p>This approximate size is used only as a threshold whether {@link org.embulk.spi.PageBuilder} is flushed, or not.
+     * It is not accurate, it does not need to be accurate, and it is impossible in general to tell an accurate size that
+     * a Java object occupies in the Java heap. But, a reasonable approximate would help to keep {@link org.embulk.spi.Page}
+     * performant in the Java heap.
+     *
+     * <p>It is better to flush more frequently for bigger JSON value objects, less often for smaller JSON value objects,
+     * but no infinite accumulation even for empty JSON value objects.
+     *
      * @return the approximate size of this JSON value in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference
+     *
+     * @see "org.embulk.spi.PageBuilderImpl#addRecord"
      */
     int presumeReferenceSizeInBytes();
 

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonValue.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonValue.java
@@ -349,6 +349,13 @@ public interface JsonValue {
     }
 
     /**
+     * Returns the approximate size of this JSON value in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference.
+     *
+     * @return the approximate size of this JSON value in bytes presumed to occupy in {@link org.embulk.spi.Page} as a reference
+     */
+    int presumeReferenceSizeInBytes();
+
+    /**
      * Compares the specified object with this JSON value for equality.
      *
      * @return {@code true} if the specified object is equal to this JSON value

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonArray.java
@@ -38,7 +38,7 @@ public final class FakeJsonArray extends AbstractList<JsonValue> implements Json
 
     @Override
     public int presumeReferenceSizeInBytes() {
-        int sum = 0;
+        int sum = 4;
         for (int i = 0; i < this.values.length; i++) {
             sum += this.values[i].presumeReferenceSizeInBytes();
         }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonArray.java
@@ -37,6 +37,15 @@ public final class FakeJsonArray extends AbstractList<JsonValue> implements Json
     }
 
     @Override
+    public int presumeReferenceSizeInBytes() {
+        int sum = 0;
+        for (int i = 0; i < this.values.length; i++) {
+            sum += this.values[i].presumeReferenceSizeInBytes();
+        }
+        return sum;
+    }
+
+    @Override
     public int size() {
         return this.values.length;
     }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonBoolean.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonBoolean.java
@@ -30,6 +30,11 @@ public final class FakeJsonBoolean implements JsonValue {
         return EntityType.BOOLEAN;
     }
 
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        return 1;
+    }
+
     public boolean booleanValue() {
         return this.value;
     }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonDouble.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonDouble.java
@@ -33,6 +33,11 @@ public final class FakeJsonDouble implements JsonValue {
         return EntityType.DOUBLE;
     }
 
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        return 8;
+    }
+
     public boolean isIntegral() {
         return !Double.isNaN(this.value) && !Double.isInfinite(this.value) && this.value == Math.rint(this.value);
     }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonLong.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonLong.java
@@ -33,6 +33,11 @@ public final class FakeJsonLong implements JsonValue {
         return EntityType.LONG;
     }
 
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        return 8;
+    }
+
     public boolean isIntegral() {
         return true;
     }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonNull.java
@@ -31,6 +31,11 @@ public final class FakeJsonNull implements JsonValue {
     }
 
     @Override
+    public int presumeReferenceSizeInBytes() {
+        return 1;
+    }
+
+    @Override
     public String toJson() {
         return "null";
     }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonObject.java
@@ -51,6 +51,15 @@ public final class FakeJsonObject extends AbstractMap<String, JsonValue> impleme
     }
 
     @Override
+    public int presumeReferenceSizeInBytes() {
+        int sum = 0;
+        for (int i = 0; i < this.values.length; i++) {
+            sum += this.values[i].presumeReferenceSizeInBytes();
+        }
+        return sum;
+    }
+
+    @Override
     public int size() {
         return this.values.length / 2;
     }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonObject.java
@@ -52,7 +52,7 @@ public final class FakeJsonObject extends AbstractMap<String, JsonValue> impleme
 
     @Override
     public int presumeReferenceSizeInBytes() {
-        int sum = 0;
+        int sum = 4;
         for (int i = 0; i < this.values.length; i++) {
             sum += this.values[i].presumeReferenceSizeInBytes();
         }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonString.java
@@ -32,6 +32,11 @@ public final class FakeJsonString implements JsonValue {
         return EntityType.STRING;
     }
 
+    @Override
+    public int presumeReferenceSizeInBytes() {
+        return this.value.length() * 2 + 4;
+    }
+
     public String getString() {
         return this.value;
     }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
@@ -50,6 +50,7 @@ public class TestJsonArray {
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
         assertEquals(jsonArray, jsonArray.asJsonArray());
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(4, jsonArray.presumeReferenceSizeInBytes());
         assertEquals(0, jsonArray.size());
         assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(0));
         assertEquals("[]", jsonArray.toJson());
@@ -78,6 +79,7 @@ public class TestJsonArray {
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
         assertEquals(jsonArray, jsonArray.asJsonArray());
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(12, jsonArray.presumeReferenceSizeInBytes());
         assertEquals(1, jsonArray.size());
         assertEquals(JsonLong.of(987), jsonArray.get(0));
         assertThrows(IndexOutOfBoundsException.class, () -> jsonArray.get(1));
@@ -111,6 +113,7 @@ public class TestJsonArray {
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
         assertEquals(jsonArray, jsonArray.asJsonArray());
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(23, jsonArray.presumeReferenceSizeInBytes());
         assertEquals(3, jsonArray.size());
         assertEquals(JsonLong.of(987), jsonArray.get(0));
         assertEquals(JsonString.of("foo"), jsonArray.get(1));
@@ -160,6 +163,7 @@ public class TestJsonArray {
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
         assertEquals(jsonArray, jsonArray.asJsonArray());
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(23, jsonArray.presumeReferenceSizeInBytes());
         assertEquals(3, jsonArray.size());
         assertEquals(JsonLong.of(987), jsonArray.get(0));
         assertEquals(JsonString.of("foo"), jsonArray.get(1));
@@ -187,7 +191,6 @@ public class TestJsonArray {
         assertFalse(jsonArray.equals(FakeJsonArray.of(JsonLong.of(987), JsonString.of("foo"), JsonBoolean.TRUE)));
     }
 
-
     @Test
     public void testMultiUnsafe() {
         final JsonValue[] values = new JsonValue[3];
@@ -210,6 +213,7 @@ public class TestJsonArray {
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
         assertEquals(jsonArray, jsonArray.asJsonArray());
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(23, jsonArray.presumeReferenceSizeInBytes());
         assertEquals(3, jsonArray.size());
         assertEquals(JsonLong.of(987), jsonArray.get(0));
         assertEquals(JsonString.of("foo"), jsonArray.get(1));
@@ -259,6 +263,7 @@ public class TestJsonArray {
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonString());
         assertEquals(jsonArray, jsonArray.asJsonArray());
         assertThrows(ClassCastException.class, () -> jsonArray.asJsonObject());
+        assertEquals(47, jsonArray.presumeReferenceSizeInBytes());
         assertEquals(3, jsonArray.size());
         assertEquals(JsonLong.of(987), jsonArray.get(0));
         assertEquals(JsonArray.of(JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")), jsonArray.get(1));

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonBoolean.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonBoolean.java
@@ -49,6 +49,7 @@ public class TestJsonBoolean {
         assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonArray());
         assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonObject());
+        assertEquals(1, jsonBoolean.presumeReferenceSizeInBytes());
         assertEquals(false, jsonBoolean.booleanValue());
         assertEquals("false", jsonBoolean.toJson());
         assertEquals("false", jsonBoolean.toString());
@@ -78,6 +79,7 @@ public class TestJsonBoolean {
         assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonArray());
         assertThrows(ClassCastException.class, () -> jsonBoolean.asJsonObject());
+        assertEquals(1, jsonBoolean.presumeReferenceSizeInBytes());
         assertEquals(true, jsonBoolean.booleanValue());
         assertEquals("true", jsonBoolean.toJson());
         assertEquals("true", jsonBoolean.toString());

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDouble.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDouble.java
@@ -51,6 +51,7 @@ public class TestJsonDouble {
         assertThrows(ClassCastException.class, () -> jsonDouble.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonDouble.asJsonArray());
         assertThrows(ClassCastException.class, () -> jsonDouble.asJsonObject());
+        assertEquals(8, jsonDouble.presumeReferenceSizeInBytes());
         assertFalse(jsonDouble.isIntegral());
         assertFalse(jsonDouble.isByteValue());
         assertFalse(jsonDouble.isShortValue());

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonLong.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonLong.java
@@ -51,6 +51,7 @@ public class TestJsonLong {
         assertThrows(ClassCastException.class, () -> integer.asJsonString());
         assertThrows(ClassCastException.class, () -> integer.asJsonArray());
         assertThrows(ClassCastException.class, () -> integer.asJsonObject());
+        assertEquals(8, integer.presumeReferenceSizeInBytes());
         assertTrue(integer.isIntegral());
         assertTrue(integer.isByteValue());
         assertTrue(integer.isShortValue());
@@ -95,6 +96,7 @@ public class TestJsonLong {
         assertThrows(ClassCastException.class, () -> integer.asJsonString());
         assertThrows(ClassCastException.class, () -> integer.asJsonArray());
         assertThrows(ClassCastException.class, () -> integer.asJsonObject());
+        assertEquals(8, integer.presumeReferenceSizeInBytes());
         assertTrue(integer.isIntegral());
         assertFalse(integer.isByteValue());
         assertTrue(integer.isShortValue());
@@ -139,6 +141,7 @@ public class TestJsonLong {
         assertThrows(ClassCastException.class, () -> integer.asJsonString());
         assertThrows(ClassCastException.class, () -> integer.asJsonArray());
         assertThrows(ClassCastException.class, () -> integer.asJsonObject());
+        assertEquals(8, integer.presumeReferenceSizeInBytes());
         assertTrue(integer.isIntegral());
         assertFalse(integer.isByteValue());
         assertFalse(integer.isShortValue());
@@ -183,6 +186,7 @@ public class TestJsonLong {
         assertThrows(ClassCastException.class, () -> integer.asJsonString());
         assertThrows(ClassCastException.class, () -> integer.asJsonArray());
         assertThrows(ClassCastException.class, () -> integer.asJsonObject());
+        assertEquals(8, integer.presumeReferenceSizeInBytes());
         assertTrue(integer.isIntegral());
         assertFalse(integer.isByteValue());
         assertFalse(integer.isShortValue());
@@ -227,6 +231,7 @@ public class TestJsonLong {
         assertThrows(ClassCastException.class, () -> integer.asJsonString());
         assertThrows(ClassCastException.class, () -> integer.asJsonArray());
         assertThrows(ClassCastException.class, () -> integer.asJsonObject());
+        assertEquals(8, integer.presumeReferenceSizeInBytes());
         assertTrue(integer.isIntegral());
         assertFalse(integer.isByteValue());
         assertFalse(integer.isShortValue());

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
@@ -49,6 +49,7 @@ public class TestJsonNull {
         assertThrows(ClassCastException.class, () -> jsonNull.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonNull.asJsonArray());
         assertThrows(ClassCastException.class, () -> jsonNull.asJsonObject());
+        assertEquals(1, jsonNull.presumeReferenceSizeInBytes());
         assertEquals("null", jsonNull.toJson());
         assertEquals("null", jsonNull.toString());
         assertEquals(JsonNull.of(), jsonNull);

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
@@ -55,6 +55,7 @@ public class TestJsonObject {
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
         assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(4, jsonObject.presumeReferenceSizeInBytes());
         assertEquals(0, jsonObject.size());
         assertEquals(0, jsonObject.entrySet().size());
         assertEquals(0, jsonObject.getKeyValueArray().length);
@@ -87,6 +88,7 @@ public class TestJsonObject {
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
         assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(40, jsonObject.presumeReferenceSizeInBytes());
         assertEquals(2, jsonObject.size());
         assertEquals(2, jsonObject.entrySet().size());
         assertEquals(4, jsonObject.getKeyValueArray().length);
@@ -132,6 +134,7 @@ public class TestJsonObject {
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
         assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(56, jsonObject.presumeReferenceSizeInBytes());
         assertEquals(3, jsonObject.size());
         assertEquals(3, jsonObject.entrySet().size());
         assertEquals(6, jsonObject.getKeyValueArray().length);
@@ -180,6 +183,7 @@ public class TestJsonObject {
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
         assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(56, jsonObject.presumeReferenceSizeInBytes());
         assertEquals(3, jsonObject.size());
         assertEquals(3, jsonObject.entrySet().size());
         assertEquals(6, jsonObject.getKeyValueArray().length);
@@ -230,6 +234,7 @@ public class TestJsonObject {
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
         assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(56, jsonObject.presumeReferenceSizeInBytes());
         assertEquals(3, jsonObject.size());
         assertEquals(3, jsonObject.entrySet().size());
         assertEquals(6, jsonObject.getKeyValueArray().length);
@@ -294,6 +299,7 @@ public class TestJsonObject {
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
         assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(56, jsonObject.presumeReferenceSizeInBytes());
         assertEquals(3, jsonObject.size());
         assertEquals(3, jsonObject.entrySet().size());
         assertEquals(6, jsonObject.getKeyValueArray().length);
@@ -368,6 +374,7 @@ public class TestJsonObject {
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
         assertEquals(jsonObject, jsonObject.asJsonObject());
+        assertEquals(155, jsonObject.presumeReferenceSizeInBytes());
         assertEquals(8, jsonObject.size());
         assertEquals(8, jsonObject.entrySet().size());
         assertEquals(16, jsonObject.getKeyValueArray().length);

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
@@ -49,6 +49,7 @@ public class TestJsonString {
         assertEquals(string, string.asJsonString());
         assertThrows(ClassCastException.class, () -> string.asJsonArray());
         assertThrows(ClassCastException.class, () -> string.asJsonObject());
+        assertEquals(12, string.presumeReferenceSizeInBytes());
         assertEquals("hoge", string.getString());
         assertEquals("hoge", string.getChars());
         assertEquals("\"hoge\"", string.toJson());
@@ -78,6 +79,7 @@ public class TestJsonString {
         assertEquals(string, string.asJsonString());
         assertThrows(ClassCastException.class, () -> string.asJsonArray());
         assertThrows(ClassCastException.class, () -> string.asJsonObject());
+        assertEquals(14, string.presumeReferenceSizeInBytes());
         assertEquals("hoge\n", string.getString());
         assertEquals("hoge\n", string.getChars());
         assertEquals("\"\\u0068oge\\n\"", string.toJson());
@@ -107,6 +109,7 @@ public class TestJsonString {
         assertEquals(string, string.asJsonString());
         assertThrows(ClassCastException.class, () -> string.asJsonArray());
         assertThrows(ClassCastException.class, () -> string.asJsonObject());
+        assertEquals(100, string.presumeReferenceSizeInBytes());
         assertEquals("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux", string.getString());
         assertEquals("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux", string.getChars());
         assertEquals(


### PR DESCRIPTION
It is a follow-up to: #1462

`PageBuilder` has had a mechanism to estimate size of each record in order to make decisions when to "flush" the `PageBuilder` to `Page`. But, it has been just assumed as `256` for JSON columns.

https://github.com/embulk/embulk/blob/v0.10.41/embulk-core/src/main/java/org/embulk/spi/PageBuilderImpl.java#L181

Introducing the new `JsonValue` is a good chance to make it better. `JsonValue#presumeReferenceSizeInBytes` is the mechanism to presume the approximate size.