### PR TITLE
Implement JsonValue#fromMsgpack

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonArray.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonArray.java
@@ -19,6 +19,7 @@ package org.embulk.spi.json;
 import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.List;
+import org.msgpack.value.ArrayValue;
 import org.msgpack.value.Value;
 import org.msgpack.value.impl.ImmutableArrayValueImpl;
 
@@ -33,6 +34,26 @@ public final class JsonArray extends AbstractList<JsonValue> implements JsonValu
     private JsonArray(final JsonValue[] values) {
         this.values = values;
         this.msgpackArrayCache = null;
+    }
+
+    private JsonArray(final JsonValue[] values, final ImmutableArrayValueImpl msgpackValue) {
+        this.values = values;
+        this.msgpackArrayCache = msgpackValue;
+    }
+
+    @SuppressWarnings("deprecation")
+    static JsonArray fromMsgpack(final ArrayValue msgpackValue) {
+        // This cast should always succeed.
+        final ImmutableArrayValueImpl immutable = (ImmutableArrayValueImpl) msgpackValue.immutableValue();
+
+        final int size = immutable.size();
+        final JsonValue[] values = new JsonValue[size];
+
+        for (int i = 0; i < size; i++) {
+            values[i] = JsonValue.fromMsgpack(immutable.get(i));
+        }
+
+        return new JsonArray(values, immutable);
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
@@ -18,6 +18,7 @@ package org.embulk.spi.json;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import org.msgpack.value.FloatValue;
 import org.msgpack.value.Value;
 import org.msgpack.value.impl.ImmutableDoubleValueImpl;
 
@@ -40,6 +41,16 @@ public final class JsonDouble implements JsonNumber {
         }
         this.value = new ImmutableDoubleValueImpl(value);
         this.literal = literal;
+    }
+
+    private JsonDouble(final ImmutableDoubleValueImpl msgpackValue) {
+        this.value = msgpackValue;
+        this.literal = null;
+    }
+
+    static JsonDouble fromMsgpack(final FloatValue msgpackValue) {
+        // This cast should always succeed.
+        return new JsonDouble((ImmutableDoubleValueImpl) msgpackValue.immutableValue());
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonLong.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonLong.java
@@ -18,6 +18,8 @@ package org.embulk.spi.json;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import org.msgpack.value.ImmutableIntegerValue;
+import org.msgpack.value.IntegerValue;
 import org.msgpack.value.Value;
 import org.msgpack.value.impl.ImmutableLongValueImpl;
 
@@ -33,6 +35,19 @@ public final class JsonLong implements JsonNumber {
         // No direct instantiation.
         this.value = new ImmutableLongValueImpl(value);
         this.literal = literal;
+    }
+
+    private JsonLong(final ImmutableLongValueImpl msgpackValue) {
+        this.value = msgpackValue;
+        this.literal = null;
+    }
+
+    static JsonLong fromMsgpack(final IntegerValue msgpackValue) {
+        final ImmutableIntegerValue immutableInteger = (ImmutableIntegerValue) msgpackValue.immutableValue();
+        if (immutableInteger instanceof ImmutableLongValueImpl) {
+            return new JsonLong((ImmutableLongValueImpl) immutableInteger);
+        }
+        throw new IllegalArgumentException("MessagePack's Integer type is not long.");
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
@@ -17,6 +17,7 @@
 package org.embulk.spi.json;
 
 import java.util.Objects;
+import org.msgpack.value.StringValue;
 import org.msgpack.value.Value;
 import org.msgpack.value.impl.ImmutableStringValueImpl;
 
@@ -36,6 +37,16 @@ public final class JsonString implements JsonValue {
         }
         this.value = new ImmutableStringValueImpl(value);
         this.literal = literal;
+    }
+
+    private JsonString(final ImmutableStringValueImpl msgpackValue) {
+        this.value = msgpackValue;
+        this.literal = null;
+    }
+
+    static JsonString fromMsgpack(final StringValue msgpackValue) {
+        // This cast should always succeed.
+        return new JsonString((ImmutableStringValueImpl) msgpackValue.immutableValue());
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonValue.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonValue.java
@@ -393,4 +393,51 @@ public interface JsonValue {
      */
     @Deprecated
     Value toMsgpack();
+
+    /**
+     * Returns a new JSON value based on the specified MessagePack's value.
+     *
+     * @param msgpackValue  the MessagePack's value
+     * @return the new JSON value
+     *
+     * @see <a href="https://github.com/embulk/embulk/pull/1538">Draft EEP: JSON Column Type</a>
+     *
+     * @deprecated Do not use this method. It is to be removed at some point after Embulk v1.0.0.
+     *     It is here only to ensure a migration period from MessagePack-based JSON values to new
+     *     JSON values of {@link JsonValue}.
+     *
+     * @since 0.10.42
+     */
+    @Deprecated
+    public static JsonValue fromMsgpack(final Value msgpackValue) {
+        if (msgpackValue == null) {
+            throw new NullPointerException("msgpackValue is null.");
+        }
+
+        switch (msgpackValue.getValueType()) {
+            case NIL:
+                return JsonNull.NULL;
+            case BOOLEAN:
+                if (msgpackValue.asBooleanValue().getBoolean()) {
+                    return JsonBoolean.TRUE;
+                }
+                return JsonBoolean.FALSE;
+            case INTEGER:
+                return JsonLong.fromMsgpack(msgpackValue.asIntegerValue());
+            case FLOAT:
+                return JsonDouble.fromMsgpack(msgpackValue.asFloatValue());
+            case STRING:
+                return JsonString.fromMsgpack(msgpackValue.asStringValue());
+            case BINARY:
+                throw new IllegalArgumentException("MessagePack's Binary type is not supported.");
+            case ARRAY:
+                return JsonArray.fromMsgpack(msgpackValue.asArrayValue());
+            case MAP:
+                return JsonObject.fromMsgpack(msgpackValue.asMapValue());
+            case EXTENSION:
+                throw new IllegalArgumentException("MessagePack's Extension type is not supported.");
+            default:
+                throw new IllegalArgumentException("MessagePack's type is unknown.");
+        }
+    }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
@@ -334,15 +334,15 @@ public class TestJsonArray {
     @Test
     public void testFromMsgpack() {
         assertEquals(
-                JsonValue.fromMsgpack(ValueFactory.newArray(
-                        ValueFactory.newInteger(987),
-                        ValueFactory.newArray(
-                                ValueFactory.newString("foo"), ValueFactory.newString("bar"), ValueFactory.newString("baz")),
-                        ValueFactory.newBoolean(true))),
                 JsonArray.of(
                         JsonLong.of(987),
                         JsonArray.of(
                                 JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")),
-                        JsonBoolean.TRUE));
+                        JsonBoolean.TRUE),
+                JsonValue.fromMsgpack(ValueFactory.newArray(
+                        ValueFactory.newInteger(987),
+                        ValueFactory.newArray(
+                                ValueFactory.newString("foo"), ValueFactory.newString("bar"), ValueFactory.newString("baz")),
+                        ValueFactory.newBoolean(true))));
     }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonArray.java
@@ -330,4 +330,19 @@ public class TestJsonArray {
                                     JsonArray.of(JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")),
                                     JsonBoolean.TRUE)));
     }
+
+    @Test
+    public void testFromMsgpack() {
+        assertEquals(
+                JsonValue.fromMsgpack(ValueFactory.newArray(
+                        ValueFactory.newInteger(987),
+                        ValueFactory.newArray(
+                                ValueFactory.newString("foo"), ValueFactory.newString("bar"), ValueFactory.newString("baz")),
+                        ValueFactory.newBoolean(true))),
+                JsonArray.of(
+                        JsonLong.of(987),
+                        JsonArray.of(
+                                JsonString.of("foo"), JsonString.of("bar"), JsonString.of("baz")),
+                        JsonBoolean.TRUE));
+    }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonBoolean.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonBoolean.java
@@ -95,4 +95,10 @@ public class TestJsonBoolean {
         assertFalse(jsonBoolean.equals(FakeJsonBoolean.FAKE_FALSE));
         assertFalse(jsonBoolean.equals(FakeJsonBoolean.FAKE_TRUE));
     }
+
+    @Test
+    public void testFromMsgpack() {
+        assertEquals(JsonBoolean.FALSE, JsonValue.fromMsgpack(ValueFactory.newBoolean(false)));
+        assertEquals(JsonBoolean.TRUE, JsonValue.fromMsgpack(ValueFactory.newBoolean(true)));
+    }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDouble.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDouble.java
@@ -837,4 +837,12 @@ public class TestJsonDouble {
         // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
         assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
     }
+
+    @Test
+    public void testFromMsgpack() {
+        assertEquals(JsonDouble.of(0.0), JsonValue.fromMsgpack(ValueFactory.newFloat(0.0)));
+        assertEquals(JsonDouble.of(-0.0), JsonValue.fromMsgpack(ValueFactory.newFloat(-0.0)));
+        assertEquals(JsonDouble.of(12.41041), JsonValue.fromMsgpack(ValueFactory.newFloat(12.41041)));
+        assertEquals(JsonDouble.of(Double.MIN_VALUE), JsonValue.fromMsgpack(ValueFactory.newFloat(Double.MIN_VALUE)));
+    }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonLong.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonLong.java
@@ -268,4 +268,12 @@ public class TestJsonLong {
         // JsonLong#equals must normally reject a fake imitation of JsonLong.
         assertFalse(integer.equals(FakeJsonLong.of(integer.longValue())));
     }
+
+    @Test
+    public void testFromMsgpack() {
+        assertEquals(JsonLong.of(0), JsonValue.fromMsgpack(ValueFactory.newInteger(0)));
+        assertEquals(JsonLong.of(-0), JsonValue.fromMsgpack(ValueFactory.newInteger(-0)));
+        assertEquals(JsonLong.of(42), JsonValue.fromMsgpack(ValueFactory.newInteger(42)));
+        assertEquals(JsonLong.of(Long.MAX_VALUE), JsonValue.fromMsgpack(ValueFactory.newInteger(Long.MAX_VALUE)));
+    }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonNull.java
@@ -61,4 +61,9 @@ public class TestJsonNull {
         // JsonNull#equals must normally reject a fake imitation of JsonNull.
         assertFalse(jsonNull.equals(FakeJsonNull.ofFake()));
     }
+
+    @Test
+    public void testFromMsgpack() {
+        assertEquals(JsonNull.NULL, JsonValue.fromMsgpack(ValueFactory.newNil()));
+    }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
@@ -735,4 +735,31 @@ public class TestJsonObject {
         assertThrows(NullPointerException.class, () -> JsonObject.of("k1", JsonString.of("f"), null, JsonNull.of()));
         assertThrows(NullPointerException.class, () -> JsonObject.of("k1", JsonLong.of(13423), "k2", null));
     }
+
+    @Test
+    public void testFromMsgpack() {
+        assertEquals(
+                JsonObject.of(
+                             "foo", JsonNull.of(),
+                             "bar", JsonArray.of(JsonLong.of(123), JsonBoolean.TRUE),
+                             "baz", JsonObject.of(
+                                     "sub1", JsonString.of("v1"),
+                                     "sub2", JsonLong.of(42)),
+                             "qux", JsonNull.of(),
+                             "hoge", JsonString.of("foo"),
+                             "fuga", JsonDouble.of(123.4),
+                             "piyo", JsonLong.of(345),
+                             "hogera", JsonString.of("bar")),
+                JsonValue.fromMsgpack(ValueFactory.newMap(
+                             ValueFactory.newString("foo"), ValueFactory.newNil(),
+                             ValueFactory.newString("bar"), ValueFactory.newArray(ValueFactory.newInteger(123), ValueFactory.newBoolean(true)),
+                             ValueFactory.newString("baz"), ValueFactory.newMap(
+                                     ValueFactory.newString("sub1"), ValueFactory.newString("v1"),
+                                     ValueFactory.newString("sub2"), ValueFactory.newInteger(42)),
+                             ValueFactory.newString("qux"), ValueFactory.newNil(),
+                             ValueFactory.newString("hoge"), ValueFactory.newString("foo"),
+                             ValueFactory.newString("fuga"), ValueFactory.newFloat(123.4),
+                             ValueFactory.newString("piyo"), ValueFactory.newInteger(345),
+                             ValueFactory.newString("hogera"), ValueFactory.newString("bar"))));
+    }
 }

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
@@ -139,4 +139,12 @@ public class TestJsonString {
         // JsonString#equals must normally reject a fake imitation of JsonString.
         assertFalse(string.equals(FakeJsonString.of(string.getString())));
     }
+
+    @Test
+    public void testFromMsgpack() {
+        assertEquals(JsonString.of(""), JsonValue.fromMsgpack(ValueFactory.newString("")));
+        assertEquals(JsonString.of("hogehoge"), JsonValue.fromMsgpack(ValueFactory.newString("hogehoge")));
+        assertEquals(JsonString.of("\n"), JsonValue.fromMsgpack(ValueFactory.newString("\n")));
+        assertEquals(JsonString.of("\0"), JsonValue.fromMsgpack(ValueFactory.newString("\0")));
+    }
 }


### PR DESCRIPTION
This is the step 3, and preparation for the step 4, in the draft EEP: JSON Column Type: #1538

> 3. "Modify the new JSON classes to represent their inner values by msgpack-java"
> 4. Add new Embulk plugin SPI methods with the new JSON classes in parallel to the existing methods

`JsonValue#fromMsgpack()` is used only for creating `JsonValue` when received a msgpack-java `Value` from plugins. It will be reverted when we finally remove msgpack-java from the Embulk SPI after v1.0.
