### PR TITLE
Update links to the slf4j-api Javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ configure(subprojects.findAll { subprojectNamesOfCoreArtifacts.contains(it.name)
             if (project.name == "embulk-api" || project.name == "embulk-spi" ) {
                 overview = "src/main/html/overview.html"
                 links "https://docs.oracle.com/javase/8/docs/api/"
-                links "https://www.javadoc.io/doc/org.slf4j/slf4j-api/1.7.30/"
+                links "https://www.slf4j.org/apidocs/"
             }
         }
     }


### PR DESCRIPTION
It should have been updated in v0.10.43, but overlooked.