### PR TITLE
Warn for v0.11.0 in v0.9.25 as embulk-latest.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'org.ajoberstar.grgit'
 apply plugin: "org.owasp.dependencycheck"
 
-version = '0.9.24'
+version = '0.9.25'
 
 description = 'Embulk is an open-source, plugin-based bulk data loader to scale and simplify data management across heterogeneous data stores. It can collect and ship any kinds of data in high throughput with transaction control.'
 

--- a/embulk-core/src/main/bat/selfrun.bat
+++ b/embulk-core/src/main/bat/selfrun.bat
@@ -5,6 +5,19 @@ rem NOTE: Just quotes are available for [ for /f "delims=" %%w ('...') ].
 
 setlocal
 
+echo. 1>&2
+echo ================================== [ NOTICE ] ================================== 1>&2
+echo  Embulk v0.11.0 will be released soon, planned for June 2023. 1>&2
+echo. 1>&2
+echo  This v0.11.0 will contain a lot of incompatible changes from v0.9. 1>&2
+echo  Many plugins are expected to stop working with v0.11.0. 1>&2
+echo. 1>&2
+echo  Try v0.10.48, a Release Candidate for v0.11.0, before it actually happens. 1>&2
+echo. 1>&2
+echo  See: https://www.embulk.org/articles/2023/04/13/embulk-v0.11-is-coming-soon.html 1>&2
+echo ================================================================================ 1>&2
+echo. 1>&2
+
 rem Do not use %0 to identify the JAR (bat) file.
 rem %0 is just "embulk" when run by just "> embulk" while %0 is "embulk.bat" when run by "> embulk.bat".
 set this=%~f0

--- a/embulk-core/src/main/bat/selfrun.bat
+++ b/embulk-core/src/main/bat/selfrun.bat
@@ -12,7 +12,7 @@ echo. 1>&2
 echo  This v0.11.0 will contain a lot of incompatible changes from v0.9. 1>&2
 echo  Many plugins are expected to stop working with v0.11.0. 1>&2
 echo. 1>&2
-echo  Try v0.10.48, a Release Candidate for v0.11.0, before it actually happens. 1>&2
+echo  Try v0.10.48 or later, Release Candidate for v0.11, before v0.11.0 is official. 1>&2
 echo. 1>&2
 echo  See: https://www.embulk.org/articles/2023/04/13/embulk-v0.11-is-coming-soon.html 1>&2
 echo ================================================================================ 1>&2

--- a/embulk-core/src/main/sh/selfrun.sh
+++ b/embulk-core/src/main/sh/selfrun.sh
@@ -3,6 +3,19 @@ jruby_args=""
 default_optimize=""
 overwrite_optimize=""
 
+echo "" 1>&2
+echo "================================== [ NOTICE ] ==================================" 1>&2
+echo " Embulk v0.11.0 will be released soon, planned for June 2023." 1>&2
+echo "" 1>&2
+echo " This v0.11.0 will contain a lot of incompatible changes from v0.9." 1>&2
+echo " Many plugins are expected to stop working with v0.11.0." 1>&2
+echo "" 1>&2
+echo " Try v0.10.48, a Release Candidate for v0.11.0, before it actually happens." 1>&2
+echo "" 1>&2
+echo " See: https://www.embulk.org/articles/2023/04/13/embulk-v0.11-is-coming-soon.html" 1>&2
+echo "================================================================================" 1>&2
+echo "" 1>&2
+
 while true; do
     case "$1" in
         -E*)

--- a/embulk-core/src/main/sh/selfrun.sh
+++ b/embulk-core/src/main/sh/selfrun.sh
@@ -10,7 +10,7 @@ echo "" 1>&2
 echo " This v0.11.0 will contain a lot of incompatible changes from v0.9." 1>&2
 echo " Many plugins are expected to stop working with v0.11.0." 1>&2
 echo "" 1>&2
-echo " Try v0.10.48, a Release Candidate for v0.11.0, before it actually happens." 1>&2
+echo " Try v0.10.48 or later, Release Candidate for v0.11, before v0.11.0 is official." 1>&2
 echo "" 1>&2
 echo " See: https://www.embulk.org/articles/2023/04/13/embulk-v0.11-is-coming-soon.html" 1>&2
 echo "================================================================================" 1>&2


### PR DESCRIPTION
The plan for Embulk v0.11.0 is announced: https://www.embulk.org/articles/2023/04/13/embulk-v0.11-is-coming-soon.html

To get this reached out for more users, I think about releasing v0.9.25 as `embulk-latest.jar` with a warning message.