### PR TITLE
Update checkout and setup-java to v3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,9 +21,9 @@ jobs:
         - ":embulk-junit4:check"
         - ":embulk-deps:check"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up OpenJDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: 8
         distribution: "zulu"


### PR DESCRIPTION
# Background
Current github actions workflows show warning:
* Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-java@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
* The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

See https://github.com/embulk/embulk/actions/runs/4060013260

# Solution
Update to the latest plugin version

# Impact
Just the github actions

# Rollback
Revert this PR