### PR TITLE
Fix PreviewValueFormatter that can't accept Boolean value

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/PreviewValueFormatter.java
+++ b/embulk-core/src/main/java/org/embulk/exec/PreviewValueFormatter.java
@@ -28,6 +28,8 @@ final class PreviewValueFormatter {
             return Instants.toString((Instant) obj);
         } else if (obj instanceof JsonValue) {
             return obj.toString();
+        } else if (obj instanceof Boolean) {
+            return obj.toString();
         } else {
             throw new IllegalStateException("Record has a value with an unexpected type: " + obj.getClass().getName());
         }


### PR DESCRIPTION
preview command is failed when values have a Boolean value.
Because PreviewValueFormatter can't accept Boolean object.

This PR fixes it.
