### PR TITLE
EEP-0: Index of Embulk Enhancement Proposals (EEPs)

### DIFF
--- a/docs/eeps/eep-0000.md
+++ b/docs/eeps/eep-0000.md
@@ -39,7 +39,7 @@ EEP Status Key
 
 * A — Accepted: Normative proposal fixed and accepted for implementation, to be ready for implementation.
 * A — Active: Currently valid informational guidance, or an in-use process.
-* <No letter> — Draft: Proposal that is not yet fixed, under active discussion and revision.
+* [No letter] — Draft: Proposal that is not yet fixed, under active discussion and revision.
 * F — Final: Accepted, implementation complete, and released.
 * R — Rejected: Formally declined and will not be accepted.
 

--- a/docs/eeps/eep-0000.md
+++ b/docs/eeps/eep-0000.md
@@ -1,0 +1,31 @@
+---
+EEP: 0
+Title: Index of Embulk Enhancement Proposals (EEPs)
+Author: dmikurube
+Status: Active
+Type: Informational
+---
+
+This EEP contains the index of all Embulk Enhancement Proposals, known as EEPs. EEP numbers are assigned by the core committers, and once assigned are never changed. The version control history of the EEP texts represent their historical record.
+
+Index
+======
+
+| Type and Status | EEP | Title |
+| --------------- | --- | ----- |
+| IA |  0 | [Index of Embulk Enhancement Proposals (EEPs)](./eep-0000.md) |
+| PA |  1 | [EEP Purpose and Guidelines](./eep-0001.md) |
+| SA |  2 | [JSON Column Type](./eep-0002.md) |
+| SF |  3 | [The "Compact Core" Principle](./eep-0003.md) |
+| SF |  4 | [System-wide Configuration by Embulk System Properties and Embulk Home](./eep-0004.md) |
+| SF |  5 | [Maven-style Plugins](./eep-0005.md) |
+| SF |  6 | [JRuby as Optional](./eep-0006.md) |
+| SF |  7 | [Core Library Dependencies](./eep-0007.md) |
+| SA |  8 | [Milestones to Embulk v1.0, and versioning strategies to follow](./eep-0008.md) |
+| SF |  9 | [Class Loading, and Executable JAR File Structure](./eep-0009.md) |
+| SF | 10 | [SPI Separation for Compatibility Contract](./eep-0010.md) |
+
+Copyright and License
+======================
+
+This document is placed under the CC0-1.0-Universal license, whichever is more permissive.

--- a/docs/eeps/eep-0000.md
+++ b/docs/eeps/eep-0000.md
@@ -25,6 +25,26 @@ Index
 | SF |  9 | [Class Loading, and Executable JAR File Structure](./eep-0009.md) |
 | SF | 10 | [SPI Separation for Compatibility Contract](./eep-0010.md) |
 
+EEP Types Key
+==============
+
+* I — Informational: Non-normative EEP containing an Embulk design issue, or provides general guidelines or information to the Embulk community, but does not propose a new feature.
+* P — Process: Normative EEP describing a process surrounding Embulk, or proposing a change to (or an event in) a process.
+* S — Standards Track: Normative EEP with a new feature or implementation for Embulk, which may also describe an interoperability standard that will be supported outside the standard library for current Embulk versions before a subsequent EEP adds standard library support in a future version.
+
+More info in [EEP-1](./eep-0001.md).
+
+EEP Status Key
+===============
+
+* A — Accepted: Normative proposal fixed and accepted for implementation, to be ready for implementation.
+* A — Active: Currently valid informational guidance, or an in-use process.
+* <No letter> — Draft: Proposal that is not yet fixed, under active discussion and revision.
+* F — Final: Accepted, implementation complete, and released.
+* R — Rejected: Formally declined and will not be accepted.
+
+More info in [EEP-1](./eep-0001.md).
+
 Copyright and License
 ======================
 


### PR DESCRIPTION
We didn't have an index for EEPs while we now have 10 EEPs. It's inconvenient when we look into published EEPs.

Like [Python's PEP-0](https://peps.python.org/pep-0000/), it'd be nice to have EEP-0 as the index.