### PR TITLE
Move classes about self-contained JAR files to org.embulk.cli

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkDependencyClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkDependencyClassLoader.java
@@ -7,8 +7,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.embulk.deps.EmbulkSelfContainedJarFiles;
-import org.embulk.deps.SelfContainedJarAwareURLClassLoader;
+import org.embulk.cli.SelfContainedJarAwareURLClassLoader;
+import org.embulk.cli.SelfContainedJarFiles;
 
 /**
  * A singleton class loader to load classes of embulk-core's hidden dependency libraries, such as Jackson.
@@ -20,7 +20,7 @@ public final class EmbulkDependencyClassLoader extends SelfContainedJarAwareURLC
     private EmbulkDependencyClassLoader(
             final Collection<Path> jarPaths, final ClassLoader parent, final boolean useSelfContainedJarFile) {
         // The delegation parent ClassLoader is processed by the super class URLClassLoader.
-        super(toUrls(jarPaths), parent, useSelfContainedJarFile ? EmbulkSelfContainedJarFiles.CORE : null);
+        super(toUrls(jarPaths), parent, useSelfContainedJarFile ? SelfContainedJarFiles.CORE : null);
     }
 
     public static final class StaticInitializer {
@@ -69,7 +69,7 @@ public final class EmbulkDependencyClassLoader extends SelfContainedJarAwareURLC
     @Override
     public void close() throws IOException {
         super.close();
-        // TODO: Close EmbulkSelfContainedJarFiles?
+        // TODO: Close SelfContainedJarFiles?
     }
 
     @Override

--- a/embulk-core/src/main/java/org/embulk/cli/ByteBufferInputStream.java
+++ b/embulk-core/src/main/java/org/embulk/cli/ByteBufferInputStream.java
@@ -1,4 +1,4 @@
-package org.embulk.deps;
+package org.embulk.cli;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/embulk-core/src/main/java/org/embulk/cli/JarEmbeddedUrlStreamHandler.java
+++ b/embulk-core/src/main/java/org/embulk/cli/JarEmbeddedUrlStreamHandler.java
@@ -1,4 +1,4 @@
-package org.embulk.deps;
+package org.embulk.cli;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/embulk-core/src/main/java/org/embulk/cli/Main.java
+++ b/embulk-core/src/main/java/org/embulk/cli/Main.java
@@ -7,7 +7,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.jar.Manifest;
 import org.embulk.EmbulkDependencyClassLoader;
 import org.embulk.EmbulkSystemProperties;
-import org.embulk.deps.EmbulkSelfContainedJarFiles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.SubstituteLoggingEvent;
@@ -18,7 +17,7 @@ public class Main {
         final Manifest manifest = CliManifest.getManifest();
 
         // They are loaded before SLF4J is initialized along with Logback. They don't use SLF4J for error logging.
-        EmbulkSelfContainedJarFiles.staticInitializer().addFromManifest(manifest).initialize();
+        SelfContainedJarFiles.staticInitializer().addFromManifest(manifest).initialize();
         EmbulkDependencyClassLoader.staticInitializer().useSelfContainedJarFiles().initialize();
 
         // Using SubstituteLogger here because SLF4J and Logback are initialized later (CliLogbackConfigurator.configure).

--- a/embulk-core/src/main/java/org/embulk/cli/Resource.java
+++ b/embulk-core/src/main/java/org/embulk/cli/Resource.java
@@ -1,4 +1,4 @@
-package org.embulk.deps;
+package org.embulk.cli;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/embulk-core/src/main/java/org/embulk/cli/SelfContainedJarAwareURLClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/cli/SelfContainedJarAwareURLClassLoader.java
@@ -1,4 +1,4 @@
-package org.embulk.deps;
+package org.embulk.cli;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -59,7 +59,7 @@ public class SelfContainedJarAwareURLClassLoader extends URLClassLoader {
                     @Override
                     public Class<?> run() throws ClassNotFoundException {
                         try {
-                            return defineClassFromEmbulkSelfContainedJarFiles(className);
+                            return defineClassFromSelfContainedJarFiles(className);
                         } catch (final ClassNotFoundException | LinkageError | ClassCastException ex) {
                             throw ex;
                         } catch (final Throwable ex) {
@@ -116,7 +116,7 @@ public class SelfContainedJarAwareURLClassLoader extends URLClassLoader {
             // TODO: Consider duplicated resources.
             final Resource resource;
             try {
-                resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName, this.selfContainedJarCategory);
+                resource = SelfContainedJarFiles.getSingleResource(resourceName, this.selfContainedJarCategory);
             } catch (final IllegalArgumentException ex) {
                 Holder.logger.info("Unexpected self-contained JAR category \"{}\" is requested for resource \"{}\".",
                                    this.selfContainedJarCategory, resourceName);
@@ -162,7 +162,7 @@ public class SelfContainedJarAwareURLClassLoader extends URLClassLoader {
             // Even if some resources are found from the delegation parent class loader, it looks into self-contained JAR files.
             final Collection<Resource> resources;
             try {
-                resources = EmbulkSelfContainedJarFiles.getMultipleResources(resourceName, this.selfContainedJarCategory);
+                resources = SelfContainedJarFiles.getMultipleResources(resourceName, this.selfContainedJarCategory);
             } catch (final IllegalArgumentException ex) {
                 Holder.logger.info("Unexpected self-contained JAR category \"{}\" is requested for resource \"{}\".",
                                    this.selfContainedJarCategory, resourceName);
@@ -195,7 +195,7 @@ public class SelfContainedJarAwareURLClassLoader extends URLClassLoader {
         return resourceUrls.elements();
     }
 
-    private Class<?> defineClassFromEmbulkSelfContainedJarFiles(final String className) throws ClassNotFoundException {
+    private Class<?> defineClassFromSelfContainedJarFiles(final String className) throws ClassNotFoundException {
         if (this.selfContainedJarCategory == null) {
             throw new ClassNotFoundException(className);
         }
@@ -205,7 +205,7 @@ public class SelfContainedJarAwareURLClassLoader extends URLClassLoader {
         // Class must be singular.
         final Resource resource;
         try {
-            resource = EmbulkSelfContainedJarFiles.getSingleResource(resourceName, this.selfContainedJarCategory);
+            resource = SelfContainedJarFiles.getSingleResource(resourceName, this.selfContainedJarCategory);
         } catch (final IllegalArgumentException ex) {
             Holder.logger.info("Unexpected self-contained JAR category \"{}\" is requested for class \"{}\"",
                                this.selfContainedJarCategory, className);

--- a/embulk-core/src/main/java/org/embulk/cli/SelfContainedJarFile.java
+++ b/embulk-core/src/main/java/org/embulk/cli/SelfContainedJarFile.java
@@ -1,4 +1,4 @@
-package org.embulk.deps;
+package org.embulk.cli;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -21,7 +21,7 @@ final class SelfContainedJarFile {
         }
 
         if (CODE_SOURCE_URL_BASE == null) {
-            System.err.println("org.embulk.deps.SelfContainedJarFile is loaded through invalid method or location.");
+            System.err.println("org.embulk.cli.SelfContainedJarFile is loaded through invalid method or location.");
             this.codeSourceUrl = null;
             this.manifest = null;
             this.innerResources = null;
@@ -210,7 +210,7 @@ final class SelfContainedJarFile {
                 throw new MalformedURLException("Invalid CodeSource URL, neither 'file:' nor 'jar:': " + codeSourceUrl);
             }
         } catch (final Exception ex) {
-            System.err.println("org.embulk.deps.SelfContainedJarFile is loaded through invalid method or location.");
+            System.err.println("org.embulk.cli.SelfContainedJarFile is loaded through invalid method or location.");
             ex.printStackTrace();
             hasFailedInCodeSource = true;
         }

--- a/embulk-core/src/main/java/org/embulk/cli/SelfContainedJarFiles.java
+++ b/embulk-core/src/main/java/org/embulk/cli/SelfContainedJarFiles.java
@@ -1,4 +1,4 @@
-package org.embulk.deps;
+package org.embulk.cli;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -17,8 +17,8 @@ import java.util.jar.Manifest;
  * <p>{@link org.embulk.EmbulkDependencyClassLoader} is introduced only to control the visibility from plugins,
  * not for customizability. It is intentionally designed to be a singleton.
  */
