### PR TITLE
Update the "Post-History" headers of updated EEPs

### DIFF
--- a/docs/eeps/eep-0003.md
+++ b/docs/eeps/eep-0003.md
@@ -5,6 +5,7 @@ Author: dmikurube
 Status: Final
 Type: Standards Track
 Published: 2023-06-15
+Post-History: 2024-06-18
 ---
 
 Introduction

--- a/docs/eeps/eep-0005.md
+++ b/docs/eeps/eep-0005.md
@@ -5,6 +5,7 @@ Author: dmikurube
 Status: Final
 Type: Standards Track
 Published: 2023-06-23
+Post-History: 2024-06-18
 ---
 
 Introduction

--- a/docs/eeps/eep-0007.md
+++ b/docs/eeps/eep-0007.md
@@ -5,6 +5,7 @@ Author: dmikurube
 Status: Final
 Type: Standards Track
 Created: 2023-12-25
+Post-History: 2024-06-18
 ---
 
 Problem: dependency conflicts


### PR DESCRIPTION
Forgot to update the `Post-History` headers of the updated EEPs in #1675 

(`Post-History` is explained in https://github.com/embulk/embulk/blob/master/docs/eeps/eep-0001.md#eep-header-preamble )