### PR TITLE
Stop String#intern when instantiating JsonString

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
@@ -42,7 +42,7 @@ public final class JsonString implements JsonValue {
      * @since 0.10.42
      */
     public static JsonString of(final String value) {
-        return new JsonString(value.intern(), null);
+        return new JsonString(value, null);
     }
 
     /**
@@ -57,7 +57,7 @@ public final class JsonString implements JsonValue {
      * @since 0.10.42
      */
     public static JsonString withLiteral(final String value, final String literal) {
-        return new JsonString(value.intern(), literal.intern());
+        return new JsonString(value, literal);
     }
 
     /**

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonString.java
@@ -24,7 +24,7 @@ public final class FakeJsonString implements JsonValue {
     }
 
     public static FakeJsonString of(final String value) {
-        return new FakeJsonString(value.intern());
+        return new FakeJsonString(value);
     }
 
     @Override


### PR DESCRIPTION
Follow-up to: #1462 

I at first used `String#intern()` forcibly when creating `JsonString` to save memory, but at the same time, it needs time to `String#intern()`.

It should be plugin developer's choice. Going to remove the `intern()`.