### PR TITLE
Let JsonLong and JsonDouble can be "equal" when JsonDouble is integral

### DIFF
--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonDouble.java
@@ -474,13 +474,17 @@ rrowing Primitive Conversion</a>
         }
 
         // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
-        if (!(otherObject instanceof JsonDouble)) {
-            return false;
+        if (otherObject instanceof JsonDouble) {
+            final JsonDouble other = (JsonDouble) otherObject;
+            return this.value.equals(other.value);
         }
 
-        final JsonDouble other = (JsonDouble) otherObject;
+        if (otherObject instanceof JsonLong) {
+            final JsonLong other = (JsonLong) otherObject;
+            return this.isLongValue() && this.value.toLong() == other.longValue();
+        }
 
-        return this.value.equals(other.value);
+        return false;
     }
 
     /**

--- a/embulk-api/src/main/java/org/embulk/spi/json/JsonLong.java
+++ b/embulk-api/src/main/java/org/embulk/spi/json/JsonLong.java
@@ -448,13 +448,17 @@ public final class JsonLong implements JsonNumber {
         }
 
         // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
-        if (!(otherObject instanceof JsonLong)) {
-            return false;
+        if (otherObject instanceof JsonLong) {
+            final JsonLong other = (JsonLong) otherObject;
+            return this.value.equals(other.value);
         }
 
-        final JsonLong other = (JsonLong) otherObject;
+        if (otherObject instanceof JsonDouble) {
+            final JsonDouble other = (JsonDouble) otherObject;
+            return other.isLongValue() && this.value.toLong() == other.longValue();
+        }
 
-        return this.value.equals(other.value);
+        return false;
     }
 
     /**

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonDouble.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonDouble.java
@@ -146,20 +146,24 @@ public final class FakeJsonDouble implements JsonValue {
             return true;
         }
 
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (otherObject instanceof FakeJsonDouble) {
+            final FakeJsonDouble other = (FakeJsonDouble) otherObject;
+            return this.value.equals(other.value);
+        }
+
         // Fake!
         if (otherObject instanceof JsonDouble) {
             final JsonDouble other = (JsonDouble) otherObject;
             return this.doubleValue() == other.doubleValue();
         }
 
-        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
-        if (!(otherObject instanceof FakeJsonDouble)) {
-            return false;
+        if (otherObject instanceof JsonLong) {
+            final JsonLong other = (JsonLong) otherObject;
+            return this.isLongValue() && this.value.toLong() == other.longValue();
         }
 
-        final FakeJsonDouble other = (FakeJsonDouble) otherObject;
-
-        return this.value.equals(other.value);
+        return false;
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonLong.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/FakeJsonLong.java
@@ -142,20 +142,24 @@ public final class FakeJsonLong implements JsonValue {
             return true;
         }
 
+        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
+        if (otherObject instanceof FakeJsonLong) {
+            final FakeJsonLong other = (FakeJsonLong) otherObject;
+            return this.value.equals(other.value);
+        }
+
         // Fake!
         if (otherObject instanceof JsonLong) {
             final JsonLong other = (JsonLong) otherObject;
             return this.longValue() == other.longValue();
         }
 
-        // Check by `instanceof` in case against unexpected arbitrary extension of JsonValue.
-        if (!(otherObject instanceof FakeJsonLong)) {
-            return false;
+        if (otherObject instanceof JsonDouble) {
+            final JsonDouble other = (JsonDouble) otherObject;
+            return other.isLongValue() && this.value.toLong() == other.longValue();
         }
 
-        final FakeJsonLong other = (FakeJsonLong) otherObject;
-
-        return this.value.equals(other.value);
+        return false;
     }
 
     @Override

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDouble.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonDouble.java
@@ -87,6 +87,8 @@ public class TestJsonDouble {
         assertEquals("1.234567890123456E9", jsonDouble.toJson());
         assertEquals("1.234567890123456E9", jsonDouble.toString());
         assertEquals(JsonDouble.of(1234567890.123456), jsonDouble);
+        assertNotEquals(JsonDouble.of(1234567890.123457), jsonDouble);
+        assertNotEquals(JsonLong.of(1234567890L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(1234567890.123456), jsonDouble.toMsgpack());
 
@@ -140,6 +142,13 @@ public class TestJsonDouble {
         assertEquals("0.0", jsonDouble.toJson());
         assertEquals("0.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(0.0), jsonDouble);
+        assertEquals(JsonDouble.of(-0.0), jsonDouble);
+        assertNotEquals(JsonDouble.of(0.000001), jsonDouble);
+        assertNotEquals(JsonDouble.of(-0.000001), jsonDouble);
+        assertEquals(JsonLong.of(0L), jsonDouble);
+        assertEquals(JsonLong.of(-0L), jsonDouble);
+        assertNotEquals(JsonLong.of(1L), jsonDouble);
+        assertNotEquals(JsonLong.of(-1L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(0.0), jsonDouble.toMsgpack());
 
@@ -193,6 +202,13 @@ public class TestJsonDouble {
         assertEquals("-0.0", jsonDouble.toJson());
         assertEquals("-0.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(0.0), jsonDouble);
+        assertEquals(JsonDouble.of(-0.0), jsonDouble);
+        assertNotEquals(JsonDouble.of(0.000001), jsonDouble);
+        assertNotEquals(JsonDouble.of(-0.000001), jsonDouble);
+        assertEquals(JsonLong.of(0L), jsonDouble);
+        assertEquals(JsonLong.of(-0L), jsonDouble);
+        assertNotEquals(JsonLong.of(1L), jsonDouble);
+        assertNotEquals(JsonLong.of(-1L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(-0.0), jsonDouble.toMsgpack());
 
@@ -244,6 +260,10 @@ public class TestJsonDouble {
         assertEquals("1.0", jsonDouble.toJson());
         assertEquals("1.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(1.0), jsonDouble);
+        assertNotEquals(JsonDouble.of(0.0), jsonDouble);
+        assertNotEquals(JsonDouble.of(1.0000001), jsonDouble);
+        assertEquals(JsonLong.of(1L), jsonDouble);
+        assertNotEquals(JsonLong.of(0L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(1.0), jsonDouble.toMsgpack());
 
@@ -295,6 +315,11 @@ public class TestJsonDouble {
         assertEquals("-1.0", jsonDouble.toJson());
         assertEquals("-1.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(-1.0), jsonDouble);
+        assertNotEquals(JsonDouble.of(0.0), jsonDouble);
+        assertNotEquals(JsonDouble.of(-0.999999), jsonDouble);
+        assertEquals(JsonLong.of(-1L), jsonDouble);
+        assertNotEquals(JsonLong.of(0L), jsonDouble);
+        assertNotEquals(JsonLong.of(1L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(-1.0), jsonDouble.toMsgpack());
 
@@ -344,6 +369,9 @@ public class TestJsonDouble {
         assertEquals("3.1415", jsonDouble.toJson());
         assertEquals("3.1415", jsonDouble.toString());
         assertEquals(JsonDouble.of(3.1415), jsonDouble);
+        assertNotEquals(JsonDouble.of(3.1416), jsonDouble);
+        assertNotEquals(JsonLong.of(3L), jsonDouble);
+        assertNotEquals(JsonLong.of(4L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(3.1415), jsonDouble.toMsgpack());
 
@@ -394,6 +422,9 @@ public class TestJsonDouble {
         assertTrue(jsonDouble.toJson().startsWith("3.1415926535897"));
         assertTrue(jsonDouble.toString().startsWith("3.1415926535897"));
         assertEquals(JsonDouble.of(Math.PI), jsonDouble);
+        assertNotEquals(JsonDouble.of(Math.PI + 0.00001), jsonDouble);
+        assertNotEquals(JsonLong.of(3L), jsonDouble);
+        assertNotEquals(JsonLong.of(4L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(Math.PI), jsonDouble.toMsgpack());
 
@@ -442,6 +473,9 @@ public class TestJsonDouble {
         assertEquals("19245.0", jsonDouble.toJson());
         assertEquals("19245.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(19245.0), jsonDouble);
+        assertNotEquals(JsonDouble.of(19245.000001), jsonDouble);
+        assertEquals(JsonLong.of(19245L), jsonDouble);
+        assertNotEquals(JsonLong.of(19246L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(19245.0), jsonDouble.toMsgpack());
 
@@ -490,6 +524,8 @@ public class TestJsonDouble {
         assertEquals("19245.12", jsonDouble.toJson());
         assertEquals("19245.12", jsonDouble.toString());
         assertEquals(JsonDouble.of(19245.12), jsonDouble);
+        assertNotEquals(JsonDouble.of(19245.0), jsonDouble);
+        assertNotEquals(JsonLong.of(19245L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(19245.12), jsonDouble.toMsgpack());
 
@@ -538,6 +574,9 @@ public class TestJsonDouble {
         assertEquals("9351902.0", jsonDouble.toJson());
         assertEquals("9351902.0", jsonDouble.toString());
         assertEquals(JsonDouble.of(9351902.0), jsonDouble);
+        assertNotEquals(JsonDouble.of(9351902.001), jsonDouble);
+        assertEquals(JsonLong.of(9351902L), jsonDouble);
+        assertNotEquals(JsonLong.of(9351903L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(9351902.0), jsonDouble.toMsgpack());
 
@@ -586,6 +625,8 @@ public class TestJsonDouble {
         assertEquals("9351902.523", jsonDouble.toJson());
         assertEquals("9351902.523", jsonDouble.toString());
         assertEquals(JsonDouble.of(9351902.523), jsonDouble);
+        assertNotEquals(JsonDouble.of(9351902.0), jsonDouble);
+        assertNotEquals(JsonLong.of(9351902L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(9351902.523), jsonDouble.toMsgpack());
 
@@ -635,6 +676,9 @@ public class TestJsonDouble {
         assertEquals("3.123456789E10", jsonDouble.toJson());
         assertEquals("3.123456789E10", jsonDouble.toString());
         assertEquals(JsonDouble.of(31234567890.0), jsonDouble);
+        assertNotEquals(JsonDouble.of(31234567890.1), jsonDouble);
+        assertEquals(JsonLong.of(31234567890L), jsonDouble);
+        assertNotEquals(JsonLong.of(31234567891L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(31234567890.0), jsonDouble.toMsgpack());
 
@@ -679,9 +723,12 @@ public class TestJsonDouble {
         assertEquals((float) 31234567890.12, jsonDouble.floatValue(), 0.001);
         assertEquals(31234567890.12, jsonDouble.doubleValue(), 0.001);
         assertEquals(BigDecimal.valueOf(31234567890.12), jsonDouble.bigDecimalValue());
+
         assertEquals("3.123456789012E10", jsonDouble.toJson());
         assertEquals("3.123456789012E10", jsonDouble.toString());
         assertEquals(JsonDouble.of(31234567890.12), jsonDouble);
+        assertNotEquals(JsonDouble.of(31234567890.0), jsonDouble);
+        assertNotEquals(JsonLong.of(31234567890L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(31234567890.12), jsonDouble.toMsgpack());
 
@@ -731,6 +778,7 @@ public class TestJsonDouble {
         assertEquals("9.223372036854776E21", jsonDouble.toJson());
         assertEquals("9.223372036854776E21", jsonDouble.toString());
         assertEquals(JsonDouble.of(9.223372036854776E21), jsonDouble);
+        assertNotEquals(JsonDouble.of(9.223372036854777E21), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(9_223_372_036_854_775_807_000.0), jsonDouble.toMsgpack());
 
@@ -780,6 +828,7 @@ public class TestJsonDouble {
         assertEquals("9.223372036854776E21", jsonDouble.toJson());
         assertEquals("9.223372036854776E21", jsonDouble.toString());
         assertEquals(JsonDouble.of(9.223372036854776E21), jsonDouble);
+        assertNotEquals(JsonDouble.of(9.223372036854777E21), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(9_223_372_036_854_775_807_000.12), jsonDouble.toMsgpack());
 
@@ -831,6 +880,8 @@ public class TestJsonDouble {
         assertEquals("4.9E-324", jsonDouble.toJson());
         assertEquals("4.9E-324", jsonDouble.toString());
         assertEquals(JsonDouble.of(Double.MIN_VALUE), jsonDouble);
+        assertNotEquals(JsonDouble.of(Double.MIN_VALUE * 2), jsonDouble);
+        assertNotEquals(JsonLong.of(0L), jsonDouble);
 
         assertEquals(ValueFactory.newFloat(Double.MIN_VALUE), jsonDouble.toMsgpack());
 

--- a/embulk-api/src/test/java/org/embulk/spi/json/TestJsonLong.java
+++ b/embulk-api/src/test/java/org/embulk/spi/json/TestJsonLong.java
@@ -18,6 +18,7 @@ package org.embulk.spi.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -74,6 +75,9 @@ public class TestJsonLong {
         assertEquals("123", integer.toJson());
         assertEquals("123", integer.toString());
         assertEquals(JsonLong.of(123L), integer);
+        assertNotEquals(JsonLong.of(122L), integer);
+        assertEquals(JsonDouble.of(123.0), integer);
+        assertNotEquals(JsonDouble.of(123.00000001), integer);
 
         assertEquals(ValueFactory.newInteger(123L), integer.toMsgpack());
 
@@ -121,6 +125,9 @@ public class TestJsonLong {
         assertEquals("12345", integer.toJson());
         assertEquals("12345", integer.toString());
         assertEquals(JsonLong.of(12345L), integer);
+        assertNotEquals(JsonLong.of(12346L), integer);
+        assertEquals(JsonDouble.of(12345.0), integer);
+        assertNotEquals(JsonDouble.of(12345.00000001), integer);
 
         assertEquals(ValueFactory.newInteger(12345L), integer.toMsgpack());
 
@@ -168,6 +175,9 @@ public class TestJsonLong {
         assertEquals("1234567890", integer.toJson());
         assertEquals("1234567890", integer.toString());
         assertEquals(JsonLong.of(1234567890L), integer);
+        assertNotEquals(JsonLong.of(1234567891L), integer);
+        assertEquals(JsonDouble.of(1234567890.0), integer);
+        assertNotEquals(JsonDouble.of(1234567890.00001), integer);
 
         assertEquals(ValueFactory.newInteger(1234567890L), integer.toMsgpack());
 
@@ -215,6 +225,9 @@ public class TestJsonLong {
         assertEquals("1234567890123456", integer.toJson());
         assertEquals("1234567890123456", integer.toString());
         assertEquals(JsonLong.of(1234567890123456L), integer);
+        assertNotEquals(JsonLong.of(1234567890123457L), integer);
+        assertEquals(JsonDouble.of(1234567890123456.0), integer);
+        assertNotEquals(JsonDouble.of(1234567890123457.0), integer);
 
         assertEquals(ValueFactory.newInteger(1234567890123456L), integer.toMsgpack());
 
@@ -262,6 +275,9 @@ public class TestJsonLong {
         assertEquals("999999999999999999991234567890123456", integer.toJson());
         assertEquals("1234567890123456", integer.toString());
         assertEquals(JsonLong.of(1234567890123456L), integer);
+        assertNotEquals(JsonLong.of(1234567890123457L), integer);
+        assertEquals(JsonDouble.of(1234567890123456.0), integer);
+        assertNotEquals(JsonDouble.of(1234567890123457.0), integer);
 
         assertEquals(ValueFactory.newInteger(1234567890123456L), integer.toMsgpack());
 


### PR DESCRIPTION
Follow-up to: #1462

In terms of the `JSON` context, `JsonLong.of(12345L)` should be "equal" to `JsonDouble.of(12345.0)` because both are "JSON numbers".
