### PR TITLE
Exclude "msgpack/" resources from "parent_first"

### DIFF
--- a/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
+++ b/embulk-core/src/main/java/org/embulk/plugin/PluginClassLoader.java
@@ -275,9 +275,6 @@ public class PluginClassLoader extends SelfContainedJarAwareURLClassLoader {
         if (name.startsWith("embulk/")) {
             return true;
         }
-        if (name.startsWith("msgpack/")) {
-            return true;
-        }
         if (name.startsWith("org/embulk/")) {
             return true;
         }

--- a/embulk-core/src/test/java/org/embulk/plugin/TestPluginClassLoader.java
+++ b/embulk-core/src/test/java/org/embulk/plugin/TestPluginClassLoader.java
@@ -115,8 +115,8 @@ public class TestPluginClassLoader {
         assertTrue(PluginClassLoader.isParentFirstPath("embulk/logback-file.xml"));
         assertFalse(PluginClassLoader.isParentFirstPath("embulkdummy/logback-file.xml"));
         assertFalse(PluginClassLoader.isParentFirstPath("msgpack"));
-        assertTrue(PluginClassLoader.isParentFirstPath("msgpack/"));
-        assertTrue(PluginClassLoader.isParentFirstPath("msgpack/dummy.txt"));
+        assertFalse(PluginClassLoader.isParentFirstPath("msgpack/"));
+        assertFalse(PluginClassLoader.isParentFirstPath("msgpack/dummy.txt"));
         assertFalse(PluginClassLoader.isParentFirstPath("msgpacker/dummy.txt"));
         assertFalse(PluginClassLoader.isParentFirstPath("org/embulk"));
         assertTrue(PluginClassLoader.isParentFirstPath("org/embulk/"));


### PR DESCRIPTION
Resources under `msgpack/` have been included in "parent_first", but actually, the existing `msgpack-core` does not contain any resource under `msgpack/`, then the Embulk packages does not include any resource under `msgpack/`.

It's no longer needed. Let's remove it.