### PR TITLE
Mix embulk-spi's classes into embulk-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,14 @@ configurations {
 }
 
 dependencies {
-    implementation project(':embulk-core')
+    // The classes of "embulk-spi" are excluded from "embulk-core" below for the consistency as a JAR file.
+    // But, they should be included in the compile classpath.
+    compileOnly project(":embulk-spi")
+
+    implementation(project(":embulk-core")) {
+        // The JAR file of "embulk-core" should already contain classes of "embulk-spi".
+        exclude group: "org.embulk", module: "embulk-spi"
+    }
 
     // Logback 1.4.x seems to be the latest as of Feb, 2023. But actually, their version strategy is:
     // * Logback 1.3.x for Java 8 and Java EE (javax.*)

--- a/embulk-core/build.gradle
+++ b/embulk-core/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "java"
-    id "java-library"
     id "maven-publish"
     id "signing"
     id "checkstyle"
@@ -15,6 +14,13 @@ version = rootProject.version
 description = "Embulk: Core classes"
 
 configurations {
+    // The "spi" configuration is used to make the scope in pom.xml to "provided".
+    spi {
+        resolutionStrategy.activateDependencyLocking()
+        transitive = false
+    }
+
+    implementation.extendsFrom(spi)
     compileClasspath.resolutionStrategy.activateDependencyLocking()
     runtimeClasspath.resolutionStrategy.activateDependencyLocking()
 }
@@ -35,10 +41,25 @@ java {
 }
 
 dependencies {
-    // Embulk plugins have expected that embulk-core's dependencies are declared as "compile" in pom.xml.
-    // Although those dependencies would be finally removed from embulk-core's direct dependencies,
-    // those "compile" declaration would be kept so that plugin developers won't be confused unnecessarily.
-    api project(":embulk-spi")
+    // The compiled class files of "embulk-spi" are mixed into the "embulk-core" JAR file, and
+    // the "embulk-core" Maven artifact has the dependency on "embulk-spi" as "provided" in pom.xml.
+    //
+    // The artifacts are structured like this so that they can bypass the restriction of Java (9+)
+    // Module System that multiple JAR files (modules) cannot contain the same Java package classes.
+    //
+    // This mixing is not necessary when using Embulk with the executable all-in-one binary. But,
+    // it would not work well with Java 9+ in case of using Embulk with self-hosted deployment of
+    // the separated artifacts, embulk-spi, embulk-core, and else.
+    spi project(":embulk-spi")
+
+    // The transitive dependencies of "embulk-spi" are listed explicitly in dependencies { ... }.
+    //
+    // The explicit dependencies may include newer versions than the dependencies of "embulk-spi",
+    // especially after "embulk-spi" goes out for another Git repository. Note that "embulk-core"
+    // may need to have newer versions of "slf4j-api" or "msgpack-core" before updating them in
+    // "embulk-spi".
+    implementation "org.slf4j:slf4j-api:2.0.7"
+    implementation "org.msgpack:msgpack-core:0.8.24"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":embulk-junit4")
@@ -59,6 +80,11 @@ javadoc {
 }
 
 jar {
+    // The compiled class files of "embulk-spi" are mixed into the "embulk-core" JAR file.
+    from {
+        project(":embulk-spi").sourceSets.main.output
+    }
+
     metaInf {
         from rootProject.file("LICENSE")
         from project.file("NOTICE")
@@ -151,6 +177,29 @@ publishing {
                     connection = "scm:git:git://github.com/embulk/embulk.git"
                     developerConnection = "scm:git:git@github.com:embulk/embulk.git"
                     url = "https://github.com/embulk/embulk"
+                }
+
+                // The "embulk-core" Maven artifact has the dependency on "embulk-spi" as "provided" in pom.xml.
+                withXml {
+                    def spiDependencies = []
+                    project.configurations.spi.allDependencies.each { dependency ->
+                        spiDependencies.add(dependency.group + ":" + dependency.name)
+                    }
+                    asNode().dependencies[0].each { dependency ->
+                        if ((dependency.groupId[0].value()[0] + ":" + dependency.artifactId[0].value()[0]) in spiDependencies) {
+                            println "[MODIFY] " + dependency.groupId[0].value()[0] +
+                                    ":" + dependency.artifactId[0].value()[0] +
+                                    ":" + dependency.version[0].value()[0] +
+                                    " @ " + dependency.scope[0].value()[0] +
+                                     " => provided"
+                            dependency.scope[0].setValue("provided")
+                        } else {
+                            println "[ KEEP ] " + dependency.groupId[0].value()[0] +
+                                    ":" + dependency.artifactId[0].value()[0] +
+                                    ":" + dependency.version[0].value()[0] +
+                                    " @ " + dependency.scope[0].value()[0]
+                        }
+                    }
                 }
             }
         }

--- a/embulk-core/gradle.lockfile
+++ b/embulk-core/gradle.lockfile
@@ -3,4 +3,4 @@
 # This file is expected to be part of source control.
 org.msgpack:msgpack-core:0.8.24=compileClasspath,runtimeClasspath
 org.slf4j:slf4j-api:2.0.7=compileClasspath,runtimeClasspath
-empty=
+empty=spi

--- a/embulk-deps/build.gradle
+++ b/embulk-deps/build.gradle
@@ -34,8 +34,9 @@ java {
 }
 
 dependencies {
-    compileOnly project(":embulk-spi")
     compileOnly project(":embulk-core")
+    compileOnly "org.slf4j:slf4j-api:2.0.7"
+    compileOnly "org.msgpack:msgpack-core:0.8.24"
 
     // Buffer
     api "io.netty:netty-buffer:4.0.44.Final"
@@ -185,6 +186,17 @@ publishing {
                     connection = "scm:git:git://github.com/embulk/embulk.git"
                     developerConnection = "scm:git:git@github.com:embulk/embulk.git"
                     url = "https://github.com/embulk/embulk"
+                }
+
+                withXml {
+                    project.configurations.compileOnly.allDependencies.each { dependency ->
+                        asNode().dependencies[0].appendNode("dependency").with {
+                            it.appendNode("groupId", dependency.group)
+                            it.appendNode("artifactId", dependency.name)
+                            it.appendNode("version", dependency.version)
+                            it.appendNode("scope", "provided")
+                        }
+                    }
                 }
             }
         }

