### PR TITLE
Set guess_sample_buffer_bytes and preview_sample_buffer_bytes from Embulk System Properties

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -81,7 +81,7 @@ public class EmbulkEmbed {
             this.bulkLoader = alternativeBulkLoader;
         }
         this.guessExecutor = new GuessExecutor(embulkSystemProperties);
-        this.previewExecutor = new PreviewExecutor();
+        this.previewExecutor = new PreviewExecutor(embulkSystemProperties);
 
         this.modelManager = createModelManager();
     }

--- a/embulk-core/src/main/java/org/embulk/EmbulkSystemProperties.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkSystemProperties.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -61,6 +62,14 @@ public final class EmbulkSystemProperties extends Properties {
             return defaultValue;
         }
         return parseInteger(value);
+    }
+
+    public OptionalInt getPropertyAsOptionalInt(final String key) {
+        final String value = this.getProperty(key);
+        if (value == null) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(parseInteger(value));
     }
 
     @Override  // From Properties

--- a/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
+++ b/embulk-core/src/main/java/org/embulk/exec/GuessExecutor.java
@@ -3,6 +3,7 @@ package org.embulk.exec;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.concurrent.ExecutionException;
 import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.Config;
@@ -30,8 +31,6 @@ import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.Schema;
 
 public class GuessExecutor {
-    private final List<PluginType> defaultGuessPlugins;
-
     private interface GuessExecutorTask extends Task {
         @Config("guess_plugins")
         @ConfigDefault("[]")
@@ -42,19 +41,26 @@ public class GuessExecutor {
         public List<PluginType> getExcludeGuessPlugins();
 
         @Config("guess_sample_buffer_bytes")
-        @ConfigDefault("32768") // 32 * 1024
-        public int getSampleBufferBytes();
+        @ConfigDefault("null")
+        public OptionalInt getSampleBufferBytes();
     }
 
     // Used by FileInputRunner#guess(..)
-    public static ConfigSource createSampleBufferConfigFromExecConfig(ConfigSource execConfig) {
+    public static ConfigSource createSampleBufferConfigFromExecConfig(
+            final ConfigSource execConfig, final EmbulkSystemProperties embulkSystemProperties) {
         final GuessExecutorTask execTask = loadGuessExecutorTask(execConfig);
-        return Exec.newConfigSource().set("sample_buffer_bytes", execTask.getSampleBufferBytes());
+        final OptionalInt systemGuessSampleBufferBytes =
+                embulkSystemProperties.getPropertyAsOptionalInt("guess_sample_buffer_bytes");
+        return Exec.newConfigSource().set(
+                "sample_buffer_bytes",
+                execTask.getSampleBufferBytes().orElse(systemGuessSampleBufferBytes.orElse(DEAULT_SAMPLE_BUFFER_BYTES)));
     }
 
     public GuessExecutor(final EmbulkSystemProperties embulkSystemProperties) {
+        this.embulkSystemProperties = embulkSystemProperties;
         final String defaultGuessPlugins = embulkSystemProperties.getProperty("default_guess_plugins", null);
         final String guessPlugins = embulkSystemProperties.getProperty("guess_plugins", null);
+        this.systemGuessSampleBufferBytes = embulkSystemProperties.getPropertyAsOptionalInt("guess_sample_buffer_bytes");
 
         final ArrayList<PluginType> guessPluginsBuilt = new ArrayList<>();
 
@@ -127,7 +133,8 @@ public class GuessExecutor {
         final GuessExecutorTask task = loadGuessExecutorTask(execConfig);
         guessPlugins.addAll(task.getGuessPlugins());
         guessPlugins.removeAll(task.getExcludeGuessPlugins());
-        final int guessParserSampleBufferBytes = task.getSampleBufferBytes();
+        final int guessParserSampleBufferBytes =
+                task.getSampleBufferBytes().orElse(this.systemGuessSampleBufferBytes.orElse(DEAULT_SAMPLE_BUFFER_BYTES));
 
         return guessParserConfig(sample, inputConfig, guessPlugins, guessParserSampleBufferBytes);
     }
@@ -146,7 +153,7 @@ public class GuessExecutor {
                     .set("guess_parser_sample_buffer_bytes", guessParserSampleBufferBytes);
 
             // run FileInputPlugin
-            final FileInputRunner input = new FileInputRunner(new BufferFileInputPlugin(sample));
+            final FileInputRunner input = new FileInputRunner(new BufferFileInputPlugin(sample), this.embulkSystemProperties);
             ConfigDiff guessed;
             try {
                 input.transaction(guessInputConfig, new InputPlugin.Control() {
@@ -297,4 +304,10 @@ public class GuessExecutor {
     private static GuessExecutorTask loadGuessExecutorTask(final ConfigSource config) {
         return config.loadConfig(GuessExecutorTask.class);
     }
+
+    private static final int DEAULT_SAMPLE_BUFFER_BYTES = 32768;  // 32 * 1024
+
+    private final List<PluginType> defaultGuessPlugins;
+    private final EmbulkSystemProperties embulkSystemProperties;
+    private final OptionalInt systemGuessSampleBufferBytes;
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/BuiltinPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/BuiltinPluginSource.java
@@ -203,7 +203,7 @@ public class BuiltinPluginSource implements PluginSource {
             final Class<? extends FileInputPlugin> fileInputPluginImpl = this.fileInputPlugins.get(name);
             if (fileInputPluginImpl != null) {
                 return pluginInterface.cast(new FileInputRunner((FileInputPlugin) PluginManager.newPluginInstance(
-                        fileInputPluginImpl, this.embulkSystemProperties)));
+                        fileInputPluginImpl, this.embulkSystemProperties), this.embulkSystemProperties));
             }
         } else if (OutputPlugin.class.isAssignableFrom(pluginInterface)) {
             // Duplications between Output Plugins and File Output Plugins are rejected when registered above.

--- a/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/SelfContainedPluginSource.java
@@ -58,7 +58,7 @@ public class SelfContainedPluginSource implements PluginSource {
                             "[FATAL/INTERNAL] Plugin class \"" + pluginMainClass.getName() + "\" is not file-input.",
                             ex);
                 }
-                pluginMainObject = new FileInputRunner(fileInputPluginMainObject);
+                pluginMainObject = new FileInputRunner(fileInputPluginMainObject, this.embulkSystemProperties);
             } else if (FileOutputPlugin.class.isAssignableFrom(pluginMainClass)) {
                 final FileOutputPlugin fileOutputPluginMainObject;
                 try {

--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginSource.java
@@ -47,7 +47,7 @@ public class MavenPluginSource implements PluginSource {
                             "[FATAL/INTERNAL] Plugin class \"" + pluginMainClass.getName() + "\" is not file-input.",
                             ex);
                 }
-                pluginMainObject = new FileInputRunner(fileInputPluginMainObject);
+                pluginMainObject = new FileInputRunner(fileInputPluginMainObject, this.embulkSystemProperties);
             } else if (FileOutputPlugin.class.isAssignableFrom(pluginMainClass)) {
                 final FileOutputPlugin fileOutputPluginMainObject;
                 try {

--- a/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
+++ b/embulk-core/src/main/java/org/embulk/spi/FileInputRunner.java
@@ -4,6 +4,7 @@ import static org.embulk.exec.GuessExecutor.createSampleBufferConfigFromExecConf
 
 import java.util.ArrayList;
 import java.util.List;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -18,10 +19,9 @@ import org.embulk.plugin.PluginType;
 import org.embulk.spi.util.DecodersInternal;
 
 public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugin {
-    private final FileInputPlugin fileInputPlugin;
-
-    public FileInputRunner(FileInputPlugin fileInputPlugin) {
+    public FileInputRunner(final FileInputPlugin fileInputPlugin, final EmbulkSystemProperties embulkSystemProperties) {
         this.fileInputPlugin = fileInputPlugin;
+        this.embulkSystemProperties = embulkSystemProperties;
     }
 
     private interface RunnerTask extends Task {
@@ -75,7 +75,7 @@ public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugi
     }
 
     public ConfigDiff guess(ConfigSource execConfig, ConfigSource inputConfig) {
-        final ConfigSource sampleBufferConfig = createSampleBufferConfigFromExecConfig(execConfig);
+        final ConfigSource sampleBufferConfig = createSampleBufferConfigFromExecConfig(execConfig, this.embulkSystemProperties);
         final Buffer sample = SamplingParserPlugin.runFileInputSampling(this, inputConfig, sampleBufferConfig);
         // SamplingParserPlugin.runFileInputSampling throws NoSampleException if there're
         // no files or all files are smaller than minSampleSize (40 bytes).
@@ -158,4 +158,7 @@ public class FileInputRunner implements InputPlugin, ConfigurableGuessInputPlugi
     private static RunnerTask loadRunnerTaskFromTaskSource(final TaskSource taskSource) {
         return taskSource.loadTask(RunnerTask.class);
     }
+
+    private final FileInputPlugin fileInputPlugin;
+    private final EmbulkSystemProperties embulkSystemProperties;
 }

--- a/embulk-core/src/test/java/org/embulk/spi/TestFileInputRunner.java
+++ b/embulk-core/src/test/java/org/embulk/spi/TestFileInputRunner.java
@@ -7,7 +7,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Properties;
 import java.util.Queue;
+import org.embulk.EmbulkSystemProperties;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
@@ -93,7 +95,7 @@ public class TestFileInputRunner {
                 runtime.getBufferAllocator().allocate() };
         MockFileInputPlugin fileInputPlugin = new MockFileInputPlugin(
                 new LinkedList<Buffer>(Arrays.asList(buffers)));
-        final FileInputRunner runner = new FileInputRunner(fileInputPlugin);
+        final FileInputRunner runner = new FileInputRunner(fileInputPlugin, EmbulkSystemProperties.of(new Properties()));
 
         ConfigSource config = Exec.newConfigSource().set(
                 "parser",
@@ -142,7 +144,7 @@ public class TestFileInputRunner {
                 runtime.getBufferAllocator().allocate() };
         MockFileInputPlugin fileInputPlugin = new MockFileInputPlugin(
                 new LinkedList<Buffer>(Arrays.asList(buffers)));
-        final FileInputRunner runner = new FileInputRunner(fileInputPlugin);
+        final FileInputRunner runner = new FileInputRunner(fileInputPlugin, EmbulkSystemProperties.of(new Properties()));
 
         ConfigSource config = Exec.newConfigSource().set(
                 "parser",

--- a/embulk-ruby/lib/embulk/file_input_plugin.rb
+++ b/embulk-ruby/lib/embulk/file_input_plugin.rb
@@ -13,7 +13,7 @@ module Embulk
     module RubyAdapter
       module ClassMethods
         def new_java
-          Java::FileInputRunner.new(Java::org.embulk.plugin.PluginManager.newPluginInstance(plugin_java_class, Embulk::Java::EmbulkSystemProperties))
+          Java::FileInputRunner.new(Java::org.embulk.plugin.PluginManager.newPluginInstance(plugin_java_class, Embulk::Java::EmbulkSystemProperties), Embulk::Java::EmbulkSystemProperties)
         end
         # TODO transaction, resume, cleanup
       end


### PR DESCRIPTION
Rivisits #1379 and #1414.

#1414 was once reverted in #1449 because of the constructor parameters of `FileInputRunner` from Ruby.

This pull request includes a fix for that case in `file_input_plugin.rb`, which is available because it is after the Guice removal.