### PR TITLE
Discard "parent_first_*.properties" files, and hard-code them in PluginClassLoader

### DIFF
--- a/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
+++ b/embulk-core/src/main/java/org/embulk/EmbulkEmbed.java
@@ -359,8 +359,6 @@ public class EmbulkEmbed {
                 .setModelManager(this.modelManager)
                 .setEmbulkSystemProperties(this.embulkSystemProperties)
                 .setGuessExecutor(this.guessExecutor)
-                .setParentFirstPackages(PARENT_FIRST_PACKAGES)
-                .setParentFirstResources(PARENT_FIRST_RESOURCES)
                 .fromExecConfig(execConfig)
                 .build();
     }
@@ -524,10 +522,6 @@ public class EmbulkEmbed {
     private static org.embulk.config.ModelManager createModelManager() {
         return new org.embulk.config.ModelManager();
     }
-
-    // TODO: Remove them finally.
-    static final Set<String> PARENT_FIRST_PACKAGES = readPropertyKeys("/embulk/parent_first_packages.properties");
-    static final Set<String> PARENT_FIRST_RESOURCES = readPropertyKeys("/embulk/parent_first_resources.properties");
 
     private static final Pattern BYTE_SIZE_PATTERN = Pattern.compile("\\A(\\d+(?:\\.\\d+)?)\\s?([a-zA-Z]*)\\z");
 

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
@@ -22,17 +22,15 @@ public class PluginClassLoader extends SelfContainedJarAwareURLClassLoader {
     private PluginClassLoader(
             final ClassLoader parentClassLoader,
             final Collection<URL> jarUrls,
-            final String selfContainedPluginName,
-            final Collection<String> parentFirstPackages,
-            final Collection<String> parentFirstResources) {
+            final String selfContainedPluginName) {
         super(jarUrls.toArray(new URL[0]), parentClassLoader, selfContainedPluginName);
 
         this.hasJep320LoggedWithStackTrace = false;
 
         this.parentFirstPackagePrefixes = Collections.unmodifiableList(
-                parentFirstPackages.stream().map(pkg -> pkg + ".").collect(Collectors.toList()));
+                PARENT_FIRST_PACKAGES.stream().map(pkg -> pkg + ".").collect(Collectors.toList()));
         this.parentFirstResourcePrefixes = Collections.unmodifiableList(
-                parentFirstResources.stream().map(pkg -> pkg + "/").collect(Collectors.toList()));
+                PARENT_FIRST_RESOURCES.stream().map(pkg -> pkg + "/").collect(Collectors.toList()));
     }
 
     /**
@@ -40,34 +38,24 @@ public class PluginClassLoader extends SelfContainedJarAwareURLClassLoader {
      *
      * @param parentClassLoader  the parent ClassLoader of this PluginClassLoader instance
      * @param jarUrls  collection of "file:" URLs of all JARs related to the plugin
-     * @param parentFirstPackages  collection of package names that are to be loaded first before the plugin's
-     * @param parentFirstResources  collection of resource names that are to be loaded first before the plugin's
      * @return {@code PluginClassLoader} instance created
      */
     public static PluginClassLoader create(
             final ClassLoader parentClassLoader,
-            final Collection<URL> jarUrls,
-            final Collection<String> parentFirstPackages,
-            final Collection<String> parentFirstResources) {
+            final Collection<URL> jarUrls) {
         return new PluginClassLoader(
                 parentClassLoader,
                 jarUrls,
-                null,
-                parentFirstPackages,
-                parentFirstResources);
+                null);
     }
 
     public static PluginClassLoader forSelfContainedPlugin(
             final ClassLoader parentClassLoader,
-            final String selfContainedPluginName,
-            final Collection<String> parentFirstPackages,
-            final Collection<String> parentFirstResources) {
+            final String selfContainedPluginName) {
         return new PluginClassLoader(
                 parentClassLoader,
                 new ArrayList<>(),
-                selfContainedPluginName,
-                parentFirstPackages,
-                parentFirstResources);
+                selfContainedPluginName);
     }
 
     /**
@@ -361,6 +349,25 @@ public class PluginClassLoader extends SelfContainedJarAwareURLClassLoader {
 
     private static Set<String> JEP_320_PACKAGES =
             Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(JEP_320_PACKAGES_ARRAY)));
+
+    // TODO: Remove them finally.
+    private static final Set<String> PARENT_FIRST_PACKAGES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "ch.qos.logback.classic",
+            "ch.qos.logback.core",
+            "java",
+            "org.embulk",
+            "org.msgpack.core",
+            "org.msgpack.value",
+            "org.slf4j"
+            )));
+
+    private static final Set<String> PARENT_FIRST_RESOURCES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "ch/qos/logback/classic/boolex",
+            "ch/qos/logback/classic/db/script",
+            "embulk",
+            "msgpack",
+            "org/embulk"
+            )));
 
     private final List<String> parentFirstPackagePrefixes;
     private final List<String> parentFirstResourcePrefixes;

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
-import java.util.stream.Collectors;
 import org.embulk.cli.SelfContainedJarAwareURLClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,11 +25,6 @@ public class PluginClassLoader extends SelfContainedJarAwareURLClassLoader {
         super(jarUrls.toArray(new URL[0]), parentClassLoader, selfContainedPluginName);
 
         this.hasJep320LoggedWithStackTrace = false;
-
-        this.parentFirstPackagePrefixes = Collections.unmodifiableList(
-                PARENT_FIRST_PACKAGES.stream().map(pkg -> pkg + ".").collect(Collectors.toList()));
-        this.parentFirstResourcePrefixes = Collections.unmodifiableList(
-                PARENT_FIRST_RESOURCES.stream().map(pkg -> pkg + "/").collect(Collectors.toList()));
     }
 
     /**
@@ -210,8 +204,8 @@ public class PluginClassLoader extends SelfContainedJarAwareURLClassLoader {
         return resources.elements();
     }
 
-    private boolean isParentFirstPackage(String name) {
-        for (String pkg : parentFirstPackagePrefixes) {
+    private boolean isParentFirstPackage(final String name) {
+        for (final String pkg : PARENT_FIRST_PACKAGE_PREFIXES) {
             if (name.startsWith(pkg)) {
                 return true;
             }
@@ -219,8 +213,8 @@ public class PluginClassLoader extends SelfContainedJarAwareURLClassLoader {
         return false;
     }
 
-    private boolean isParentFirstPath(String name) {
-        for (String path : parentFirstResourcePrefixes) {
+    private boolean isParentFirstPath(final String name) {
+        for (final String path : PARENT_FIRST_RESOURCE_PREFIXES) {
             if (name.startsWith(path)) {
                 return true;
             }
@@ -350,27 +344,23 @@ public class PluginClassLoader extends SelfContainedJarAwareURLClassLoader {
     private static Set<String> JEP_320_PACKAGES =
             Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(JEP_320_PACKAGES_ARRAY)));
 
-    // TODO: Remove them finally.
-    private static final Set<String> PARENT_FIRST_PACKAGES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            "ch.qos.logback.classic",
-            "ch.qos.logback.core",
-            "java",
-            "org.embulk",
-            "org.msgpack.core",
-            "org.msgpack.value",
-            "org.slf4j"
-            )));
+    private static final List<String> PARENT_FIRST_PACKAGE_PREFIXES = Collections.unmodifiableList(Arrays.asList(
+            "ch.qos.logback.classic.",
+            "ch.qos.logback.core.",
+            "java.",
+            "org.embulk.",
+            "org.msgpack.core.",
+            "org.msgpack.value.",
+            "org.slf4j."
+            ));
 
-    private static final Set<String> PARENT_FIRST_RESOURCES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            "ch/qos/logback/classic/boolex",
-            "ch/qos/logback/classic/db/script",
-            "embulk",
-            "msgpack",
-            "org/embulk"
-            )));
-
-    private final List<String> parentFirstPackagePrefixes;
-    private final List<String> parentFirstResourcePrefixes;
+    private static final List<String> PARENT_FIRST_RESOURCE_PREFIXES = Collections.unmodifiableList(Arrays.asList(
+            "ch/qos/logback/classic/boolex/",
+            "ch/qos/logback/classic/db/script/",
+            "embulk/",
+            "msgpack/",
+            "org/embulk/"
+            ));
 
     private boolean hasJep320LoggedWithStackTrace;
 }

--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactoryImpl.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoaderFactoryImpl.java
@@ -5,27 +5,19 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 public class PluginClassLoaderFactoryImpl implements PluginClassLoaderFactory {
-    private PluginClassLoaderFactoryImpl(
-            final Collection<String> parentFirstPackages,
-            final Collection<String> parentFirstResources) {
-        this.parentFirstPackages = parentFirstPackages;
-        this.parentFirstResources = parentFirstResources;
+    private PluginClassLoaderFactoryImpl() {
         this.createdPluginClassLoaders = new ArrayList<>();
     }
 
-    public static PluginClassLoaderFactoryImpl of(
-            final Collection<String> parentFirstPackages,
-            final Collection<String> parentFirstResources) {
-        return new PluginClassLoaderFactoryImpl(parentFirstPackages, parentFirstResources);
+    public static PluginClassLoaderFactoryImpl of() {
+        return new PluginClassLoaderFactoryImpl();
     }
 
     @Override
     public PluginClassLoader create(final Collection<URL> urls, final ClassLoader parentClassLoader) {
         final PluginClassLoader created = PluginClassLoader.create(
                 parentClassLoader,
-                urls,
-                parentFirstPackages,
-                parentFirstResources);
+                urls);
         this.createdPluginClassLoaders.add(created);
         return created;
     }
@@ -34,9 +26,7 @@ public class PluginClassLoaderFactoryImpl implements PluginClassLoaderFactory {
     public PluginClassLoader forSelfContainedPlugin(final String selfContainedPluginName, final ClassLoader parentClassLoader) {
         final PluginClassLoader created = PluginClassLoader.forSelfContainedPlugin(
                 parentClassLoader,
-                selfContainedPluginName,
-                this.parentFirstPackages,
-                this.parentFirstResources);
+                selfContainedPluginName);
         this.createdPluginClassLoaders.add(created);
         return created;
     }
@@ -51,9 +41,6 @@ public class PluginClassLoaderFactoryImpl implements PluginClassLoaderFactory {
         */
         this.createdPluginClassLoaders.clear();
     }
