### PR TITLE
Add the size of literal in presumeReferenceSizeInBytes() of JsonLong, JsonDouble, and JsonString

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
@@ -125,7 +125,10 @@ public final class JsonDouble implements JsonNumber {
      */
     @Override
     public int presumeReferenceSizeInBytes() {
-        return 8;
+        if (this.literal == null) {
+            return 8;
+        }
+        return this.literal.length() * 2 + 8;
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonLong.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonLong.java
@@ -121,7 +121,10 @@ public final class JsonLong implements JsonNumber {
      */
     @Override
     public int presumeReferenceSizeInBytes() {
-        return 8;
+        if (this.literal == null) {
+            return 8;
+        }
+        return this.literal.length() * 2 + 8;
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonString.java
@@ -124,8 +124,10 @@ public final class JsonString implements JsonValue {
      */
     @Override
     public int presumeReferenceSizeInBytes() {
-        // Indeed, null is stored in Page as a special form as |nullBitSet|, but considered as 1 here in JsonValue just for ease.
-        return this.value.asString().length() * 2 + 4;
+        if (this.literal == null) {
+            return this.value.asString().length() * 2 + 4;
+        }
+        return (this.value.asString().length()) * 2 + (this.literal.length() * 2) + 4;
     }
 
     /**

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDouble.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDouble.java
@@ -95,6 +95,53 @@ public class TestJsonDouble {
     }
 
     @Test
+    public void testLiteral() {
+        final JsonDouble jsonDouble = JsonDouble.withLiteral(1234567890.123456, "1234567890.1234567890123456789");
+        assertEquals(JsonValue.EntityType.DOUBLE, jsonDouble.getEntityType());
+        assertFalse(jsonDouble.isJsonNull());
+        assertFalse(jsonDouble.isJsonBoolean());
+        assertFalse(jsonDouble.isJsonLong());
+        assertTrue(jsonDouble.isJsonDouble());
+        assertFalse(jsonDouble.isJsonString());
+        assertFalse(jsonDouble.isJsonArray());
+        assertFalse(jsonDouble.isJsonObject());
+        assertThrows(ClassCastException.class, () -> jsonDouble.asJsonNull());
+        assertThrows(ClassCastException.class, () -> jsonDouble.asJsonBoolean());
+        assertThrows(ClassCastException.class, () -> jsonDouble.asJsonLong());
+        assertEquals(jsonDouble, jsonDouble.asJsonDouble());
+        assertThrows(ClassCastException.class, () -> jsonDouble.asJsonString());
+        assertThrows(ClassCastException.class, () -> jsonDouble.asJsonArray());
+        assertThrows(ClassCastException.class, () -> jsonDouble.asJsonObject());
+        assertEquals(68, jsonDouble.presumeReferenceSizeInBytes());
+        assertFalse(jsonDouble.isIntegral());
+        assertFalse(jsonDouble.isByteValue());
+        assertFalse(jsonDouble.isShortValue());
+        assertFalse(jsonDouble.isIntValue());
+        assertFalse(jsonDouble.isLongValue());
+        assertEquals((byte) -46, jsonDouble.byteValue());  // Overflow & fractional
+        assertThrows(ArithmeticException.class, () -> jsonDouble.byteValueExact());
+        assertEquals((short) 722, jsonDouble.shortValue());  // Overflow & fractional
+        assertThrows(ArithmeticException.class, () -> jsonDouble.shortValueExact());
+        assertEquals((int) 1234567890, jsonDouble.intValue());  // Fractional
+        assertThrows(ArithmeticException.class, () -> jsonDouble.intValueExact());
+        assertEquals(1234567890L, jsonDouble.longValue());  // Fractional
+        assertThrows(ArithmeticException.class, () -> jsonDouble.longValueExact());
+        assertEquals(BigInteger.valueOf(1234567890L), jsonDouble.bigIntegerValue());
+        assertThrows(ArithmeticException.class, () -> jsonDouble.bigIntegerValueExact());
+        assertEquals((float) 1234567890.123456, jsonDouble.floatValue(), 0.001);
+        assertEquals(1234567890.123456, jsonDouble.doubleValue(), 0.001);
+        assertEquals(BigDecimal.valueOf(1234567890.123456), jsonDouble.bigDecimalValue());
+        assertEquals("1234567890.1234567890123456789", jsonDouble.toJson());
+        assertEquals("1.234567890123456E9", jsonDouble.toString());
+        assertEquals(JsonDouble.of(1234567890.123456), jsonDouble);
+
+        assertEquals(ValueFactory.newFloat(1234567890.123456), jsonDouble.toMsgpack());
+
+        // JsonDouble#equals must normally reject a fake imitation of JsonDouble.
+        assertFalse(jsonDouble.equals(FakeJsonDouble.of(jsonDouble.doubleValue())));
+    }
+
+    @Test
     public void testZero() {
         final JsonDouble jsonDouble = JsonDouble.of(0.0);
         assertEquals(JsonValue.EntityType.DOUBLE, jsonDouble.getEntityType());

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonLong.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonLong.java
@@ -240,7 +240,7 @@ public class TestJsonLong {
         assertThrows(ClassCastException.class, () -> integer.asJsonString());
         assertThrows(ClassCastException.class, () -> integer.asJsonArray());
         assertThrows(ClassCastException.class, () -> integer.asJsonObject());
-        assertEquals(8, integer.presumeReferenceSizeInBytes());
+        assertEquals(80, integer.presumeReferenceSizeInBytes());
         assertTrue(integer.isIntegral());
         assertFalse(integer.isByteValue());
         assertFalse(integer.isShortValue());

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonObject.java
@@ -485,7 +485,7 @@ public class TestJsonObject {
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonString());
         assertThrows(ClassCastException.class, () -> jsonObject.asJsonArray());
         assertEquals(jsonObject, jsonObject.asJsonObject());
-        assertEquals(155, jsonObject.presumeReferenceSizeInBytes());
+        assertEquals(175, jsonObject.presumeReferenceSizeInBytes());
         assertEquals(8, jsonObject.size());
         assertEquals(8, jsonObject.entrySet().size());
         assertEquals(16, jsonObject.getKeyValueArray().length);

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonString.java
@@ -88,7 +88,7 @@ public class TestJsonString {
         assertEquals(string, string.asJsonString());
         assertThrows(ClassCastException.class, () -> string.asJsonArray());
         assertThrows(ClassCastException.class, () -> string.asJsonObject());
-        assertEquals(14, string.presumeReferenceSizeInBytes());
+        assertEquals(40, string.presumeReferenceSizeInBytes());
         assertEquals("hoge\n", string.getString());
         assertEquals("hoge\n", string.getChars());
         assertEquals("\"\\u0068oge\\n\"", string.toJson());


### PR DESCRIPTION
Follow-up to: #1462

`#presumeReferenceSizeInBytes()` should include the size of `literal` in `JsonLong`, `JsonDouble`, and `JsonString` because `literal` consumes the Java heap.