### PR TITLE
Use macos-13 in GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macOS-latest
+        - macos-13  # OpenJDK 8 is not supported on macos-14+ (M1).
         - windows-latest
         gradle_task:
         - ":embulk-core:check"


### PR DESCRIPTION
Temurin OpenJDK 8 is unavailable in `macos-latest` (Apple M1 / aarch64).

https://github.com/actions/setup-java/issues/625