-
-    private final Collection<String> parentFirstPackages;
-    private final Collection<String> parentFirstResources;
 
     // Created PluginClassLoaders are maintained in the list so that they are not garbage-collected accidentally.
     private final ArrayList<PluginClassLoader> createdPluginClassLoaders;

--- a/embulk-core/src/main/resources/embulk/parent_first_packages.properties
+++ b/embulk-core/src/main/resources/embulk/parent_first_packages.properties
@@ -1,7 +1,0 @@
-ch.qos.logback.classic
-ch.qos.logback.core
-java
-org.embulk
-org.msgpack.core
-org.msgpack.value
-org.slf4j

--- a/embulk-core/src/main/resources/embulk/parent_first_resources.properties
+++ b/embulk-core/src/main/resources/embulk/parent_first_resources.properties
@@ -1,5 +1,0 @@
-ch/qos/logback/classic/boolex
-ch/qos/logback/classic/db/script
-embulk
-msgpack
-org/embulk

--- a/embulk-junit4/src/main/java/org/embulk/test/EmbulkTestRuntime.java
+++ b/embulk-junit4/src/main/java/org/embulk/test/EmbulkTestRuntime.java
@@ -61,7 +61,7 @@ public class EmbulkTestRuntime implements TestRule {
     }
 
     public static PluginClassLoaderFactory buildPluginClassLoaderFactory() {
-        return PluginClassLoaderFactoryImpl.of(PARENT_FIRST_PACKAGES, PARENT_FIRST_RESOURCES);
+        return PluginClassLoaderFactoryImpl.of();
     }
 
     @Override
