### PR TITLE
Upgrade embulk-api's slf4j-api to 2.0.6, and executable's logback-classic to 1.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,13 @@ dependencies {
     implementation project(':embulk-core')
 
     // Logback and jansi are included only in the executable package. (jansi for logback colors to work on Windows.)
-    implementation "ch.qos.logback:logback-classic:1.2.3"
+
+    // Logback 1.4.x seems to be the latest as of Feb, 2023. But actually, their version strategy is:
+    // * Logback 1.3.x for Java 8 and Java EE (javax.*)
+    // * Logback 1.4.x for Java 11 and Jakarta EE (jakarta.*)
+    // https://logback.qos.ch/dependencies.html
+    implementation "ch.qos.logback:logback-classic:1.3.5"
+
     implementation "org.fusesource.jansi:jansi:1.18"
 
     embed project(":embulk-deps")

--- a/embulk-api/build.gradle
+++ b/embulk-api/build.gradle
@@ -10,7 +10,7 @@ configurations {
 }
 
 dependencies {
-    api "org.slf4j:slf4j-api:1.7.30"
+    api "org.slf4j:slf4j-api:2.0.6"
 
     // It will be removed in the future, but not very soon from Embulk v1.0.0.
     //

--- a/embulk-api/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-api/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,4 +2,4 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.24
-org.slf4j:slf4j-api:1.7.30
+org.slf4j:slf4j-api:2.0.6

--- a/embulk-api/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-api/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,4 +2,4 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.24
-org.slf4j:slf4j-api:1.7.30
+org.slf4j:slf4j-api:2.0.6

--- a/embulk-core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-core/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,4 +2,4 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.24
-org.slf4j:slf4j-api:1.7.30
+org.slf4j:slf4j-api:2.0.6

--- a/embulk-core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,4 +2,4 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.24
-org.slf4j:slf4j-api:1.7.30
+org.slf4j:slf4j-api:2.0.6

--- a/embulk-deps/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/gradle/dependency-locks/compileClasspath.lockfile
@@ -33,5 +33,5 @@ org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-timestamp:0.2.1
 org.jline:jline-terminal:3.16.0
 org.msgpack:msgpack-core:0.8.24
-org.slf4j:slf4j-api:1.7.30
+org.slf4j:slf4j-api:2.0.6
 org.yaml:snakeyaml:1.18

--- a/embulk-junit4/build.gradle
+++ b/embulk-junit4/build.gradle
@@ -15,5 +15,5 @@ dependencies {
 
     api project(":embulk-api")
     api project(":embulk-core")
-    compileOnly "org.slf4j:slf4j-api:1.7.12"
+    compileOnly "org.slf4j:slf4j-api:2.0.6"
 }

--- a/embulk-junit4/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-junit4/gradle/dependency-locks/compileClasspath.lockfile
@@ -5,4 +5,4 @@ junit:junit:4.13.2
 org.hamcrest:hamcrest-core:1.3
 org.hamcrest:hamcrest-library:1.3
 org.msgpack:msgpack-core:0.8.24
-org.slf4j:slf4j-api:1.7.30
+org.slf4j:slf4j-api:2.0.6

--- a/embulk-junit4/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-junit4/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -5,4 +5,4 @@ junit:junit:4.13.2
 org.hamcrest:hamcrest-core:1.3
 org.hamcrest:hamcrest-library:1.3
 org.msgpack:msgpack-core:0.8.24
-org.slf4j:slf4j-api:1.7.30
+org.slf4j:slf4j-api:2.0.6

--- a/embulk-spi/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-spi/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,4 +2,4 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.24
-org.slf4j:slf4j-api:1.7.30
+org.slf4j:slf4j-api:2.0.6

--- a/embulk-spi/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-spi/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,4 +2,4 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.24
-org.slf4j:slf4j-api:1.7.30
+org.slf4j:slf4j-api:2.0.6


### PR DESCRIPTION
Let's update SLF4J and Logback to the (available) latest before we go into Embulk v0.11!

SLF4J v2.0 should basically have a compatible interface with SLF4J v1.7, just with :
* Fluent logging interface in addition, and
* Better support for Java 9+ modules (Jigsaw).

Logback needs to be updated to v1.3 to follow. (I believe that v1.3 will work with Java 9+ whiel v1.4 does not work with Java 8.)

Plugins should be depending on `embulk-api` just with `compileOnly`. The actual SLF4J and Logback artifacts are bundled only with the Embulk executable binary. The dependency on `embulk-api` from plugins should not be a big problem.