-public final class EmbulkSelfContainedJarFiles {
-    private EmbulkSelfContainedJarFiles() {
+public final class SelfContainedJarFiles {
+    private SelfContainedJarFiles() {
         // No instantiation.
     }
 
@@ -105,12 +105,12 @@ public final class EmbulkSelfContainedJarFiles {
 
     static Resource getSingleResource(final String targetResourceName, final String category) {
         if (category == null) {
-            throw new NullPointerException("EmbulkSelfContainedJarFiles.getSingleResources received null.");
+            throw new NullPointerException("SelfContainedJarFiles.getSingleResources received null.");
         }
         final List<String> jarResourceNames = JAR_RESOURCE_NAMES.get(category);
         if (jarResourceNames == null) {
             throw new IllegalArgumentException(
-                    "EmbulkSelfContainedJarFiles.getSingleResources received unexpected category: " + category);
+                    "SelfContainedJarFiles.getSingleResources received unexpected category: " + category);
         }
 
         String foundJarResourceName = null;
@@ -131,12 +131,12 @@ public final class EmbulkSelfContainedJarFiles {
 
     static Collection<Resource> getMultipleResources(final String targetResourceName, final String category) {
         if (category == null) {
-            throw new NullPointerException("EmbulkSelfContainedJarFiles.getMultipleResources received null.");
+            throw new NullPointerException("SelfContainedJarFiles.getMultipleResources received null.");
         }
         final List<String> jarResourceNames = JAR_RESOURCE_NAMES.get(category);
         if (jarResourceNames == null) {
             throw new IllegalArgumentException(
-                    "EmbulkSelfContainedJarFiles.getMultipleResources received unexpected category: " + category);
+                    "SelfContainedJarFiles.getMultipleResources received unexpected category: " + category);
         }
 
         final ArrayList<Resource> resourcesToReturn = new ArrayList<>();

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Vector;
 import java.util.stream.Collectors;
-import org.embulk.deps.SelfContainedJarAwareURLClassLoader;
+import org.embulk.cli.SelfContainedJarAwareURLClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginRegistry.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginRegistry.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.embulk.EmbulkSystemProperties;
-import org.embulk.deps.EmbulkSelfContainedJarFiles;
+import org.embulk.cli.SelfContainedJarFiles;
 import org.embulk.plugin.DefaultPluginType;
 import org.embulk.plugin.PluginClassLoaderFactory;
 import org.embulk.plugin.PluginSourceNotMatchException;
@@ -73,7 +73,7 @@ final class SelfContainedPluginRegistry {
 
     private Class<?> search(final DefaultPluginType pluginType) throws PluginSourceNotMatchException {
         final String selfContainedPluginName = "embulk-" + this.category + "-" + pluginType.getName();
-        if (!EmbulkSelfContainedJarFiles.has(selfContainedPluginName)) {
+        if (!SelfContainedJarFiles.has(selfContainedPluginName)) {
             throw new PluginSourceNotMatchException();
         }
 

--- a/embulk-core/src/main/java/org/embulk/plugin/jar/JarPluginLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/jar/JarPluginLoader.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-import org.embulk.deps.EmbulkSelfContainedJarFiles;
+import org.embulk.cli.SelfContainedJarFiles;
 import org.embulk.plugin.PluginClassLoader;
 import org.embulk.plugin.PluginClassLoaderFactory;
 
@@ -55,7 +55,7 @@ public class JarPluginLoader implements AutoCloseable {
             final String selfContainedPluginName,
             final PluginClassLoaderFactory classLoaderFactory)
             throws InvalidJarPluginException {
-        final Manifest manifest = EmbulkSelfContainedJarFiles.getFirstManifest(selfContainedPluginName);
+        final Manifest manifest = SelfContainedJarFiles.getFirstManifest(selfContainedPluginName);
         final Attributes manifestAttributes = manifest.getMainAttributes();
         final int spiVersion = getPluginSpiVersionFromManifest(manifestAttributes);
 


### PR DESCRIPTION
Wanted not to have classes under org.embulk.deps in embulk-core, for the same motivation with #1589, #1590, #1591, and #1592.

"Self-contained JAR files" are used for the all-in-one executable JAR file, then those classes are used with CLI, therefore nice to locate them in `org.embulk.cli`.