@@ -120,11 +120,4 @@ public class EmbulkTestRuntime implements TestRule {
             throw new UncheckedIOException(ex);
         }
     }
-
-    // EmbulkEmbed.PARENT_FIRST_PACKAGES and EmbulkEmbed.PARENT_FIRST_RESOURCES are package-private.
-    // They are not accessible from org.embulk.test.
-    //
-    // TODO: Remove them finally.
-    private static final Set<String> PARENT_FIRST_PACKAGES = readPropertyKeys("/embulk/parent_first_packages.properties");
-    private static final Set<String> PARENT_FIRST_RESOURCES = readPropertyKeys("/embulk/parent_first_resources.properties");
 }


### PR DESCRIPTION
`parent_first_packages.properties` and `parent_first_resources.properties` have been used to suppress some classes from being loaded by plugin class loaders. However, it was not working properly, then we have planned to remove this mechanism, as declared in EEP-9:

https://github.com/embulk/embulk/blob/master/docs/eeps/eep-0009.md#parent_first_packages-and-parent_first_resources

The time has come. As the first step, this pull request removes those files, and hard-code them directly in `PluginClassLoader`.

----

In addition, we needed `PluginClassLoader` to be more flexible so that the class loading mechanism could work with testing a plugin, hopefully with a new test helper `embulk-junit5`.