### PR TITLE
Use JsonValue in Page, PageBuilder, and PageReader, instead of org.msgpack.value.Value

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/Page.java
+++ b/embulk-api/src/main/java/org/embulk/spi/Page.java
@@ -19,6 +19,7 @@ package org.embulk.spi;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.ImmutableValue;
 
 /**
@@ -44,34 +45,85 @@ import org.msgpack.value.ImmutableValue;
  */
 public abstract class Page {
     /**
+     * Sets the list of string references in this {@link Page}.
+     *
+     * @param values  the list of string references to set
+     * @return this {@link Page} itself
+     * @deprecated Do not call this method directly from plugins.
+     *
      * @since 0.4.0
      */
+    @Deprecated
     public abstract Page setStringReferences(List<String> values);
 
     /**
+     * Sets the list of JSON value references in this {@link Page} in the {@code msgpack-java} representation.
+     *
+     * <p>The JSON values are converted to {@link org.embulk.spi.json.JsonValue} from the {@code msgpack-java} representation.
+     *
+     * @param values  the list of JSON value references to set in the {@code msgpack-java} representation
+     * @return this {@link Page} itself
+     * @deprecated Do not call this method directly from plugins.
+     *
      * @since 0.8.0
      */
+    @Deprecated
     public abstract Page setValueReferences(List<ImmutableValue> values);
 
     /**
+     * Returns the list of string references in this {@link Page}.
+     *
+     * @return the list of string references in this {@link Page}
+     * @deprecated Do not call this method directly from plugins.
+     *
      * @since 0.6.0
      */
+    @Deprecated
     public abstract List<String> getStringReferences();
 
     /**
+     * Returns the list of JSON value references in this {@link Page} in the {@code msgpack-java} representation.
+     *
+     * <p>The JSON values are converted to the {@code msgpack-java} representation from {@link org.embulk.spi.json.JsonValue} in this {@link Page}.
+     *
+     * @return the list of JSON value references in this {@link Page} in the {@code msgpack-java} representation
+     * @deprecated Do not call this method directly from plugins.
+     *
      * @since 0.8.0
      */
+    @Deprecated
     public abstract List<ImmutableValue> getValueReferences();
 
     /**
+     * Returns a string from the string references in this {@link Page} at {@code index}.
+     *
+     * @return the string from the string references in this {@link Page} at {@code index}
+     *
      * @since 0.4.0
      */
     public abstract String getStringReference(int index);
 
     /**
+     * Returns a JSON value from the JSON value references in this {@link Page} at {@code index} in the {@code msgpack-java} representation.
+     *
+     * <p>The JSON value is converted to the {@code msgpack-java} representatino from {@link org.embulk.spi.json.JsonValue} in this {@link Page}.
+     *
+     * @return the JSON value from the JSON value references in this {@link Page} at {@code index} in the {@code msgpack-java} representation
+     * @deprecated Use {@link #getJsonValueReference(int)} instead.
+     *
      * @since 0.8.0
      */
+    @Deprecated
     public abstract ImmutableValue getValueReference(int index);
+
+    /**
+     * Returns a JSON value from the JSON value references in this {@link Page} at {@code index}.
+     *
+     * @return the JSON value from the JSON value references in this {@link Page} at {@code index}
+     *
+     * @since 0.10.42
+     */
+    public abstract JsonValue getJsonValueReference(int index);
 
     /**
      * @since 0.4.0

--- a/embulk-api/src/main/java/org/embulk/spi/Page.java
+++ b/embulk-api/src/main/java/org/embulk/spi/Page.java
@@ -97,6 +97,7 @@ public abstract class Page {
     /**
      * Returns a string from the string references in this {@link Page} at {@code index}.
      *
+     * @param index  the index of the string reference to return
      * @return the string from the string references in this {@link Page} at {@code index}
      *
      * @since 0.4.0
@@ -108,6 +109,7 @@ public abstract class Page {
      *
      * <p>The JSON value is converted to the {@code msgpack-java} representatino from {@link org.embulk.spi.json.JsonValue} in this {@link Page}.
      *
+     * @param index  the index of the JSON value reference to return
      * @return the JSON value from the JSON value references in this {@link Page} at {@code index} in the {@code msgpack-java} representation
      * @deprecated Use {@link #getJsonValueReference(int)} instead.
      *
@@ -119,6 +121,7 @@ public abstract class Page {
     /**
      * Returns a JSON value from the JSON value references in this {@link Page} at {@code index}.
      *
+     * @param index  the index of the JSON value reference to return
      * @return the JSON value from the JSON value references in this {@link Page} at {@code index}
      *
      * @since 0.10.42

--- a/embulk-api/src/main/java/org/embulk/spi/PageBuilder.java
+++ b/embulk-api/src/main/java/org/embulk/spi/PageBuilder.java
@@ -159,7 +159,7 @@ public class PageBuilder implements AutoCloseable {
      *
      * @param columnIndex  the index of the column to set the JSON value
      * @param value  the JSON value in the {@code msgpack-java} representation
-     * @deprecated Use {@link #setJson(org.embulk.spi.Column, org.embulk.spi.json.JsonValue)} instead.
+     * @deprecated Use {@link #setJson(int, org.embulk.spi.json.JsonValue)} instead.
      *
      * @since 0.8.0
      */

--- a/embulk-api/src/main/java/org/embulk/spi/PageBuilder.java
+++ b/embulk-api/src/main/java/org/embulk/spi/PageBuilder.java
@@ -19,6 +19,7 @@ package org.embulk.spi;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.time.Instant;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
 
 /**
@@ -127,16 +128,56 @@ public class PageBuilder implements AutoCloseable {
     }
 
     /**
+     * Sets a JSON value at the specified column in the {@code msgpack-java} representation.
+     *
+     * @param column  the column to set the JSON value
+     * @param value  the JSON value in the {@code msgpack-java} representation
+     * @deprecated Use {@link #setJson(org.embulk.spi.Column, org.embulk.spi.json.JsonValue)} instead.
+     *
      * @since 0.8.0
      */
+    @Deprecated
+    @SuppressWarnings("deprecation")
     public void setJson(Column column, Value value) {
         this.delegate.setJson(column, value);
     }
 
     /**
+     * Sets a JSON value at the specified column.
+     *
+     * @param column  the column to set the JSON value
+     * @param value  the JSON value
+     *
+     * @since 0.10.42
+     */
+    public void setJson(final Column column, final JsonValue value) {
+        this.delegate.setJson(column, value);
+    }
+
+    /**
+     * Sets a JSON value at the specified column in the {@code msgpack-java} representation.
+     *
+     * @param columnIndex  the index of the column to set the JSON value
+     * @param value  the JSON value in the {@code msgpack-java} representation
+     * @deprecated Use {@link #setJson(org.embulk.spi.Column, org.embulk.spi.json.JsonValue)} instead.
+     *
      * @since 0.8.0
      */
+    @Deprecated
+    @SuppressWarnings("deprecation")
     public void setJson(int columnIndex, Value value) {
+        this.delegate.setJson(columnIndex, value);
+    }
+
+    /**
+     * Sets a JSON value at the specified column.
+     *
+     * @param columnIndex  the index of the column to set the JSON value
+     * @param value  the JSON value
+     *
+     * @since 0.10.42
+     */
+    public void setJson(final int columnIndex, final JsonValue value) {
         this.delegate.setJson(columnIndex, value);
     }
 

--- a/embulk-api/src/main/java/org/embulk/spi/PageReader.java
+++ b/embulk-api/src/main/java/org/embulk/spi/PageReader.java
@@ -186,7 +186,7 @@ public class PageReader implements AutoCloseable {
      *
      * @param column  the column to get the JSON value
      * @return the JSON value in the {@code msgpack-java} representation
-     * @deprecated Use {@link #getJsonValue(int)} instead.
+     * @deprecated Use {@link #getJsonValue(org.embulk.spi.Column)} instead.
      *
      * @since 0.8.0
      */
@@ -213,7 +213,7 @@ public class PageReader implements AutoCloseable {
      * Returns a JSON value at the specified column.
      *
      * @param column  the column to get the JSON value
-     * @return the JSON value in the {@code msgpack-java} representation
+     * @return the JSON value
      *
      * @since 0.10.42
      */
@@ -225,7 +225,7 @@ public class PageReader implements AutoCloseable {
      * Returns a JSON value at the specified column.
      *
      * @param columnIndex  the index of the column to get the JSON value
-     * @return the JSON value in the {@code msgpack-java} representation
+     * @return the JSON value
      *
      * @since 0.10.42
      */

--- a/embulk-api/src/main/java/org/embulk/spi/PageReader.java
+++ b/embulk-api/src/main/java/org/embulk/spi/PageReader.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Instant;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
 
 /**
@@ -181,17 +182,55 @@ public class PageReader implements AutoCloseable {
     }
 
     /**
+     * Returns a JSON value at the specified column in the {@code msgpack-java} representation.
+     *
+     * @param column  the column to get the JSON value
+     * @return the JSON value in the {@code msgpack-java} representation
+     * @deprecated Use {@link #getJsonValue(int)} instead.
+     *
      * @since 0.8.0
      */
+    @Deprecated
     public Value getJson(Column column) {
         return this.delegate.getJson(column);
     }
 
     /**
+     * Returns a JSON value at the specified column in the {@code msgpack-java} representation.
+     *
+     * @param columnIndex  the index of the column to get the JSON value
+     * @return the JSON value in the {@code msgpack-java} representation
+     * @deprecated Use {@link #getJsonValue(int)} instead.
+     *
      * @since 0.8.0
      */
+    @Deprecated
     public Value getJson(int columnIndex) {
         return this.delegate.getJson(columnIndex);
+    }
+
+    /**
+     * Returns a JSON value at the specified column.
+     *
+     * @param column  the column to get the JSON value
+     * @return the JSON value in the {@code msgpack-java} representation
+     *
+     * @since 0.10.42
+     */
+    public JsonValue getJsonValue(final Column column) {
+        return this.delegate.getJsonValue(column);
+    }
+
+    /**
+     * Returns a JSON value at the specified column.
+     *
+     * @param columnIndex  the index of the column to get the JSON value
+     * @return the JSON value in the {@code msgpack-java} representation
+     *
+     * @since 0.10.42
+     */
+    public JsonValue getJsonValue(final int columnIndex) {
+        return this.delegate.getJsonValue(columnIndex);
     }
 
     /**

--- a/embulk-core/src/main/java/org/embulk/spi/PageImpl.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageImpl.java
@@ -1,7 +1,13 @@
 package org.embulk.spi;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.ImmutableValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Page is an in-process (in-JVM) container of data records.
@@ -22,44 +28,75 @@ import org.msgpack.value.ImmutableValue;
 public class PageImpl extends Page {
     private final Buffer buffer;
     private List<String> stringReferences;
-    private List<ImmutableValue> valueReferences;
+    private List<JsonValue> jsonValueReferences;
 
     protected PageImpl(Buffer buffer) {
         this.buffer = buffer;
     }
 
     @SuppressWarnings("deprecation")  // Page.allocate(int) is deprecated.
-    public static Page allocate(int length) {
+    public static PageImpl allocate(int length) {
         return new PageImpl(BufferImpl.allocate(length));
     }
 
     @SuppressWarnings("deprecation")  // Page.wrap(Buffer) is deprecated.
-    public static Page wrap(Buffer buffer) {
+    public static PageImpl wrap(Buffer buffer) {
         return new PageImpl(buffer);
     }
 
+    @Deprecated
     @Override
     public Page setStringReferences(List<String> values) {
+        warn("Page#setStringReferences(List<String>)", hasLoggedSetStringReferences);
+        return this.setStringReferencesInternal(values);
+    }
+
+    PageImpl setStringReferencesInternal(final List<String> values) {
         this.stringReferences = values;
         return this;
     }
 
+    @Deprecated
     @Override
+    @SuppressWarnings("deprecation")
     public Page setValueReferences(List<ImmutableValue> values) {
-        this.valueReferences = values;
+        warn("Page#setValueReferences(List<ImmutableValue>)", hasLoggedSetValueReferences);
+        final ArrayList<JsonValue> newList = new ArrayList<>();
+        for (final ImmutableValue msgpackValue : values) {
+            newList.add(JsonValue.fromMsgpack(msgpackValue));
+        }
+        return this.setJsonValueReferencesInternal(Collections.unmodifiableList(newList));
+    }
+
+    PageImpl setJsonValueReferencesInternal(final List<JsonValue> values) {
+        this.jsonValueReferences = values;
         return this;
     }
 
+    @Deprecated
     @Override
     public List<String> getStringReferences() {
-        // TODO used by mapreduce executor
-        return stringReferences;
+        warn("Page#getStringReferences()", hasLoggedGetStringReferences);
+        return this.getStringReferencesInternal();
     }
 
+    List<String> getStringReferencesInternal() {
+        return this.stringReferences;
+    }
+
+    @Deprecated
     @Override
     public List<ImmutableValue> getValueReferences() {
-        // TODO used by mapreduce executor
-        return valueReferences;
+        warn("Page#getValueReferences()", hasLoggedGetValueReferences);
+        final ArrayList<ImmutableValue> msgpackValueReferences = new ArrayList<>();
+        for (final JsonValue jsonValue : this.getJsonValueReferencesInternal()) {
+            msgpackValueReferences.add(jsonValue.toMsgpack().immutableValue());
+        }
+        return Collections.unmodifiableList(msgpackValueReferences);
+    }
+
+    List<JsonValue> getJsonValueReferencesInternal() {
+        return this.jsonValueReferences;
     }
 
     @Override
@@ -67,9 +104,16 @@ public class PageImpl extends Page {
         return stringReferences.get(index);
     }
 
+    @Deprecated
     @Override
     public ImmutableValue getValueReference(int index) {
-        return valueReferences.get(index);
+        warn("Page#getValueReference()", hasLoggedGetValueReference);
+        return this.getJsonValueReference(index).toMsgpack().immutableValue();
+    }
+
+    @Override
+    public JsonValue getJsonValueReference(final int index) {
+        return this.jsonValueReferences.get(index);
     }
 
     @Override
@@ -81,4 +125,30 @@ public class PageImpl extends Page {
     public Buffer buffer() {
         return buffer;
     }
+
+    private static class Warning extends RuntimeException {
+        Warning(final String methodName) {
+            super("Page#" + methodName + " is called.");
+        }
+    }
+
+    private static void warn(final String methodName, final AtomicBoolean hasLogged) {
+        if (!hasLogged.getAndSet(true)) {
+            logger.debug("{} is called.", methodName);
+        } else {
+            logger.info(methodName + " is called.", new Warning(methodName + " is called."));
+        }
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(PageImpl.class);
+
+    private static final AtomicBoolean hasLoggedSetStringReferences = new AtomicBoolean(false);
+
+    private static final AtomicBoolean hasLoggedSetValueReferences = new AtomicBoolean(false);
+
+    private static final AtomicBoolean hasLoggedGetStringReferences = new AtomicBoolean(false);
+
+    private static final AtomicBoolean hasLoggedGetValueReferences = new AtomicBoolean(false);
+
+    private static final AtomicBoolean hasLoggedGetValueReference = new AtomicBoolean(false);
 }

--- a/embulk-core/src/main/java/org/embulk/spi/PageReaderImpl.java
+++ b/embulk-core/src/main/java/org/embulk/spi/PageReaderImpl.java
@@ -2,6 +2,7 @@ package org.embulk.spi;
 
 import java.time.Instant;
 import org.embulk.deps.buffer.Slice;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
 
 public class PageReaderImpl extends PageReader {
@@ -151,19 +152,59 @@ public class PageReaderImpl extends PageReader {
         return Instant.ofEpochSecond(sec, nsec);
     }
 
+    /**
+     * Returns a JSON value at the specified column in the {@code msgpack-java} representation.
+     *
+     * @param column  the column to get the JSON value
+     * @return the JSON value
+     * @deprecated Use {@link #getJsonValue(Column)} instead.
+     */
+    @Deprecated
     @Override
+    @SuppressWarnings("deprecation")
     public Value getJson(Column column) {
-        // TODO check type?
         return getJson(column.getIndex());
     }
 
+    /**
+     * Returns a JSON value at the specified column in the {@code msgpack-java} representation.
+     *
+     * @param columnIndex  the index the column to get the JSON value
+     * @return the JSON value
+     * @deprecated Use {@link #getJsonValue(int)} instead.
+     */
+    @Deprecated
     @Override
+    @SuppressWarnings("deprecation")
     public Value getJson(int columnIndex) {
-        if (isNull(columnIndex)) {
+        return this.getJsonValue(columnIndex).toMsgpack();
+    }
+
+    /**
+     * Returns a JSON value at the specified column.
+     *
+     * @param column  the column to get the JSON value
+     * @return the JSON value
+     */
+    @Override
+    public JsonValue getJsonValue(final Column column) {
+        // TODO check type?
+        return this.getJsonValue(column.getIndex());
+    }
+
+    /**
+     * Returns a JSON value at the specified column.
+     *
+     * @param columnIndex  the index the column to get the JSON value
+     * @return the JSON value
+     */
+    @Override
+    public JsonValue getJsonValue(final int columnIndex) {
+        if (this.isNull(columnIndex)) {
             return null;
         }
         int index = pageSlice.getInt(getOffset(columnIndex));
-        return page.getValueReference(index);
+        return this.page.getJsonValueReference(index);
     }
 
     private int getOffset(int columnIndex) {

--- a/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/DynamicColumnSetter.java
@@ -1,6 +1,7 @@
 package org.embulk.spi.util;
 
 import java.time.Instant;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
 
 public interface DynamicColumnSetter {
@@ -23,5 +24,11 @@ public interface DynamicColumnSetter {
         this.set(org.embulk.spi.time.Timestamp.ofInstant(value));
     }
 
+    @Deprecated
     void set(Value value);
+
+    @SuppressWarnings("deprecation")
+    default void set(final JsonValue value) {
+        this.set(value.toMsgpack());
+    }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/PagePrinter.java
@@ -93,7 +93,7 @@ public class PagePrinter {
         }
 
         public void jsonColumn(Column column) {
-            string = reader.getJson(column).toString();
+            this.string = this.reader.getJsonValue(column).toString();
         }
     }
 

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/AbstractDynamicColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/AbstractDynamicColumnSetter.java
@@ -3,6 +3,7 @@ package org.embulk.spi.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonValue;
 import org.embulk.spi.util.DynamicColumnSetter;
 import org.msgpack.value.Value;
 
@@ -38,5 +39,11 @@ public abstract class AbstractDynamicColumnSetter implements DynamicColumnSetter
         this.set(org.embulk.spi.time.Timestamp.ofInstant(value));
     }
 
+    @Deprecated
     public abstract void set(Value value);
+
+    @SuppressWarnings("deprecation")
+    public void set(final JsonValue value) {
+        this.set(value.toMsgpack());
+    }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/BooleanColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/BooleanColumnSetter.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
 
 public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
@@ -65,8 +66,14 @@ public class BooleanColumnSetter extends AbstractDynamicColumnSetter {
         defaultValue.setBoolean(pageBuilder, column);
     }
 
+    @Deprecated
     @Override
     public void set(Value v) {
+        defaultValue.setBoolean(pageBuilder, column);
+    }
+
+    @Override
+    public void set(final JsonValue v) {
         defaultValue.setBoolean(pageBuilder, column);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/DoubleColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/DoubleColumnSetter.java
@@ -3,6 +3,7 @@ package org.embulk.spi.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
 
 public class DoubleColumnSetter extends AbstractDynamicColumnSetter {
@@ -58,8 +59,14 @@ public class DoubleColumnSetter extends AbstractDynamicColumnSetter {
         pageBuilder.setDouble(column, sec + frac);
     }
 
+    @Deprecated
     @Override
     public void set(Value v) {
+        defaultValue.setDouble(pageBuilder, column);
+    }
+
+    @Override
+    public void set(final JsonValue v) {
         defaultValue.setDouble(pageBuilder, column);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/JsonColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/JsonColumnSetter.java
@@ -3,8 +3,12 @@ package org.embulk.spi.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonBoolean;
+import org.embulk.spi.json.JsonDouble;
+import org.embulk.spi.json.JsonLong;
+import org.embulk.spi.json.JsonString;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
-import org.msgpack.value.ValueFactory;
 
 public class JsonColumnSetter extends AbstractDynamicColumnSetter {
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1298
@@ -25,38 +29,44 @@ public class JsonColumnSetter extends AbstractDynamicColumnSetter {
 
     @Override
     public void set(boolean v) {
-        pageBuilder.setJson(column, ValueFactory.newBoolean(v));
+        pageBuilder.setJson(column, JsonBoolean.of(v));
     }
 
     @Override
     public void set(long v) {
-        pageBuilder.setJson(column, ValueFactory.newInteger(v));
+        pageBuilder.setJson(column, JsonLong.of(v));
     }
 
     @Override
     public void set(double v) {
-        pageBuilder.setJson(column, ValueFactory.newFloat(v));
+        pageBuilder.setJson(column, JsonDouble.of(v));
     }
 
     @Override
     public void set(String v) {
-        pageBuilder.setJson(column, ValueFactory.newString(v));
+        pageBuilder.setJson(column, JsonString.of(v));
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(final org.embulk.spi.time.Timestamp v) {
-        pageBuilder.setJson(column, ValueFactory.newString(timestampFormatter.format(v)));
+        pageBuilder.setJson(column, JsonString.of(timestampFormatter.format(v)));
     }
 
     @Override
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk/issues/1292
     public void set(Instant v) {
-        pageBuilder.setJson(column, ValueFactory.newString(timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v))));
+        pageBuilder.setJson(column, JsonString.of(timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v))));
+    }
+
+    @Deprecated
+    @Override
+    public void set(Value v) {
+        pageBuilder.setJson(column, JsonValue.fromMsgpack(v));
     }
 
     @Override
-    public void set(Value v) {
+    public void set(final JsonValue v) {
         pageBuilder.setJson(column, v);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/LongColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/LongColumnSetter.java
@@ -3,6 +3,7 @@ package org.embulk.spi.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
 
 public class LongColumnSetter extends AbstractDynamicColumnSetter {
@@ -68,8 +69,14 @@ public class LongColumnSetter extends AbstractDynamicColumnSetter {
         pageBuilder.setLong(column, v.getEpochSecond());
     }
 
+    @Deprecated
     @Override
     public void set(Value v) {
+        defaultValue.setLong(pageBuilder, column);
+    }
+
+    @Override
+    public void set(final JsonValue v) {
         defaultValue.setLong(pageBuilder, column);
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/SkipColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/SkipColumnSetter.java
@@ -1,6 +1,7 @@
 package org.embulk.spi.util.dynamic;
 
 import java.time.Instant;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
 
 public class SkipColumnSetter extends AbstractDynamicColumnSetter {
@@ -36,6 +37,10 @@ public class SkipColumnSetter extends AbstractDynamicColumnSetter {
     @Override
     public void set(Instant v) {}
 
+    @Deprecated
     @Override
     public void set(Value v) {}
+
+    @Override
+    public void set(final JsonValue v) {}
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/StringColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/StringColumnSetter.java
@@ -3,6 +3,7 @@ package org.embulk.spi.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
 
 public class StringColumnSetter extends AbstractDynamicColumnSetter {
@@ -54,8 +55,14 @@ public class StringColumnSetter extends AbstractDynamicColumnSetter {
         pageBuilder.setString(column, timestampFormatter.format(org.embulk.spi.time.Timestamp.ofInstant(v)));
     }
 
+    @Deprecated
     @Override
     public void set(Value v) {
+        pageBuilder.setString(column, v.toJson());
+    }
+
+    @Override
+    public void set(final JsonValue v) {
         pageBuilder.setString(column, v.toJson());
     }
 }

--- a/embulk-core/src/main/java/org/embulk/spi/util/dynamic/TimestampColumnSetter.java
+++ b/embulk-core/src/main/java/org/embulk/spi/util/dynamic/TimestampColumnSetter.java
@@ -3,6 +3,7 @@ package org.embulk.spi.util.dynamic;
 import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonValue;
 import org.msgpack.value.Value;
 
 public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
@@ -63,8 +64,14 @@ public class TimestampColumnSetter extends AbstractDynamicColumnSetter {
         pageBuilder.setTimestamp(column, v);
     }
 
+    @Deprecated
     @Override
     public void set(Value v) {
+        defaultValue.setTimestamp(pageBuilder, column);
+    }
+
+    @Override
+    public void set(final JsonValue v) {
         defaultValue.setTimestamp(pageBuilder, column);
     }
 }


### PR DESCRIPTION
This is almost the last step 4 in the draft EEP: JSON Column Type: #1538

> 4. Update `Page`, `PageBuilder`, and `PageReader` to represent JSON values by the new JSON classes, along with :
>     * Adding new Embulk plugin SPI methods with the new JSON classes in parallel to the existing methods
>         * Existing :
>             * `org.embulk.spi.Page`
>                 * `Page setValueReferences(List<org.msgpack.value.ImmutableValue>)`
>                 * `List<org.msgpack.value.ImmutableValue> getValueReferences()`
>                 * `org.msgpack.value.ImmutableValue getValueReference(int)`
>             * `org.embulk.spi.PageBuilder`
>                 * `void setJson(int, org.msgpack.value.Value)`
>                 * `void setJson(Column, org.msgpack.value.Value)`
>             * `org.embulk.spi.PageReader`
>                 * `org.msgpack.value.Value getJson(int)`
>                 * `org.msgpack.value.Value getJson(Column)`
>         * New :
>             * `org.embulk.spi.Page`
>                 * `org.embulk.spi.json.JsonValue getJsonValueReference(int)`
>             * `org.embulk.spi.PageBuilder`
>                 * `void setJson(int, org.embulk.spi.json.JsonValue)`
>                 * `void setJson(Column, org.embulk.spi.json.JsonValue)`
>             * `org.embulk.spi.PageReader`
>                 * `org.embulk.spi.json.JsonValue getJsonValue(int)`
>                 * `org.embulk.spi.json.JsonValue getJsonValue(Column)`
>         * The old methods would be forwarded to the new methods.
>     * Annotating `@Deprecated` on the older existing SPI methods
>     * Updating `DynamicColumnSetter` to use the new SPI methods
>     * Updating `PagePrinter` to use the new SPI method
>     * Updating `Pages` to use the new SPI methods