### PR TITLE
Remove the Gradle embulk-plugins plugin from build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id "java-library"
     id "maven-publish"
     id "jacoco"
-    id "org.embulk.embulk-plugins" version "0.4.2" apply false
 }
 
 repositories {


### PR DESCRIPTION
The `embulk-plugins` Gradle plugin has been no longer used after the standards plugins were moved to: https://github.com/embulk/embulk-standards