### PR TITLE
Change EEP's "Created" to "Published"

### DIFF
--- a/docs/eeps/eep-0001.md
+++ b/docs/eeps/eep-0001.md
@@ -4,7 +4,7 @@ Title: EEP Purpose and Guidelines
 Author: dmikurube
 Status: Active
 Type: Process
-Created: 2022-11-07
+Published: 2022-11-21
 ---
 
 What is an EEP?
@@ -176,7 +176,7 @@ Each EEP must begin with an [RFC-2822](https://www.rfc-editor.org/rfc/rfc2822) s
   Status: <Draft | Accepted | Final | Rejected | Replaced | Active >
   Type: <Standards Track | Informational | Process>
 * Content-Type: text/markdown
-  Created: <date created on, in yyyy-mm-dd format>
+  Published: <date published on, in yyyy-mm-dd format, not required in a Draft EEP>
 * Post-History: <comma-separated list of dates, in yyyy-mm-dd format>
 * Replaced-By: <eep number>
 * Replaces: <eep number>
@@ -184,6 +184,8 @@ Each EEP must begin with an [RFC-2822](https://www.rfc-editor.org/rfc/rfc2822) s
 ```
 
 The Sponsor field records which developer (basically in the core team) is sponsoring the EEP. If one of the authors of the EEP is a core team member then no sponsor is necessary and thus this field should be left out.
+
+The Published field represents the date when an EEP number is assigned after being reviewed.
 
 EEPs may also have a Replaced-By header indicating that a EEP has been rendered obsolete by a later document; the value is the number of the EEP that replaces the current document. The newer EEP must have a Replaces header containing the number of the EEP that it rendered obsolete.
 

--- a/docs/eeps/eep-0002.md
+++ b/docs/eeps/eep-0002.md
@@ -4,7 +4,7 @@ Title: JSON Column Type
 Author: dmikurube
 Status: Accepted
 Type: Standards Track
-Created: 2023-02-21
+Published: 2023-02-21
 ---
 
 Introduction

--- a/docs/eeps/eep-0003.md
+++ b/docs/eeps/eep-0003.md
@@ -4,7 +4,7 @@ Title: The "Compact Core" Principle
 Author: dmikurube
 Status: Final
 Type: Standards Track
-Created: 2023-06-14
+Published: 2023-06-15
 ---
 
 Introduction

--- a/docs/eeps/eep-0004.md
+++ b/docs/eeps/eep-0004.md
@@ -4,7 +4,7 @@ Title: System-wide Configuration by Embulk System Properties and Embulk Home
 Author: dmikurube
 Status: Final
 Type: Standards Track
-Created: 2023-06-16
+Published: 2023-06-19
 ---
 
 Introduction

--- a/docs/eeps/eep-0005.md
+++ b/docs/eeps/eep-0005.md
@@ -4,7 +4,7 @@ Title: Maven-style Plugins
 Author: dmikurube
 Status: Final
 Type: Standards Track
-Created: 2023-06-19
+Published: 2023-06-23
 ---
 
 Introduction

--- a/docs/eeps/eep-0006.md
+++ b/docs/eeps/eep-0006.md
@@ -4,7 +4,7 @@ Title: JRuby as Optional
 Author: dmikurube
 Status: Final
 Type: Standards Track
-Created: 2023-06-22
+Published: 2023-06-26
 ---
 
 Introduction


### PR DESCRIPTION
The "Created" date of an EEP has not been very clear. It may be the date of the first draft, the date of getting ready for review, or the date of publishing.

This pull request changes "Created" to "Published" so that the date would be clear. The "Published" date would be the date when an EEP number is assigned after being reviewed, and the EEP gets effective.