### PR TITLE
Change JsonValue classes to back with msgpack-java classes

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonBoolean.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonBoolean.java
@@ -16,6 +16,9 @@
 
 package org.embulk.spi.json;
 
+import org.msgpack.value.Value;
+import org.msgpack.value.impl.ImmutableBooleanValueImpl;
+
 /**
  * Represents {@code true} or {@code false} in JSON.
  *
@@ -128,6 +131,28 @@ public final class JsonBoolean implements JsonValue {
             return "true";
         }
         return "false";
+    }
+
+    /**
+     * Returns the corresponding MessagePack's Boolean value of this JSON {@code true} or {@code false}.
+     *
+     * @return the corresponding MessagePack's Boolean value of this JSON {@code true} or {@code false}
+     *
+     * @see <a href="https://github.com/embulk/embulk/pull/1538">Draft EEP: JSON Column Type</a>
+     *
+     * @deprecated Do not use this method. It is to be removed at some point after Embulk v1.0.0.
+     *     It is here only to ensure a migration period from MessagePack-based JSON values to new
+     *     JSON values of {@link JsonValue}.
+     *
+     * @since 0.10.42
+     */
+    @Deprecated
+    @Override
+    public Value toMsgpack() {
+        if (this.value) {
+            return ImmutableBooleanValueImpl.TRUE;
+        }
+        return ImmutableBooleanValueImpl.FALSE;
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
@@ -18,6 +18,8 @@ package org.embulk.spi.json;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import org.msgpack.value.Value;
+import org.msgpack.value.impl.ImmutableDoubleValueImpl;
 
 /**
  * Represents a number in JSON, represented by a Java primitive {@code double}, which is the same as Embulk's {@code DOUBLE} column type.
@@ -36,7 +38,7 @@ public final class JsonDouble implements JsonNumber {
         if (Double.isInfinite(value)) {
             throw new ArithmeticException("JsonDouble does not accept the infinity.");
         }
-        this.value = value;
+        this.value = new ImmutableDoubleValueImpl(value);
         this.literal = literal;
     }
 
@@ -130,7 +132,8 @@ public final class JsonDouble implements JsonNumber {
         // |this.value| must not be NaN nor infinite. If JsonDouble supports NaN or the infinity in the future, check also:
         //
         //     !Double.isNaN(this.value) && !Double.isInfinite(this.value)
-        return this.value == Math.rint(this.value);
+        final double inner = this.value.toDouble();
+        return inner == Math.rint(inner);
     }
 
     /**
@@ -142,7 +145,7 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public boolean isByteValue() {
-        return this.isIntegral() && ((double) Byte.MIN_VALUE) <= this.value && this.value <= ((double) Byte.MAX_VALUE);
+        return this.isIntegral() && ((double) Byte.MIN_VALUE) <= this.value.toDouble() && this.value.toDouble() <= ((double) Byte.MAX_VALUE);
     }
 
     /**
@@ -154,7 +157,7 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public boolean isShortValue() {
-        return this.isIntegral() && ((double) Short.MIN_VALUE) <= this.value && this.value <= ((double) Short.MAX_VALUE);
+        return this.isIntegral() && ((double) Short.MIN_VALUE) <= this.value.toDouble() && this.value.toDouble() <= ((double) Short.MAX_VALUE);
     }
 
     /**
@@ -166,7 +169,7 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public boolean isIntValue() {
-        return this.isIntegral() && ((double) Integer.MIN_VALUE) <= this.value && this.value <= ((double) Integer.MAX_VALUE);
+        return this.isIntegral() && ((double) Integer.MIN_VALUE) <= this.value.toDouble() && this.value.toDouble() <= ((double) Integer.MAX_VALUE);
     }
 
     /**
@@ -178,7 +181,7 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public boolean isLongValue() {
-        return this.isIntegral() && ((double) Long.MIN_VALUE) <= this.value && this.value <= ((double) Long.MAX_VALUE);
+        return this.isIntegral() && ((double) Long.MIN_VALUE) <= this.value.toDouble() && this.value.toDouble() <= ((double) Long.MAX_VALUE);
     }
 
     /**
@@ -195,7 +198,7 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public byte byteValue() {
-        return (byte) this.value;
+        return this.value.toByte();
     }
 
     /**
@@ -214,7 +217,7 @@ public final class JsonDouble implements JsonNumber {
         if (!this.isByteValue()) {
             throw new ArithmeticException("Out of the range of byte, or not integral: " + this.value);
         }
-        return (byte) this.value;
+        return this.value.toByte();
     }
 
     /**
@@ -231,7 +234,7 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public short shortValue() {
-        return (short) this.value;
+        return this.value.toShort();
     }
 
     /**
@@ -250,7 +253,7 @@ public final class JsonDouble implements JsonNumber {
         if (!this.isShortValue()) {
             throw new ArithmeticException("Out of the range of short, or not integral: " + this.value);
         }
-        return (short) this.value;
+        return this.value.toShort();
     }
 
     /**
@@ -267,7 +270,7 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public int intValue() {
-        return (int) this.value;
+        return this.value.toInt();
     }
 
     /**
@@ -286,7 +289,7 @@ public final class JsonDouble implements JsonNumber {
         if (!this.isIntValue()) {
             throw new ArithmeticException("Out of the range of int, or not integral: " + this.value);
         }
-        return (int) this.value;
+        return this.value.toInt();
     }
 
     /**
@@ -303,7 +306,7 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public long longValue() {
-        return (long) this.value;
+        return this.value.toLong();
     }
 
     /**
@@ -322,7 +325,7 @@ public final class JsonDouble implements JsonNumber {
         if (!this.isLongValue()) {
             throw new ArithmeticException("Out of the range of long, or not integral: " + this.value);
         }
-        return (long) this.value;
+        return this.value.toLong();
     }
 
     /**
@@ -337,7 +340,7 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public BigInteger bigIntegerValue() {
-        return BigDecimal.valueOf(this.value).toBigInteger();
+        return BigDecimal.valueOf(this.value.toDouble()).toBigInteger();
     }
 
     /**
@@ -352,7 +355,7 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public BigInteger bigIntegerValueExact() {
-        return BigDecimal.valueOf(this.value).toBigIntegerExact();
+        return BigDecimal.valueOf(this.value.toDouble()).toBigIntegerExact();
     }
 
     /**
@@ -370,7 +373,7 @@ rrowing Primitive Conversion</a>
      */
     @Override
     public float floatValue() {
-        return (float) this.value;
+        return this.value.toFloat();
     }
 
     /**
@@ -383,7 +386,7 @@ rrowing Primitive Conversion</a>
      */
     @Override
     public double doubleValue() {
-        return this.value;
+        return this.value.toDouble();
     }
 
     /**
@@ -393,7 +396,7 @@ rrowing Primitive Conversion</a>
      */
     @Override
     public BigDecimal bigDecimalValue() {
-        return BigDecimal.valueOf(this.value);
+        return BigDecimal.valueOf(this.value.toDouble());
     }
 
     /**
@@ -411,7 +414,26 @@ rrowing Primitive Conversion</a>
         if (this.literal != null) {
             return this.literal;
         }
-        return Double.toString(this.value);
+        return Double.toString(this.value.toDouble());
+    }
+
+    /**
+     * Returns the corresponding MessagePack's Float value of this JSON number.
+     *
+     * @return the corresponding MessagePack's Float value of this JSON number
+     *
+     * @see <a href="https://github.com/embulk/embulk/pull/1538">Draft EEP: JSON Column Type</a>
+     *
+     * @deprecated Do not use this method. It is to be removed at some point after Embulk v1.0.0.
+     *     It is here only to ensure a migration period from MessagePack-based JSON values to new
+     *     JSON values of {@link JsonValue}.
+     *
+     * @since 0.10.42
+     */
+    @Deprecated
+    @Override
+    public Value toMsgpack() {
+        return this.value;
     }
 
     /**
@@ -424,7 +446,7 @@ rrowing Primitive Conversion</a>
     @Override
     public String toString() {
         // |this.value| must not be NaN nor infinite. Consider the output if JsonDouble supports NaN or the infinity in the future.
-        return Double.toString(this.value);
+        return Double.toString(this.value.toDouble());
     }
 
     /**
@@ -447,7 +469,7 @@ rrowing Primitive Conversion</a>
 
         final JsonDouble other = (JsonDouble) otherObject;
 
-        return this.value == other.value;
+        return this.value.equals(other.value);
     }
 
     /**
@@ -459,11 +481,10 @@ rrowing Primitive Conversion</a>
      */
     @Override
     public int hashCode() {
-        final long bits = Double.doubleToLongBits(this.value);
-        return (int) (bits ^ (bits >>> 32));
+        return this.value.hashCode();
     }
 
-    private final double value;
+    private final ImmutableDoubleValueImpl value;
 
     private final String literal;
 }

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonNull.java
@@ -16,6 +16,9 @@
 
 package org.embulk.spi.json;
 
