### PR TITLE
Represent JsonObject's internal keys by String, not JsonString

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
@@ -272,7 +272,7 @@ public final class JsonString implements JsonValue {
         builder.append("\"");
     }
 
-    private static String escapeStringForJsonLiteral(final String original) {
+    static String escapeStringForJsonLiteral(final String original) {
         final StringBuilder builder = new StringBuilder();
         appendEscapedStringForJsonLiteral(original, builder);
         return builder.toString();


### PR DESCRIPTION
Follow-up to: #1462

`JsonObject` started from a single array containing both keys and values because it started from a clone of msgpack-java's [`ImmutableMapValueImpl`](https://github.com/msgpack/msgpack-java/blob/v0.8.24/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableMapValueImpl.java).

But, unlike msgpack-java's `MapValue` taking any `Value` as a key, `JsonObject` takes only strings as a key. It would be more reasonable and straightforward to have `JsonObject`'s keys as plain `String`s.

It does not change any behavior observed from outside. No changes in tests, then.