### PR TITLE
Remove Jansi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,15 +45,11 @@ configurations {
 dependencies {
     implementation project(':embulk-core')
 
-    // Logback and jansi are included only in the executable package. (jansi for logback colors to work on Windows.)
-
     // Logback 1.4.x seems to be the latest as of Feb, 2023. But actually, their version strategy is:
     // * Logback 1.3.x for Java 8 and Java EE (javax.*)
     // * Logback 1.4.x for Java 11 and Jakarta EE (jakarta.*)
     // https://logback.qos.ch/dependencies.html
     implementation "ch.qos.logback:logback-classic:1.3.5"
-
-    implementation "org.fusesource.jansi:jansi:1.18"
 
     embed project(":embulk-deps")
 


### PR DESCRIPTION
Jansi had been included in Embulk since v0.6.12 to "color" Logback logs even in Windows.
See commit: 34d238494e05231ecb5fe5e10910119035767492

We, however, do not see a big benefit to keep it. It is not critical, but taking a certain amount in Embulk's executable size. Let's remove it.

We may get it back if we receive many requests to do it again in the future.