--- a/embulk-junit4/build.gradle
+++ b/embulk-junit4/build.gradle
@@ -34,12 +34,12 @@ java {
 }
 
 dependencies {
+    compileOnly project(":embulk-spi")
+
     api "junit:junit:4.13.2"
     api "org.hamcrest:hamcrest-library:1.3"
 
-    api project(":embulk-spi")
     api project(":embulk-core")
-    compileOnly "org.slf4j:slf4j-api:2.0.6"
 }
 
 javadoc {


### PR DESCRIPTION
The compiled class files of "embulk-spi" are mixed into the "embulk-core" JAR file, and the "embulk-core" Maven artifact has the dependency on "embulk-spi" as "provided" in pom.xml.

The artifacts are structured like this so that they can bypass the restriction of Java (9+) Module System that multiple JAR files (modules) cannot contain the same Java package classes.

This mixing is not necessary when using Embulk with the executable all-in-one binary. But, it would not work well with Java 9+ in case of using Embulk with self-hosted deployment of the separated artifacts, embulk-spi, embulk-core, and else.

----

With this change, `embulk-core`'s `pom.xml` would be like following:

```xml
  <dependencies>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>2.0.7</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.msgpack</groupId>
      <artifactId>msgpack-core</artifactId>
      <version>0.8.24</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.embulk</groupId>
      <artifactId>embulk-spi</artifactId>
      <version>0.10.47</version>
      <scope>provided</scope>   <!--  THIS  -->
    </dependency>
  </dependencies>
```

And, `embulk-core`'s JAR (`embulk-core-0.10.47.jar`) would include `embulk-spi`'s classes like following:

```
$ unzip -l build/maven/org/embulk/embulk-core/0.10.47/embulk-core-0.10.47.jar
Archive:  build/maven/org/embulk/embulk-core/0.10.47/embulk-core-0.10.47.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2023-04-04 14:48   META-INF/
      215  2023-04-04 14:48   META-INF/MANIFEST.MF
    11358  2022-10-26 16:48   META-INF/LICENSE
      519  2023-04-03 15:29   META-INF/NOTICE
        0  2023-04-04 14:48   org/
        0  2023-04-04 14:48   org/embulk/
     7953  2023-04-04 14:48   org/embulk/EmbulkEmbed$Bootstrap.class
        0  2023-04-04 14:48   org/embulk/cli/
     1050  2023-04-04 14:48   org/embulk/cli/EmbulkRun$2.class
      504  2023-04-04 14:48   org/embulk/cli/CliManifest.class
...
        0  2023-04-04 14:48   org/embulk/jruby/bundler/template/embulk/filter/
      990  2023-04-04 14:48   org/embulk/jruby/bundler/template/embulk/filter/example.rb
        0  2023-04-04 14:48   embulk/
       89  2023-04-04 14:48   embulk/parent_first_resources.properties
      791  2023-04-04 14:48   embulk/logback-file.xml
      104  2023-04-04 14:48   embulk/parent_first_packages.properties
      378  2023-04-04 14:48   embulk/logback-console.xml
     2418  2023-04-04 14:48   embulk/logback-color.xml
      791  2023-04-04 14:48   org/embulk/config/ConfigException.class  # Files under this line are from embulk-spi.
     2497  2023-04-04 14:48   org/embulk/config/TaskSource.class
     2736  2023-04-04 14:48   org/embulk/config/DataSource.class
...
      698  2023-04-04 14:48   org/embulk/spi/DataException.class
      415  2023-04-04 14:48   org/embulk/spi/InputPlugin$Control.class
      275  2023-04-04 14:48   org/embulk/spi/ParserPlugin$Control.class
      255  2023-04-04 14:48   org/embulk/spi/DecoderPlugin$Control.class
---------                     -------
  1033891                     430 files
```