+import org.msgpack.value.Value;
+import org.msgpack.value.impl.ImmutableNilValueImpl;
+
 /**
  * Represents {@code null} in JSON.
  *
@@ -103,6 +106,25 @@ public final class JsonNull implements JsonValue {
     @Override
     public String toJson() {
         return "null";
+    }
+
+    /**
+     * Returns the corresponding MessagePack's Nil value of this JSON {@code null}.
+     *
+     * @return the corresponding MessagePack's Nil value of this JSON {@code null}
+     *
+     * @see <a href="https://github.com/embulk/embulk/pull/1538">Draft EEP: JSON Column Type</a>
+     *
+     * @deprecated Do not use this method. It is to be removed at some point after Embulk v1.0.0.
+     *     It is here only to ensure a migration period from MessagePack-based JSON values to new
+     *     JSON values of {@link JsonValue}.
+     *
+     * @since 0.10.42
+     */
+    @Deprecated
+    @Override
+    public Value toMsgpack() {
+        return ImmutableNilValueImpl.get();
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonValue.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonValue.java
@@ -16,6 +16,8 @@
 
 package org.embulk.spi.json;
 
+import org.msgpack.value.Value;
+
 /**
  * Represents a value in JSON: {@code null}, {@code true}, {@code false}, numbers, strings, arrays, or objects.
  *
@@ -375,4 +377,20 @@ public interface JsonValue {
      * @since 0.10.42
      */
     String toJson();
+
+    /**
+     * Returns the corresponding MessagePack's value object of this JSON value.
+     *
+     * @return the corresponding MessagePack's value object of this JSON value
+     *
+     * @see <a href="https://github.com/embulk/embulk/pull/1538">Draft EEP: JSON Column Type</a>
+     *
+     * @deprecated Do not use this method. It is to be removed at some point after Embulk v1.0.0.
+     *     It is here only to ensure a migration period from MessagePack-based JSON values to new
+     *     JSON values of {@link JsonValue}.
+     *
+     * @since 0.10.42
+     */
+    @Deprecated
+    Value toMsgpack();
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonBoolean.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonBoolean.java
@@ -16,6 +16,9 @@
 
 package org.embulk.spi.json;
 
+import org.msgpack.value.Value;
+import org.msgpack.value.impl.ImmutableBooleanValueImpl;
+
 public final class FakeJsonBoolean implements JsonValue {
     private FakeJsonBoolean(final boolean value) {
         this.value = value;
@@ -45,6 +48,14 @@ public final class FakeJsonBoolean implements JsonValue {
             return "true";
         }
         return "false";
+    }
+
+    @Deprecated
+    public Value toMsgpack() {
+        if (this.value) {
+            return ImmutableBooleanValueImpl.TRUE;
+        }
+        return ImmutableBooleanValueImpl.FALSE;
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonLong.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonLong.java
@@ -18,10 +18,12 @@ package org.embulk.spi.json;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import org.msgpack.value.Value;
+import org.msgpack.value.impl.ImmutableLongValueImpl;
 
 public final class FakeJsonLong implements JsonValue {
     private FakeJsonLong(final long value) {
-        this.value = value;
+        this.value = new ImmutableLongValueImpl(value);
     }
 
     public static FakeJsonLong of(final long value) {
@@ -43,15 +45,15 @@ public final class FakeJsonLong implements JsonValue {
     }
 
     public boolean isByteValue() {
-        return ((long) Byte.MIN_VALUE) <= this.value && this.value <= ((long) Byte.MAX_VALUE);
+        return this.value.isInByteRange();
     }
 
     public boolean isShortValue() {
-        return ((long) Short.MIN_VALUE) <= this.value && this.value <= ((long) Short.MAX_VALUE);
+        return this.value.isInShortRange();
     }
 
     public boolean isIntValue() {
-        return ((long) Integer.MIN_VALUE) <= this.value && this.value <= ((long) Integer.MAX_VALUE);
+        return this.value.isInIntRange();
     }
 
     public boolean isLongValue() {
@@ -59,74 +61,79 @@ public final class FakeJsonLong implements JsonValue {
     }
 
     public byte byteValue() {
-        return (byte) this.value;
+        return this.value.toByte();
     }
 
     public byte byteValueExact() {
         if (!this.isByteValue()) {
             throw new ArithmeticException("Out of the range of byte: " + this.value);
         }
-        return (byte) this.value;
+        return this.value.toByte();
     }
 
     public short shortValue() {
-        return (short) this.value;
+        return this.value.toShort();
     }
 
     public short shortValueExact() {
         if (!this.isShortValue()) {
             throw new ArithmeticException("Out of the range of short: " + this.value);
         }
-        return (short) this.value;
+        return this.value.toShort();
     }
 
     public int intValue() {
-        return (int) this.value;
+        return this.value.toInt();
     }
 
     public int intValueExact() {
         if (!this.isIntValue()) {
             throw new ArithmeticException("Out of the range of int: " + this.value);
         }
-        return (int) this.value;
+        return this.value.toInt();
     }
 
     public long longValue() {
-        return (long) this.value;
+        return this.value.toLong();
     }
 
     public long longValueExact() {
-        return (long) this.value;
+        return this.value.toLong();
     }
 
     public BigInteger bigIntegerValue() {
-        return BigInteger.valueOf(this.value);
+        return this.value.toBigInteger();
     }
 
     public BigInteger bigIntegerValueExact() {
-        return BigInteger.valueOf(this.value);
+        return this.value.toBigInteger();
     }
 
     public float floatValue() {
-        return (float) this.value;
+        return this.value.toFloat();
     }
 
     public double doubleValue() {
-        return (double) this.value;
+        return this.value.toDouble();
     }
 
     public BigDecimal bigDecimalValue() {
-        return BigDecimal.valueOf(this.value);
+        return BigDecimal.valueOf(this.value.toLong());
     }
 
     @Override
     public String toJson() {
-        return Long.toString(this.value);
+        return Long.toString(this.value.toLong());
+    }
+
+    @Deprecated
+    public Value toMsgpack() {
+        return this.value;
     }
 
     @Override
     public String toString() {
-        return Long.toString(this.value);
+        return Long.toString(this.value.toLong());
     }
 
     @Override
@@ -138,7 +145,7 @@ public final class FakeJsonLong implements JsonValue {
         // Fake!
         if (otherObject instanceof JsonLong) {
             final JsonLong other = (JsonLong) otherObject;
-            return this.value == other.longValue();
+            return this.longValue() == other.longValue();
         }
 
         // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
@@ -148,16 +155,13 @@ public final class FakeJsonLong implements JsonValue {
 
         final FakeJsonLong other = (FakeJsonLong) otherObject;
 
-        return this.value == other.value;
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        if (((long) Integer.MIN_VALUE) <= this.value && this.value <= ((long) Integer.MAX_VALUE)) {
-            return (int) value;
-        }
-        return (int) (value ^ (value >>> 32));
+        return this.value.hashCode();
     }
 
-    private final long value;
+    private final ImmutableLongValueImpl value;
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonNull.java
@@ -16,6 +16,9 @@
 
 package org.embulk.spi.json;
 
+import org.msgpack.value.Value;
+import org.msgpack.value.impl.ImmutableNilValueImpl;
+
 public final class FakeJsonNull implements JsonValue {
     private FakeJsonNull() {
         // No direct instantiation.
@@ -40,6 +43,11 @@ public final class FakeJsonNull implements JsonValue {
     @Override
     public String toJson() {
         return "null";
+    }
+
+    @Deprecated
+    public Value toMsgpack() {
+        return ImmutableNilValueImpl.get();
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonObject.java
@@ -23,11 +23,15 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import org.msgpack.value.Value;
+import org.msgpack.value.impl.ImmutableMapValueImpl;
+import org.msgpack.value.impl.ImmutableStringValueImpl;
 
 public final class FakeJsonObject extends AbstractMap<String, JsonValue> implements JsonValue {
     private FakeJsonObject(final String[] keys, final JsonValue[] values) {
         this.keys = keys;
         this.values = values;
+        this.msgpackMapCache = null;
     }
 
     public static FakeJsonObject of(final JsonValue... keyValues) {
@@ -103,6 +107,21 @@ public final class FakeJsonObject extends AbstractMap<String, JsonValue> impleme
         }
         builder.append("}");
         return builder.toString();
+    }
+
+    @Deprecated
+    public Value toMsgpack() {
+        if (this.msgpackMapCache != null) {
+            return this.msgpackMapCache;
+        }
+
+        final Value[] msgpackKeyValues = new Value[this.keys.length * 2];
+        for (int i = 0; i < this.keys.length; i++) {
+            msgpackKeyValues[i * 2] = new ImmutableStringValueImpl(this.keys[i]);
+            msgpackKeyValues[i * 2 + 1] = this.values[i].toMsgpack();
+        }
+        this.msgpackMapCache = new ImmutableMapValueImpl(msgpackKeyValues);
+        return this.msgpackMapCache;
     }
 
     @Override
@@ -215,4 +234,6 @@ public final class FakeJsonObject extends AbstractMap<String, JsonValue> impleme
 
     private final String[] keys;
     private final JsonValue[] values;
+
+    private ImmutableMapValueImpl msgpackMapCache;
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonString.java
@@ -17,10 +17,12 @@
 package org.embulk.spi.json;
 
 import java.util.Objects;
+import org.msgpack.value.Value;
+import org.msgpack.value.impl.ImmutableStringValueImpl;
 
 public final class FakeJsonString implements JsonValue {
     private FakeJsonString(final String value) {
-        this.value = value;
+        this.value = new ImmutableStringValueImpl(value);
     }
 
     public static FakeJsonString of(final String value) {
@@ -34,25 +36,30 @@ public final class FakeJsonString implements JsonValue {
 
     @Override
     public int presumeReferenceSizeInBytes() {
-        return this.value.length() * 2 + 4;
+        return this.value.asString().length() * 2 + 4;
     }
 
     public String getString() {
-        return this.value;
+        return this.value.asString();
     }
 
     public CharSequence getChars() {
-        return this.value;
+        return this.value.asString();
     }
 
     @Override
     public String toJson() {
-        return escapeStringForJsonLiteral(this.value).toString();
+        return escapeStringForJsonLiteral(this.value.asString());
+    }
+
+    @Deprecated
+    public Value toMsgpack() {
+        return this.value;
     }
 
     @Override
     public String toString() {
-        return escapeStringForJsonLiteral(this.value).toString();
+        return escapeStringForJsonLiteral(this.value.asString());
     }
 
     @Override
@@ -63,7 +70,7 @@ public final class FakeJsonString implements JsonValue {
 
         // Fake!
         if (otherObject instanceof JsonString) {
-            return Objects.equals(this.value, ((JsonString) otherObject).getString());
+            return Objects.equals(this.value.asString(), ((JsonString) otherObject).getString());
         }
 
         // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
@@ -73,12 +80,12 @@ public final class FakeJsonString implements JsonValue {
 
         final FakeJsonString other = (FakeJsonString) otherObject;
 
-        return Objects.equals(this.value, other.value);
+        return Objects.equals(this.value.asString(), other.value.asString());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.value);
+        return Objects.hashCode(this.value.asString());
     }
 
     static void appendEscapedStringForJsonLiteral(final String original, final StringBuilder builder) {
@@ -163,5 +170,5 @@ public final class FakeJsonString implements JsonValue {
         return builder.toString();
     }
 
-    private final String value;
+    private final ImmutableStringValueImpl value;
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
+import org.msgpack.value.ValueFactory;
 
 public class TestJsonArray {
     @Test
@@ -69,6 +70,8 @@ public class TestJsonArray {
         assertEquals("[]", jsonArray.toString());
         assertEquals(JsonArray.of(), jsonArray);
 
+        assertEquals(ValueFactory.emptyArray(), jsonArray.toMsgpack());
+
         // JsonArray#equals must normally reject a fake imitation of JsonArray.
         assertFalse(jsonArray.equals(FakeJsonArray.of()));
     }
@@ -98,6 +101,8 @@ public class TestJsonArray {
         assertEquals("[987]", jsonArray.toJson());
         assertEquals("[987]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonLong.of(987)), jsonArray);
+
+        assertEquals(ValueFactory.newArray(ValueFactory.newInteger(987)), jsonArray.toMsgpack());
 
         // JsonArray#equals must normally reject a fake imitation of JsonArray.
         assertFalse(jsonArray.equals(FakeJsonArray.of(JsonLong.of(987))));
@@ -149,6 +154,10 @@ public class TestJsonArray {
         assertEquals("[987,\"foo\",true]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonLong.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
 
+        assertEquals(
+                ValueFactory.newArray(ValueFactory.newInteger(987), ValueFactory.newString("foo"), ValueFactory.newBoolean(true)),
+                jsonArray.toMsgpack());
+
         // JsonArray#equals must normally reject a fake imitation of JsonArray.
         assertFalse(jsonArray.equals(FakeJsonArray.of(JsonLong.of(987), JsonString.of("foo"), JsonBoolean.TRUE)));
     }
@@ -198,6 +207,10 @@ public class TestJsonArray {
         assertEquals("[987,\"foo\",true]", jsonArray.toJson());
         assertEquals("[987,\"foo\",true]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonLong.of(987), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);
+
+        assertEquals(
+                ValueFactory.newArray(ValueFactory.newInteger(987), ValueFactory.newString("foo"), ValueFactory.newBoolean(true)),
+                jsonArray.toMsgpack());
 
         // JsonArray#equals must normally reject a fake imitation of JsonArray.
         assertFalse(jsonArray.equals(FakeJsonArray.of(JsonLong.of(987), JsonString.of("foo"), JsonBoolean.TRUE)));
@@ -249,6 +262,10 @@ public class TestJsonArray {
         assertEquals("[1234,\"foo\",true]", jsonArray.toString());  // Updated
         assertEquals(JsonArray.of(JsonLong.of(1234), JsonString.of("foo"), JsonBoolean.TRUE), jsonArray);  // Updated
 
+        assertEquals(
+                ValueFactory.newArray(ValueFactory.newInteger(1234), ValueFactory.newString("foo"), ValueFactory.newBoolean(true)),
+                jsonArray.toMsgpack());
+
         // JsonArray#equals must normally reject a fake imitation of JsonArray.
         assertFalse(jsonArray.equals(FakeJsonArray.of(JsonLong.of(1234), JsonString.of("foo"), JsonBoolean.TRUE)));
     }
@@ -297,6 +314,14 @@ public class TestJsonArray {
         assertEquals("[987,[\"foo\",\"bar\",\"baz\"],true]", jsonArray.toJson());
         assertEquals("[987,[\"foo\",\"bar\",\"baz\"],true]", jsonArray.toString());
         assertEquals(JsonArray.of(JsonLong.of(987), JsonArray.of(JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")), JsonBoolean.TRUE), jsonArray);
+
+        assertEquals(
+                ValueFactory.newArray(
+                        ValueFactory.newInteger(987),
+                        ValueFactory.newArray(
+                                ValueFactory.newString("foo"), ValueFactory.newString("bar"), ValueFactory.newString("baz")),
+                        ValueFactory.newBoolean(true)),
+                jsonArray.toMsgpack());
 
         // JsonArray#equals must normally reject a fake imitation of JsonArray.
         assertFalse(jsonArray.equals(

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonBoolean.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonBoolean.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
+import org.msgpack.value.ValueFactory;
 
 public class TestJsonBoolean {
     @Test
@@ -56,6 +57,8 @@ public class TestJsonBoolean {
         assertEquals(JsonBoolean.FALSE, jsonBoolean);
         assertTrue(JsonBoolean.FALSE == jsonBoolean);
 
+        assertEquals(ValueFactory.newBoolean(false), jsonBoolean.toMsgpack());
+
         // JsonBoolean#equals must normally reject a fake imitation of JsonBoolean.
         assertFalse(jsonBoolean.equals(FakeJsonBoolean.FAKE_FALSE));
         assertFalse(jsonBoolean.equals(FakeJsonBoolean.FAKE_TRUE));
@@ -85,6 +88,8 @@ public class TestJsonBoolean {
         assertEquals("true", jsonBoolean.toString());
         assertEquals(JsonBoolean.TRUE, jsonBoolean);
         assertTrue(JsonBoolean.TRUE == jsonBoolean);
+
+        assertEquals(ValueFactory.newBoolean(true), jsonBoolean.toMsgpack());
 
         // JsonBoolean#equals must normally reject a fake imitation of JsonBoolean.
         assertFalse(jsonBoolean.equals(FakeJsonBoolean.FAKE_FALSE));

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDouble.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDouble.java
@@ -27,6 +27,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import org.junit.jupiter.api.Test;
+import org.msgpack.value.ValueFactory;
 
 public class TestJsonDouble {
     @Test
@@ -87,6 +88,8 @@ public class TestJsonDouble {
         assertEquals("1.234567890123456E9", jsonDouble.toString());
         assertEquals(JsonDouble.of(1234567890.123456), jsonDouble);
 
+        assertEquals(ValueFactory.newFloat(1234567890.123456), jsonDouble.toMsgpack());
+
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
     }
@@ -137,6 +140,8 @@ public class TestJsonDouble {
         assertEquals("0.0", jsonDouble.toJson());
         assertEquals("0.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(0.0), jsonDouble);
+
+        assertEquals(ValueFactory.newFloat(0.0), jsonDouble.toMsgpack());
 
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
@@ -189,6 +194,8 @@ public class TestJsonDouble {
         assertEquals("-0.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(0.0), jsonDouble);
 
+        assertEquals(ValueFactory.newFloat(-0.0), jsonDouble.toMsgpack());
+
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
     }
@@ -237,6 +244,8 @@ public class TestJsonDouble {
         assertEquals("1.0", jsonDouble.toJson());
         assertEquals("1.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(1.0), jsonDouble);
+
+        assertEquals(ValueFactory.newFloat(1.0), jsonDouble.toMsgpack());
 
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
@@ -287,6 +296,8 @@ public class TestJsonDouble {
         assertEquals("-1.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(-1.0), jsonDouble);
 
+        assertEquals(ValueFactory.newFloat(-1.0), jsonDouble.toMsgpack());
+
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
     }
@@ -333,6 +344,8 @@ public class TestJsonDouble {
         assertEquals("3.1415", jsonDouble.toJson());
         assertEquals("3.1415", jsonDouble.toString());
         assertEquals(JsonDouble.of(3.1415), jsonDouble);
+
+        assertEquals(ValueFactory.newFloat(3.1415), jsonDouble.toMsgpack());
 
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
@@ -382,6 +395,8 @@ public class TestJsonDouble {
         assertTrue(jsonDouble.toString().startsWith("3.1415926535897"));
         assertEquals(JsonDouble.of(Math.PI), jsonDouble);
 
+        assertEquals(ValueFactory.newFloat(Math.PI), jsonDouble.toMsgpack());
+
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
     }
@@ -427,6 +442,8 @@ public class TestJsonDouble {
         assertEquals("19245.0", jsonDouble.toJson());
         assertEquals("19245.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(19245.0), jsonDouble);
+
+        assertEquals(ValueFactory.newFloat(19245.0), jsonDouble.toMsgpack());
 
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
@@ -474,6 +491,8 @@ public class TestJsonDouble {
         assertEquals("19245.12", jsonDouble.toString());
         assertEquals(JsonDouble.of(19245.12), jsonDouble);
 
+        assertEquals(ValueFactory.newFloat(19245.12), jsonDouble.toMsgpack());
+
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
     }
@@ -520,6 +539,8 @@ public class TestJsonDouble {
         assertEquals("9351902.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(9351902.0), jsonDouble);
 
+        assertEquals(ValueFactory.newFloat(9351902.0), jsonDouble.toMsgpack());
+
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
     }
@@ -565,6 +586,8 @@ public class TestJsonDouble {
         assertEquals("9351902.523", jsonDouble.toJson());
         assertEquals("9351902.523", jsonDouble.toString());
         assertEquals(JsonDouble.of(9351902.523), jsonDouble);
+
+        assertEquals(ValueFactory.newFloat(9351902.523), jsonDouble.toMsgpack());
 
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
@@ -613,6 +636,8 @@ public class TestJsonDouble {
         assertEquals("3.123456789E10", jsonDouble.toString());
         assertEquals(JsonDouble.of(31234567890.0), jsonDouble);
 
+        assertEquals(ValueFactory.newFloat(31234567890.0), jsonDouble.toMsgpack());
+
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
     }
@@ -657,6 +682,8 @@ public class TestJsonDouble {
         assertEquals("3.123456789012E10", jsonDouble.toJson());
         assertEquals("3.123456789012E10", jsonDouble.toString());
         assertEquals(JsonDouble.of(31234567890.12), jsonDouble);
+
+        assertEquals(ValueFactory.newFloat(31234567890.12), jsonDouble.toMsgpack());
 
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
@@ -705,6 +732,8 @@ public class TestJsonDouble {
         assertEquals("9.223372036854776E21", jsonDouble.toString());
         assertEquals(JsonDouble.of(9.223372036854776E21), jsonDouble);
 
+        assertEquals(ValueFactory.newFloat(9_223_372_036_854_775_807_000.0), jsonDouble.toMsgpack());
+
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
     }
@@ -751,6 +780,8 @@ public class TestJsonDouble {
         assertEquals("9.223372036854776E21", jsonDouble.toJson());
         assertEquals("9.223372036854776E21", jsonDouble.toString());
         assertEquals(JsonDouble.of(9.223372036854776E21), jsonDouble);
+
+        assertEquals(ValueFactory.newFloat(9_223_372_036_854_775_807_000.12), jsonDouble.toMsgpack());
 
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
@@ -800,6 +831,8 @@ public class TestJsonDouble {
         assertEquals("4.9E-324", jsonDouble.toJson());
         assertEquals("4.9E-324", jsonDouble.toString());
         assertEquals(JsonDouble.of(Double.MIN_VALUE), jsonDouble);
+
+        assertEquals(ValueFactory.newFloat(Double.MIN_VALUE), jsonDouble.toMsgpack());
 
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonLong.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonLong.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
+import org.msgpack.value.ValueFactory;
 
 public class TestJsonLong {
     @Test
@@ -74,6 +75,8 @@ public class TestJsonLong {
         assertEquals("123", integer.toString());
         assertEquals(JsonLong.of(123L), integer);
 
+        assertEquals(ValueFactory.newInteger(123L), integer.toMsgpack());
+
         // JsonLong#equals must normally reject a fake imitation of JsonLong.
         assertFalse(integer.equals(FakeJsonLong.of(integer.longValue())));
     }
@@ -118,6 +121,8 @@ public class TestJsonLong {
         assertEquals("12345", integer.toJson());
         assertEquals("12345", integer.toString());
         assertEquals(JsonLong.of(12345L), integer);
+
+        assertEquals(ValueFactory.newInteger(12345L), integer.toMsgpack());
 
         // JsonLong#equals must normally reject a fake imitation of JsonLong.
         assertFalse(integer.equals(FakeJsonLong.of(integer.longValue())));
@@ -164,6 +169,8 @@ public class TestJsonLong {
         assertEquals("1234567890", integer.toString());
         assertEquals(JsonLong.of(1234567890L), integer);
 
+        assertEquals(ValueFactory.newInteger(1234567890L), integer.toMsgpack());
+
         // JsonLong#equals must normally reject a fake imitation of JsonLong.
         assertFalse(integer.equals(FakeJsonLong.of(integer.longValue())));
     }
@@ -209,6 +216,8 @@ public class TestJsonLong {
         assertEquals("1234567890123456", integer.toString());
         assertEquals(JsonLong.of(1234567890123456L), integer);
 
+        assertEquals(ValueFactory.newInteger(1234567890123456L), integer.toMsgpack());
+
         // JsonLong#equals must normally reject a fake imitation of JsonLong.
         assertFalse(integer.equals(FakeJsonLong.of(integer.longValue())));
     }
@@ -253,6 +262,8 @@ public class TestJsonLong {
         assertEquals("999999999999999999991234567890123456", integer.toJson());
         assertEquals("1234567890123456", integer.toString());
         assertEquals(JsonLong.of(1234567890123456L), integer);
+
+        assertEquals(ValueFactory.newInteger(1234567890123456L), integer.toMsgpack());
 
         // JsonLong#equals must normally reject a fake imitation of JsonLong.
         assertFalse(integer.equals(FakeJsonLong.of(integer.longValue())));

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
+import org.msgpack.value.ValueFactory;
 
 public class TestJsonNull {
     @Test
@@ -54,6 +55,8 @@ public class TestJsonNull {
         assertEquals("null", jsonNull.toString());
         assertEquals(JsonNull.NULL, jsonNull);
         assertEquals(JsonNull.of(), jsonNull);
+
+        assertEquals(ValueFactory.newNil(), jsonNull.toMsgpack());
 
         // JsonNull#equals must normally reject a fake imitation of JsonNull.
         assertFalse(jsonNull.equals(FakeJsonNull.ofFake()));

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
+import org.msgpack.value.ValueFactory;
 
 public class TestJsonObject {
     @Test
@@ -64,6 +65,8 @@ public class TestJsonObject {
         assertEquals("{}", jsonObject.toJson());
         assertEquals("{}", jsonObject.toString());
         assertEquals(JsonObject.of(), jsonObject);
+
+        assertEquals(ValueFactory.emptyMap(), jsonObject.toMsgpack());
 
         // JsonObject#equals must normally reject a fake imitation of JsonObject.
         assertFalse(jsonObject.equals(FakeJsonObject.of()));
@@ -111,6 +114,11 @@ public class TestJsonObject {
                          JsonString.of("foo"), JsonLong.of(456),
                          JsonString.of("bar"), JsonLong.of(456)),
                      jsonObject);
+
+        assertEquals(ValueFactory.newMap(
+                         ValueFactory.newString("foo"), ValueFactory.newInteger(456),
+                         ValueFactory.newString("bar"), ValueFactory.newInteger(456)),
+                     jsonObject.toMsgpack());
 
         // JsonObject#equals must normally reject a fake imitation of JsonObject.
         assertFalse(jsonObject.equals(FakeJsonObject.of(
@@ -168,6 +176,12 @@ public class TestJsonObject {
                              JsonString.of("bar"), JsonArray.of(JsonLong.of(123), JsonBoolean.TRUE),
                              JsonString.of("baz"), JsonLong.of(678)),
                      jsonObject);
+
+        assertEquals(ValueFactory.newMap(
+                             ValueFactory.newString("foo"), ValueFactory.newNil(),
+                             ValueFactory.newString("bar"), ValueFactory.newArray(ValueFactory.newInteger(123), ValueFactory.newBoolean(true)),
+                             ValueFactory.newString("baz"), ValueFactory.newInteger(678)),
+                     jsonObject.toMsgpack());
 
         // JsonObject#equals must normally reject a fake imitation of JsonObject.
         assertFalse(jsonObject.equals(FakeJsonObject.of(
@@ -227,6 +241,12 @@ public class TestJsonObject {
                              JsonString.of("bar"), JsonArray.of(JsonLong.of(123), JsonBoolean.TRUE),
                              JsonString.of("baz"), JsonLong.of(678)),
                      jsonObject);
+
+        assertEquals(ValueFactory.newMap(
+                             ValueFactory.newString("foo"), ValueFactory.newNil(),
+                             ValueFactory.newString("bar"), ValueFactory.newArray(ValueFactory.newInteger(123), ValueFactory.newBoolean(true)),
+                             ValueFactory.newString("baz"), ValueFactory.newInteger(678)),
+                     jsonObject.toMsgpack());
 
         // JsonObject#equals must normally reject a fake imitation of JsonObject.
         assertFalse(jsonObject.equals(FakeJsonObject.of(
@@ -288,6 +308,12 @@ public class TestJsonObject {
                              JsonString.of("bar"), JsonArray.of(JsonLong.of(123), JsonBoolean.TRUE),
                              JsonString.of("baz"), JsonLong.of(678)),
                      jsonObject);
+
+        assertEquals(ValueFactory.newMap(
+                             ValueFactory.newString("foo"), ValueFactory.newNil(),
+                             ValueFactory.newString("bar"), ValueFactory.newArray(ValueFactory.newInteger(123), ValueFactory.newBoolean(true)),
+                             ValueFactory.newString("baz"), ValueFactory.newInteger(678)),
+                     jsonObject.toMsgpack());
 
         // Ordered differently.
         assertEquals(JsonObject.of(
@@ -363,6 +389,12 @@ public class TestJsonObject {
                              JsonString.of("bar"), JsonArray.of(JsonLong.of(123), JsonBoolean.TRUE),
                              JsonString.of("baz"), JsonLong.of(678)),
                      jsonObject);
+
+        assertEquals(ValueFactory.newMap(
+                             ValueFactory.newString("foo"), ValueFactory.newNil(),
+                             ValueFactory.newString("bar"), ValueFactory.newArray(ValueFactory.newInteger(123), ValueFactory.newBoolean(true)),
+                             ValueFactory.newString("baz"), ValueFactory.newInteger(678)),
+                     jsonObject.toMsgpack());
 
         // Ordered differently.
         assertEquals(JsonObject.of(
@@ -488,6 +520,17 @@ public class TestJsonObject {
                              JsonString.of("piyo"), JsonLong.of(345),
                              JsonString.of("hogera"), JsonString.of("bar")),
                      jsonObject);
+
+        assertEquals(ValueFactory.newMap(
+                             ValueFactory.newString("foo"), ValueFactory.newNil(),
+                             ValueFactory.newString("bar"), ValueFactory.newArray(ValueFactory.newInteger(123), ValueFactory.newBoolean(true)),
+                             ValueFactory.newString("baz"), ValueFactory.newInteger(678),
+                             ValueFactory.newString("qux"), ValueFactory.newNil(),
+                             ValueFactory.newString("hoge"), ValueFactory.newString("foo"),
+                             ValueFactory.newString("fuga"), ValueFactory.newFloat(123.4),
+                             ValueFactory.newString("piyo"), ValueFactory.newInteger(345),
+                             ValueFactory.newString("hogera"), ValueFactory.newString("bar")),
+                     jsonObject.toMsgpack());
 
         // JsonObject#equals must normally reject a fake imitation of JsonObject.
         assertFalse(jsonObject.equals(FakeJsonObject.of(

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
+import org.msgpack.value.ValueFactory;
 
 public class TestJsonString {
     @Test
@@ -63,6 +64,8 @@ public class TestJsonString {
         assertEquals(JsonString.of("hoge"), string);
         assertEquals("hoge".hashCode(), string.hashCode());
 
+        assertEquals(ValueFactory.newString("hoge"), string.toMsgpack());
+
         // JsonString#equals must normally reject a fake imitation of JsonString.
         assertFalse(string.equals(FakeJsonString.of(string.getString())));
     }
@@ -92,6 +95,8 @@ public class TestJsonString {
         assertEquals("\"hoge\\n\"", string.toString());
         assertEquals(JsonString.of("hoge\n"), string);
         assertEquals("hoge\n".hashCode(), string.hashCode());
+
+        assertEquals(ValueFactory.newString("hoge\n"), string.toMsgpack());
 
         // JsonString#equals must normally reject a fake imitation of JsonString.
         assertFalse(string.equals(FakeJsonString.of(string.getString())));
@@ -126,6 +131,10 @@ public class TestJsonString {
                 string.toString());
         assertEquals(JsonString.of("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux"), string);
         assertEquals("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux".hashCode(), string.hashCode());
+
+        assertEquals(
+                ValueFactory.newString("\\foo\"bar\nbaz\bqux\ffoo\nbar\rbaz\tqux\0foo\u0001bar\u0002baz\u001fqux"),
+                string.toMsgpack());
 
         // JsonString#equals must normally reject a fake imitation of JsonString.
         assertFalse(string.equals(FakeJsonString.of(string.getString())));


### PR DESCRIPTION
This is the step 3 in the draft EEP: JSON Column Type: #1538 

> "Modify the new JSON classes to represent their inner values by msgpack-java"

`#toMsgpack()` is used only for running with the existing methods in `Page`, `PageBuilder`, `PageReader`. It will be reverted when we finally remove msgpack-java from the Embulk SPI after v1.0.
