### PR TITLE
Warn against use of org.embulk.spi.json.JsonParser

### DIFF
--- a/embulk-core/src/main/java/org/embulk/spi/json/JsonParser.java
+++ b/embulk-core/src/main/java/org/embulk/spi/json/JsonParser.java
@@ -3,9 +3,12 @@ package org.embulk.spi.json;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.msgpack.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Deprecated  // Externalized to embulk-util-json
+@Deprecated
 public class JsonParser {
     public interface Stream extends Closeable {
         Value next() throws IOException;
@@ -14,6 +17,11 @@ public class JsonParser {
     }
 
     public JsonParser() {
+        if (!hasLogged.getAndSet(true)) {
+            logger.warn(
+                    "Let the plugin maintainer know: org.embulk.spi.json.JsonParser has been deprecated, but it is used at: ",
+                    new Deprecation());
+        }
         this.delegate = JsonParserDelegate.of();
     }
 
@@ -32,6 +40,13 @@ public class JsonParser {
     public Value parseWithOffsetInJsonPointer(String json, String offsetInJsonPointer) {
         return this.delegate.parseWithOffsetInJsonPointer(json, offsetInJsonPointer);
     }
+
+    private static class Deprecation extends RuntimeException {
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(JsonParser.class);
+
+    private static final AtomicBoolean hasLogged = new AtomicBoolean(false);
 
     private final JsonParserDelegate delegate;
 }


### PR DESCRIPTION
`org.embulk.spi.json.JsonParser` is deprecated, and we may remove it in the future. Let's dump a duplication message for use of that.