### PR TITLE
Define a public constant NULL in JsonNull

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
@@ -29,6 +29,13 @@ public final class JsonNull implements JsonValue {
     }
 
     /**
+     * The singleton instance that represents {@code null} in JSON.
+     *
+     * @since 0.10.42
+     */
+    public static final JsonNull NULL = new JsonNull();
+
+    /**
      * Returns the singleton instance of {@link JsonNull}.
      *
      * @return the singleton instance of {@link JsonNull}
@@ -36,7 +43,7 @@ public final class JsonNull implements JsonValue {
      * @since 0.10.42
      */
     public static JsonNull of() {
-        return INSTANCE;
+        return NULL;
     }
 
     /**
@@ -110,7 +117,7 @@ public final class JsonNull implements JsonValue {
     @Override
     public boolean equals(final Object otherObject) {
         // Only the singleton instance is accepted. No arbitrary instantiation.
-        return this == INSTANCE && otherObject == INSTANCE;
+        return this == NULL && otherObject == NULL;
     }
 
     /**
@@ -124,6 +131,4 @@ public final class JsonNull implements JsonValue {
     public int hashCode() {
         return 0;
     }
-
-    private static final JsonNull INSTANCE = new JsonNull();
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonNull.java
@@ -21,8 +21,10 @@ public final class FakeJsonNull implements JsonValue {
         // No direct instantiation.
     }
 
+    public static final FakeJsonNull FAKE_NULL = new FakeJsonNull();
+
     public static FakeJsonNull ofFake() {
-        return INSTANCE;
+        return FAKE_NULL;
     }
 
     @Override
@@ -53,13 +55,11 @@ public final class FakeJsonNull implements JsonValue {
         }
 
         // Only the singleton instance is accepted. No arbitrary instantiation.
-        return this == INSTANCE && otherObject == INSTANCE;
+        return this == FAKE_NULL && otherObject == FAKE_NULL;
     }
 
     @Override
     public int hashCode() {
         return 0;
     }
-
-    private static final FakeJsonNull INSTANCE = new FakeJsonNull();
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
@@ -52,6 +52,7 @@ public class TestJsonNull {
         assertEquals(1, jsonNull.presumeReferenceSizeInBytes());
         assertEquals("null", jsonNull.toJson());
         assertEquals("null", jsonNull.toString());
+        assertEquals(JsonNull.NULL, jsonNull);
         assertEquals(JsonNull.of(), jsonNull);
 
         // JsonNull#equals must normally reject a fake imitation of JsonNull.


### PR DESCRIPTION
It is a follow-up to: #1462 

It is just to make `JsonNull` consistent with `JsonBoolean` which has `FALSE` and `TRUE` as constants.