### PR TITLE
fix logging statement formatting

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginRegistry.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/maven/MavenPluginRegistry.java
@@ -79,8 +79,9 @@ final class MavenPluginRegistry {
                 throw new PluginSourceNotMatchException(ex);
             }
 
-            logger.info("Loaded plugin {} ({})",
-                        "embulk-" + this.category + "-" + mavenPluginType.getName(),
+            logger.info("Loaded plugin embulk-{}-{} ({})", 
+                        this.category, 
+                        mavenPluginType.getName(), 
                         mavenPluginType.getFullName());
 
             this.cacheMap.put(mavenPluginType, loadedPluginMainClass);


### PR DESCRIPTION
## Description

This pull request aims to enhance the logging statement within the `lookup` method of the plugin loader by making the log message more structured and easier to read. The original logging statement concatenated strings directly within the log message, which can be less readable and harder to maintain.

## Changes Made

- Modified the logging statement to use parameterized logging for better readability and maintainability.

### Original Code

```java
logger.info("Loaded plugin {} ({})", "embulk-" + this.category + "-" + mavenPluginType.getName(), mavenPluginType.getFullName());
```

### Updated Code

```java
logger.info("Loaded plugin embulk-{}-{} ({})", this.category, mavenPluginType.getName(), mavenPluginType.getFullName());
```

## Rationale

The updated logging statement uses parameterized logging to separate the log message template from the values being inserted. This approach improves readability and makes it easier to understand the log message structure at a glance. It also helps in avoiding potential errors that might arise from string concatenation.


---

Thank you for reviewing this pull request. Please let me know if there are any questions or if further changes are needed.

