### PR TITLE
Set the ":checkDependencies" task to check for all projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,11 +75,17 @@ dependencies {
 // In contrast, "dependencies (--write-locks)" does not fail even when a part the dependencies are unavailable.
 //
 // https://docs.gradle.org/7.6.1/userguide/dependency_locking.html#generating_and_updating_dependency_locks
-task checkDependencies {
-    notCompatibleWithConfigurationCache("The task \"checkDependencies\" filters configurations at execution time.")
-    doLast {
-        configurations.findAll { it.canBeResolved }.each { it.resolve() }
+allprojects {
+    task checkDependencies {
+        notCompatibleWithConfigurationCache("The task \"checkDependencies\" filters configurations at execution time.")
+        doLast {
+            configurations.findAll { it.canBeResolved }.each { it.resolve() }
+        }
     }
+}
+
+subprojects.each { subProject ->
+    rootProject.tasks.getByPath(":checkDependencies").dependsOn(subProject.tasks.getByPath("checkDependencies"))
 }
 
 def listEmbeddedDependencies = { configurationName, rootModuleName, prefix ->


### PR DESCRIPTION
Its `build.gradle` has had the `:checkDependencies` task to check dependencies (to fail when dependencies are invalid), but it has not iterated over subprojects. It was not very convenient.

This pull request makes the `:chedkDependencies` task to iterate over all subprojects.

(Note: we may consider applying this to other repositories, but only in this repository as of now. We may find another better approach.)