### PR TITLE
Remove JLine

### DIFF
--- a/embulk-deps/build.gradle
+++ b/embulk-deps/build.gradle
@@ -42,7 +42,6 @@ dependencies {
 
     // CLI
     api "commons-cli:commons-cli:1.4"
-    api "org.jline:jline-terminal:3.16.0"
 
     // Config
     api "org.yaml:snakeyaml:1.18"

--- a/embulk-deps/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-deps/gradle/dependency-locks/compileClasspath.lockfile
@@ -30,7 +30,6 @@ org.codehaus.plexus:plexus-interpolation:1.25
 org.codehaus.plexus:plexus-utils:3.2.0
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-timestamp:0.2.1
-org.jline:jline-terminal:3.16.0
 org.msgpack:msgpack-core:0.8.24
 org.slf4j:slf4j-api:2.0.6
 org.yaml:snakeyaml:1.18

--- a/embulk-deps/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-deps/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -31,5 +31,4 @@ org.codehaus.plexus:plexus-utils:3.2.0
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1
-org.jline:jline-terminal:3.16.0
 org.yaml:snakeyaml:1.18

--- a/embulk-deps/src/main/java/org/embulk/deps/cli/CommandLineImpl.java
+++ b/embulk-deps/src/main/java/org/embulk/deps/cli/CommandLineImpl.java
@@ -15,7 +15,6 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.embulk.EmbulkVersion;
 import org.embulk.cli.Command;
-import org.jline.terminal.TerminalBuilder;
 import org.slf4j.Logger;
 
 final class CommandLineImpl extends org.embulk.cli.CommandLine {
@@ -278,7 +277,7 @@ final class CommandLineImpl extends org.embulk.cli.CommandLine {
         final HelpFormatter formatter = new HelpFormatterWithPlaceholders("Usage: ", 22);
         formatter.printHelp(
                 writer,
-                TerminalHolder.WIDTH,
+                TERMINAL_WIDTH,
                 usage,
                 header,
                 options,
@@ -381,25 +380,7 @@ final class CommandLineImpl extends org.embulk.cli.CommandLine {
         }
     }
 
-    private static class TerminalHolder {  // Initialization-on-demand holder idiom.
-        private static final int WIDTH = getTerminalWidth(78);
-
-        private static int getTerminalWidth(final int defaultWidth) {
-            java.util.logging.Logger.getLogger("org.jline").setLevel(java.util.logging.Level.OFF);
-
-            final int retrievedWidth;
-            try {
-                retrievedWidth = TerminalBuilder.builder().system(true).build().getWidth();
-            } catch (final Throwable ex) {
-                return defaultWidth;
-            }
-
-            if (retrievedWidth <= 40) {
-                return defaultWidth;
-            }
-            return retrievedWidth;
-        }
-    }
+    private static final int TERMINAL_WIDTH = 78;
 
     private static final String COMMANDS_HELP =
             "\nCommands:\n"


### PR DESCRIPTION
JLine has been included in Embulk since v0.10.20 along with refactoring the command line parser.
See pull request: #1333

We, however, do not see a big benefit to keep it. It is not critical, but taking a certain amount in Embulk's executable size. Let's remove it.

We may get it back if we receive many requests to do it again in the future.