### PR TITLE
Add JsonObject#of(...) methods

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonObject.java
@@ -50,6 +50,311 @@ public final class JsonObject extends AbstractMap<String, JsonValue> implements 
     }
 
     /**
+     * Returns a JSON object containing the specified single JSON key-value mapping.
+     *
+     * @param k1  the mapping's key, not null
+     * @param v1  the mapping's value, not null
+     * @return a JSON object containing the specified mapping
+     * @throws NullPointerException  if the key or the value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(
+            final String k1, final JsonValue v1) {
+        return new JsonObject(
+                buildKeys(k1),
+                buildValues(v1));
+    }
+
+    /**
+     * Returns a JSON object containing the specified two JSON key-value mappings.
+     *
+     * @param k1 the first mapping's key, not null
+     * @param v1 the first mapping's value, not null
+     * @param k2 the second mapping's key, not null
+     * @param v2 the second mapping's value, not null
+     * @return a JSON object containing the specified mappings
+     * @throws NullPointerException  if any key or any value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(
+            final String k1, final JsonValue v1,
+            final String k2, final JsonValue v2) {
+        return new JsonObject(
+                buildKeys(k1, k2),
+                buildValues(v1, v2));
+    }
+
+    /**
+     * Returns a JSON object containing the specified three JSON key-value mappings.
+     *
+     * @param k1 the first mapping's key, not null
+     * @param v1 the first mapping's value, not null
+     * @param k2 the second mapping's key, not null
+     * @param v2 the second mapping's value, not null
+     * @param k3 the third mapping's key, not null
+     * @param v3 the third mapping's value, not null
+     * @return a JSON object containing the specified mappings
+     * @throws NullPointerException  if any key or any value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(
+            final String k1, final JsonValue v1,
+            final String k2, final JsonValue v2,
+            final String k3, final JsonValue v3) {
+        return new JsonObject(
+                buildKeys(k1, k2, k3),
+                buildValues(v1, v2, v3));
+    }
+
+    /**
+     * Returns a JSON object containing the specified four JSON key-value mappings.
+     *
+     * @param k1 the first mapping's key, not null
+     * @param v1 the first mapping's value, not null
+     * @param k2 the second mapping's key, not null
+     * @param v2 the second mapping's value, not null
+     * @param k3 the third mapping's key, not null
+     * @param v3 the third mapping's value, not null
+     * @param k4 the fourth mapping's key, not null
+     * @param v4 the fourth mapping's value, not null
+     * @return a JSON object containing the specified mappings
+     * @throws NullPointerException  if any key or any value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(
+            final String k1, final JsonValue v1,
+            final String k2, final JsonValue v2,
+            final String k3, final JsonValue v3,
+            final String k4, final JsonValue v4) {
+        return new JsonObject(
+                buildKeys(k1, k2, k3, k4),
+                buildValues(v1, v2, v3, v4));
+    }
+
+    /**
+     * Returns a JSON object containing the specified five JSON key-value mappings.
+     *
+     * @param k1 the first mapping's key, not null
+     * @param v1 the first mapping's value, not null
+     * @param k2 the second mapping's key, not null
+     * @param v2 the second mapping's value, not null
+     * @param k3 the third mapping's key, not null
+     * @param v3 the third mapping's value, not null
+     * @param k4 the fourth mapping's key, not null
+     * @param v4 the fourth mapping's value, not null
+     * @param k5 the fifth mapping's key, not null
+     * @param v5 the fifth mapping's value, not null
+     * @return a JSON object containing the specified mappings
+     * @throws NullPointerException  if any key or any value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(
+            final String k1, final JsonValue v1,
+            final String k2, final JsonValue v2,
+            final String k3, final JsonValue v3,
+            final String k4, final JsonValue v4,
+            final String k5, final JsonValue v5) {
+        return new JsonObject(
+                buildKeys(k1, k2, k3, k4, k5),
+                buildValues(v1, v2, v3, v4, v5));
+    }
+
+    /**
+     * Returns a JSON object containing the specified six JSON key-value mappings.
+     *
+     * @param k1 the first mapping's key, not null
+     * @param v1 the first mapping's value, not null
+     * @param k2 the second mapping's key, not null
+     * @param v2 the second mapping's value, not null
+     * @param k3 the third mapping's key, not null
+     * @param v3 the third mapping's value, not null
+     * @param k4 the fourth mapping's key, not null
+     * @param v4 the fourth mapping's value, not null
+     * @param k5 the fifth mapping's key, not null
+     * @param v5 the fifth mapping's value, not null
+     * @param k6 the sixth mapping's key, not null
+     * @param v6 the sixth mapping's value, not null
+     * @return a JSON object containing the specified mappings
+     * @throws NullPointerException  if any key or any value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(
+            final String k1, final JsonValue v1,
+            final String k2, final JsonValue v2,
+            final String k3, final JsonValue v3,
+            final String k4, final JsonValue v4,
+            final String k5, final JsonValue v5,
+            final String k6, final JsonValue v6) {
+        return new JsonObject(
+                buildKeys(k1, k2, k3, k4, k5, k6),
+                buildValues(v1, v2, v3, v4, v5, v6));
+    }
+
+    /**
+     * Returns a JSON object containing the specified seven JSON key-value mappings.
+     *
+     * @param k1 the first mapping's key, not null
+     * @param v1 the first mapping's value, not null
+     * @param k2 the second mapping's key, not null
+     * @param v2 the second mapping's value, not null
+     * @param k3 the third mapping's key, not null
+     * @param v3 the third mapping's value, not null
+     * @param k4 the fourth mapping's key, not null
+     * @param v4 the fourth mapping's value, not null
+     * @param k5 the fifth mapping's key, not null
+     * @param v5 the fifth mapping's value, not null
+     * @param k6 the sixth mapping's key, not null
+     * @param v6 the sixth mapping's value, not null
+     * @param k7 the seventh mapping's key, not null
+     * @param v7 the seventh mapping's value, not null
+     * @return a JSON object containing the specified mappings
+     * @throws NullPointerException  if any key or any value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(
+            final String k1, final JsonValue v1,
+            final String k2, final JsonValue v2,
+            final String k3, final JsonValue v3,
+            final String k4, final JsonValue v4,
+            final String k5, final JsonValue v5,
+            final String k6, final JsonValue v6,
+            final String k7, final JsonValue v7) {
+        return new JsonObject(
+                buildKeys(k1, k2, k3, k4, k5, k6, k7),
+                buildValues(v1, v2, v3, v4, v5, v6, v7));
+    }
+
+    /**
+     * Returns a JSON object containing the specified eight JSON key-value mappings.
+     *
+     * @param k1 the first mapping's key, not null
+     * @param v1 the first mapping's value, not null
+     * @param k2 the second mapping's key, not null
+     * @param v2 the second mapping's value, not null
+     * @param k3 the third mapping's key, not null
+     * @param v3 the third mapping's value, not null
+     * @param k4 the fourth mapping's key, not null
+     * @param v4 the fourth mapping's value, not null
+     * @param k5 the fifth mapping's key, not null
+     * @param v5 the fifth mapping's value, not null
+     * @param k6 the sixth mapping's key, not null
+     * @param v6 the sixth mapping's value, not null
+     * @param k7 the seventh mapping's key, not null
+     * @param v7 the seventh mapping's value, not null
+     * @param k8 the eighth mapping's key, not null
+     * @param v8 the eighth mapping's value, not null
+     * @return a JSON object containing the specified mappings
+     * @throws NullPointerException  if any key or any value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(
+            final String k1, final JsonValue v1,
+            final String k2, final JsonValue v2,
+            final String k3, final JsonValue v3,
+            final String k4, final JsonValue v4,
+            final String k5, final JsonValue v5,
+            final String k6, final JsonValue v6,
+            final String k7, final JsonValue v7,
+            final String k8, final JsonValue v8) {
+        return new JsonObject(
+                buildKeys(k1, k2, k3, k4, k5, k6, k7, k8),
+                buildValues(v1, v2, v3, v4, v5, v6, v7, v8));
+    }
+
+    /**
+     * Returns a JSON object containing the specified nine JSON key-value mappings.
+     *
+     * @param k1 the first mapping's key, not null
+     * @param v1 the first mapping's value, not null
+     * @param k2 the second mapping's key, not null
+     * @param v2 the second mapping's value, not null
+     * @param k3 the third mapping's key, not null
+     * @param v3 the third mapping's value, not null
+     * @param k4 the fourth mapping's key, not null
+     * @param v4 the fourth mapping's value, not null
+     * @param k5 the fifth mapping's key, not null
+     * @param v5 the fifth mapping's value, not null
+     * @param k6 the sixth mapping's key, not null
+     * @param v6 the sixth mapping's value, not null
+     * @param k7 the seventh mapping's key, not null
+     * @param v7 the seventh mapping's value, not null
+     * @param k8 the eighth mapping's key, not null
+     * @param v8 the eighth mapping's value, not null
+     * @param k9 the ninth mapping's key, not null
+     * @param v9 the ninth mapping's value, not null
+     * @return a JSON object containing the specified mappings
+     * @throws NullPointerException  if any key or any value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(
+            final String k1, final JsonValue v1,
+            final String k2, final JsonValue v2,
+            final String k3, final JsonValue v3,
+            final String k4, final JsonValue v4,
+            final String k5, final JsonValue v5,
+            final String k6, final JsonValue v6,
+            final String k7, final JsonValue v7,
+            final String k8, final JsonValue v8,
+            final String k9, final JsonValue v9) {
+        return new JsonObject(
+                buildKeys(k1, k2, k3, k4, k5, k6, k7, k8, k9),
+                buildValues(v1, v2, v3, v4, v5, v6, v7, v8, v9));
+    }
+
+    /**
+     * Returns a JSON object containing the specified ten JSON key-value mappings.
+     *
+     * @param k1 the first mapping's key, not null
+     * @param v1 the first mapping's value, not null
+     * @param k2 the second mapping's key, not null
+     * @param v2 the second mapping's value, not null
+     * @param k3 the third mapping's key, not null
+     * @param v3 the third mapping's value, not null
+     * @param k4 the fourth mapping's key, not null
+     * @param v4 the fourth mapping's value, not null
+     * @param k5 the fifth mapping's key, not null
+     * @param v5 the fifth mapping's value, not null
+     * @param k6 the sixth mapping's key, not null
+     * @param v6 the sixth mapping's value, not null
+     * @param k7 the seventh mapping's key, not null
+     * @param v7 the seventh mapping's value, not null
+     * @param k8 the eighth mapping's key, not null
+     * @param v8 the eighth mapping's value, not null
+     * @param k9 the ninth mapping's key, not null
+     * @param v9 the ninth mapping's value, not null
+     * @param k10 the tenth mapping's key, not null
+     * @param v10 the tenth mapping's value, not null
+     * @return a JSON object containing the specified mappings
+     * @throws NullPointerException  if any key or any value is {@code null}
+     *
+     * @since 0.10.42
+     */
+    public static JsonObject of(
+            final String k1, final JsonValue v1,
+            final String k2, final JsonValue v2,
+            final String k3, final JsonValue v3,
+            final String k4, final JsonValue v4,
+            final String k5, final JsonValue v5,
+            final String k6, final JsonValue v6,
+            final String k7, final JsonValue v7,
+            final String k8, final JsonValue v8,
+            final String k9, final JsonValue v9,
+            final String k10, final JsonValue v10) {
+        return new JsonObject(
+                buildKeys(k1, k2, k3, k4, k5, k6, k7, k8, k9, k10),
+                buildValues(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10));
+    }
+
+    /**
      * Returns a JSON object containing an arbitrary number of JSON key-value mappings.
      *
      * <p>Keys and values are specified as varargs. Even numbers of arguments must be specified. Where <i>i</i> as an
@@ -573,6 +878,24 @@ public final class JsonObject extends AbstractMap<String, JsonValue> implements 
         private final JsonValue[] values;
 
         private int index;
+    }
+
+    private static String[] buildKeys(final String... keys) {
+        for (final String key : keys) {
+            if (key == null) {
+                throw new NullPointerException("null in keys.");
+            }
+        }
+        return keys;
+    }
+
+    private static JsonValue[] buildValues(final JsonValue... values) {
+        for (final JsonValue value : values) {
+            if (value == null) {
+                throw new NullPointerException("null in values.");
+            }
+        }
+        return values;
     }
 
     private static final JsonObject EMPTY = new JsonObject(new String[0], new JsonValue[0]);

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
@@ -436,4 +436,181 @@ public class TestJsonObject {
                 IllegalArgumentException.class, () -> JsonObject.of(JsonBoolean.TRUE, JsonBoolean.TRUE));
         assertEquals("JsonString must be specified as a key for JsonObject#of(...).", ex3.getMessage());
     }
+
+    @Test
+    public void testOf1() {
+        final JsonObject o1 = JsonObject.of("k1", JsonLong.of(1));
+        assertEquals(1, o1.size());
+        assertEquals(JsonLong.of(1), o1.get("k1"));
+    }
+
+    @Test
+    public void testOf2() {
+        final JsonObject o = JsonObject.of(
+                "k1", JsonLong.of(1),
+                "k2", JsonLong.of(2));
+        assertEquals(2, o.size());
+        assertEquals(JsonLong.of(1), o.get("k1"));
+        assertEquals(JsonLong.of(2), o.get("k2"));
+    }
+
+    @Test
+    public void testOf3() {
+        final JsonObject o = JsonObject.of(
+                "k1", JsonLong.of(1),
+                "k2", JsonLong.of(2),
+                "k3", JsonLong.of(3));
+        assertEquals(3, o.size());
+        assertEquals(JsonLong.of(1), o.get("k1"));
+        assertEquals(JsonLong.of(2), o.get("k2"));
+        assertEquals(JsonLong.of(3), o.get("k3"));
+    }
+
+    @Test
+    public void testOf4() {
+        final JsonObject o = JsonObject.of(
+                "k1", JsonLong.of(1),
+                "k2", JsonLong.of(2),
+                "k3", JsonLong.of(3),
+                "k4", JsonLong.of(4));
+        assertEquals(4, o.size());
+        assertEquals(JsonLong.of(1), o.get("k1"));
+        assertEquals(JsonLong.of(2), o.get("k2"));
+        assertEquals(JsonLong.of(3), o.get("k3"));
+        assertEquals(JsonLong.of(4), o.get("k4"));
+    }
+
+    @Test
+    public void testOf5() {
+        final JsonObject o = JsonObject.of(
+                "k1", JsonLong.of(1),
+                "k2", JsonLong.of(2),
+                "k3", JsonLong.of(3),
+                "k4", JsonLong.of(4),
+                "k5", JsonLong.of(5));
+        assertEquals(5, o.size());
+        assertEquals(JsonLong.of(1), o.get("k1"));
+        assertEquals(JsonLong.of(2), o.get("k2"));
+        assertEquals(JsonLong.of(3), o.get("k3"));
+        assertEquals(JsonLong.of(4), o.get("k4"));
+        assertEquals(JsonLong.of(5), o.get("k5"));
+    }
+
+    @Test
+    public void testOf6() {
+        final JsonObject o = JsonObject.of(
+                "k1", JsonLong.of(1),
+                "k2", JsonLong.of(2),
+                "k3", JsonLong.of(3),
+                "k4", JsonLong.of(4),
+                "k5", JsonLong.of(5),
+                "k6", JsonLong.of(6));
+        assertEquals(6, o.size());
+        assertEquals(JsonLong.of(1), o.get("k1"));
+        assertEquals(JsonLong.of(2), o.get("k2"));
+        assertEquals(JsonLong.of(3), o.get("k3"));
+        assertEquals(JsonLong.of(4), o.get("k4"));
+        assertEquals(JsonLong.of(5), o.get("k5"));
+        assertEquals(JsonLong.of(6), o.get("k6"));
+    }
+
+    @Test
+    public void testOf7() {
+        final JsonObject o = JsonObject.of(
+                "k1", JsonLong.of(1),
+                "k2", JsonLong.of(2),
+                "k3", JsonLong.of(3),
+                "k4", JsonLong.of(4),
+                "k5", JsonLong.of(5),
+                "k6", JsonLong.of(6),
+                "k7", JsonLong.of(7));
+        assertEquals(7, o.size());
+        assertEquals(JsonLong.of(1), o.get("k1"));
+        assertEquals(JsonLong.of(2), o.get("k2"));
+        assertEquals(JsonLong.of(3), o.get("k3"));
+        assertEquals(JsonLong.of(4), o.get("k4"));
+        assertEquals(JsonLong.of(5), o.get("k5"));
+        assertEquals(JsonLong.of(6), o.get("k6"));
+        assertEquals(JsonLong.of(7), o.get("k7"));
+    }
+
+    @Test
+    public void testOf8() {
+        final JsonObject o = JsonObject.of(
+                "k1", JsonLong.of(1),
+                "k2", JsonLong.of(2),
+                "k3", JsonLong.of(3),
+                "k4", JsonLong.of(4),
+                "k5", JsonLong.of(5),
+                "k6", JsonLong.of(6),
+                "k7", JsonLong.of(7),
+                "k8", JsonLong.of(8));
+        assertEquals(8, o.size());
+        assertEquals(JsonLong.of(1), o.get("k1"));
+        assertEquals(JsonLong.of(2), o.get("k2"));
+        assertEquals(JsonLong.of(3), o.get("k3"));
+        assertEquals(JsonLong.of(4), o.get("k4"));
+        assertEquals(JsonLong.of(5), o.get("k5"));
+        assertEquals(JsonLong.of(6), o.get("k6"));
+        assertEquals(JsonLong.of(7), o.get("k7"));
+        assertEquals(JsonLong.of(8), o.get("k8"));
+    }
+
+    @Test
+    public void testOf9() {
+        final JsonObject o = JsonObject.of(
+                "k1", JsonLong.of(1),
+                "k2", JsonLong.of(2),
+                "k3", JsonLong.of(3),
+                "k4", JsonLong.of(4),
+                "k5", JsonLong.of(5),
+                "k6", JsonLong.of(6),
+                "k7", JsonLong.of(7),
+                "k8", JsonLong.of(8),
+                "k9", JsonLong.of(9));
+        assertEquals(9, o.size());
+        assertEquals(JsonLong.of(1), o.get("k1"));
+        assertEquals(JsonLong.of(2), o.get("k2"));
+        assertEquals(JsonLong.of(3), o.get("k3"));
+        assertEquals(JsonLong.of(4), o.get("k4"));
+        assertEquals(JsonLong.of(5), o.get("k5"));
+        assertEquals(JsonLong.of(6), o.get("k6"));
+        assertEquals(JsonLong.of(7), o.get("k7"));
+        assertEquals(JsonLong.of(8), o.get("k8"));
+        assertEquals(JsonLong.of(9), o.get("k9"));
+    }
+
+    @Test
+    public void testOf10() {
+        final JsonObject o = JsonObject.of(
+                "k1", JsonLong.of(1),
+                "k2", JsonLong.of(2),
+                "k3", JsonLong.of(3),
+                "k4", JsonLong.of(4),
+                "k5", JsonLong.of(5),
+                "k6", JsonLong.of(6),
+                "k7", JsonLong.of(7),
+                "k8", JsonLong.of(8),
+                "k9", JsonLong.of(9),
+                "k10", JsonLong.of(10));
+        assertEquals(10, o.size());
+        assertEquals(JsonLong.of(1), o.get("k1"));
+        assertEquals(JsonLong.of(2), o.get("k2"));
+        assertEquals(JsonLong.of(3), o.get("k3"));
+        assertEquals(JsonLong.of(4), o.get("k4"));
+        assertEquals(JsonLong.of(5), o.get("k5"));
+        assertEquals(JsonLong.of(6), o.get("k6"));
+        assertEquals(JsonLong.of(7), o.get("k7"));
+        assertEquals(JsonLong.of(8), o.get("k8"));
+        assertEquals(JsonLong.of(9), o.get("k9"));
+        assertEquals(JsonLong.of(10), o.get("k10"));
+    }
+
+    @Test
+    public void testOfNulls() {
+        assertThrows(NullPointerException.class, () -> JsonObject.of("k1", null));
+        assertThrows(NullPointerException.class, () -> JsonObject.of(null, JsonNull.of()));
+        assertThrows(NullPointerException.class, () -> JsonObject.of("k1", JsonString.of("f"), null, JsonNull.of()));
+        assertThrows(NullPointerException.class, () -> JsonObject.of("k1", JsonLong.of(13423), "k2", null));
+    }
 }


### PR DESCRIPTION
Follow-up to: #1462

It just adds a lot of convenient creator methods `JsonObject.of(String, JsonValue, ...)` that are similar to `Map` in Java 9+.

https://docs.oracle.com/javase/9/docs/api/java/util/Map.html
