### PR TITLE
Fix EEP "Published" dates for EEP-7, EEP-12, and EEP-13

### DIFF
--- a/docs/eeps/eep-0007.md
+++ b/docs/eeps/eep-0007.md
@@ -4,7 +4,7 @@ Title: Core Library Dependencies
 Author: dmikurube
 Status: Final
 Type: Standards Track
-Created: 2023-12-25
+Published: 2023-12-25
 Post-History: 2024-06-18
 ---
 

--- a/docs/eeps/eep-0012.md
+++ b/docs/eeps/eep-0012.md
@@ -4,6 +4,7 @@ Title: Obsolete Execution as a Command
 Author: dmikurube
 Status: Accepted
 Type: Standards Track
+Published: 2024-09-24
 ---
 
 Obsolete Execution as a Command

--- a/docs/eeps/eep-0013.md
+++ b/docs/eeps/eep-0013.md
@@ -4,6 +4,7 @@ Title: Logging and SLF4J
 Author: dmikurube
 Status: Final
 Type: Standards Track
+Published: 2024-12-03
 ---
 
 Logging is important and complicated


### PR DESCRIPTION
Found that the `Published:` fields were missing in some EEPs (including the recent EEP-13). ;)